### PR TITLE
Fix: Interaction and commands in dm channels

### DIFF
--- a/lib/core/api.dart
+++ b/lib/core/api.dart
@@ -33,6 +33,7 @@ export '../src/api/interactions/select_menu_interaction.dart' show SelectMenuInt
 export '../src/api/managers/member_role_manager.dart' show MemberRoleManager;
 export '../src/api/managers/voice_manager.dart' show VoiceManager;
 export '../src/api/messages/message.dart' show Message;
+export '../src/api/messages/dm_message.dart' show DmMessage;
 export '../src/api/moderation_rule.dart' show ModerationEventType, ModerationTriggerType, ModerationPresetType, ModerationActionType, ModerationTriggerMetadata, ModerationActionMetadata, ModerationAction, ModerationRule;
 export '../src/api/permission_overwrite.dart' show PermissionOverwrite, PermissionOverwriteType;
 export '../src/api/role.dart' show Role;

--- a/lib/core/api.dart
+++ b/lib/core/api.dart
@@ -23,6 +23,8 @@ export '../src/api/guilds/guild_scheduled_event.dart' show ScheduledEventStatus,
 export '../src/api/image_formater.dart' show ImageFormater;
 export '../src/api/interactions/button_interaction.dart' show ButtonInteraction;
 export '../src/api/interactions/command_interaction.dart' show CommandInteraction;
+export '../src/api/interactions/global_command_interaction.dart' show GlobalCommandInteraction;
+export '../src/api/interactions/guild_command_interaction.dart' show GuildCommandInteraction;
 export '../src/api/interactions/context_message_interaction.dart' show ContextMessageInteraction;
 export '../src/api/interactions/context_user_interaction.dart' show ContextUserInteraction;
 export '../src/api/interactions/interaction.dart' show Interaction;

--- a/lib/src/api/channels/dm_channel.dart
+++ b/lib/src/api/channels/dm_channel.dart
@@ -1,7 +1,6 @@
 import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
 import 'package:mineral/src/api/managers/message_manager.dart';
-import 'package:mineral/src/api/messages/dm_message.dart';
 import 'package:mineral_ioc/ioc.dart';
 
 class DmChannel extends PartialChannel {

--- a/lib/src/api/interactions/button_interaction.dart
+++ b/lib/src/api/interactions/button_interaction.dart
@@ -2,6 +2,8 @@ import 'dart:core';
 
 import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
+import 'package:mineral/src/api/messages/partial_message.dart';
+import 'package:mineral_ioc/ioc.dart';
 
 class ButtonInteraction extends Interaction {
   Snowflake _customId;
@@ -24,8 +26,10 @@ class ButtonInteraction extends Interaction {
 
   Snowflake get customId => _customId;
   Snowflake? get mid => _messageId;
-  Message? get message => (guild?.channels.cache.get(_channelId) as dynamic)?.messages.cache[_messageId];
-  TextBasedChannel get channel => guild != null
+  PartialMessage? get message => guild != null
+    ? (guild?.channels.cache.get(_channelId) as dynamic)?.messages.cache[_messageId]
+    : ioc.use<MineralClient>().dmChannels.cache.get(_channelId)?.messages.cache.getOrFail(_messageId);
+  PartialChannel get channel => guild != null
     ? guild!.channels.cache.getOrFail<TextBasedChannel>(_channelId)
     : throw UnsupportedError('DM channel is not supported');
 

--- a/lib/src/api/interactions/command_interaction.dart
+++ b/lib/src/api/interactions/command_interaction.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 
 import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
+import 'package:mineral_cli/mineral_cli.dart';
 import 'package:mineral_ioc/ioc.dart';
 
 class CommandInteraction extends Interaction  {
@@ -27,7 +28,9 @@ class CommandInteraction extends Interaction  {
   );
 
   String get identifier => _identifier;
-  TextBasedChannel? get channel => guild?.channels.cache.get<TextBasedChannel>(_channelId);
+  PartialChannel? get channel => guild != null
+    ? guild!.channels.cache.get(_channelId)
+    : ioc.use<MineralClient>().dmChannels.cache.get(_channelId);
   Map<String, dynamic> get data => _data;
   Map<String, dynamic> get params => _params;
 
@@ -219,7 +222,7 @@ class CommandInteraction extends Interaction  {
       payload['version'],
       payload['type'],
       payload['token'],
-      payload['member']?['user']?['id'],
+      payload['guild_id'] == null ? payload['user']['id'] : payload['member']?['user']?['id'],
       payload['guild_id'],
       payload['data']['name'],
       payload['channel_id'],

--- a/lib/src/api/interactions/global_command_interaction.dart
+++ b/lib/src/api/interactions/global_command_interaction.dart
@@ -1,0 +1,53 @@
+import 'package:mineral/core/api.dart';
+
+class GlobalCommandInteraction extends CommandInteraction {
+  GlobalCommandInteraction(
+    super.id,
+    super.label,
+    super.applicationId,
+    super.version,
+    super.typeId,
+    super.token,
+    super.userId,
+    super.guildId,
+    super.identifier,
+    super.channelId,
+    super.data,
+    super.params
+  );
+
+  @override
+  PartialChannel? get channel => super.channel as PartialChannel;
+
+  factory GlobalCommandInteraction.fromPayload(dynamic payload) {
+    final Map<String, dynamic> params = {};
+    void walk (List<dynamic> options) {
+      for (final option in options) {
+        if (option['options'] != null) {
+          walk(option['options']);
+        } else {
+          params.putIfAbsent(option['name'], () => option['value']);
+        }
+      }
+    }
+
+    if (payload['data']?['options'] != null) {
+      walk(payload['data']['options']);
+    }
+
+    return GlobalCommandInteraction(
+        payload['id'],
+        payload['data']['name'],
+        payload['application_id'],
+        payload['version'],
+        payload['type'],
+        payload['token'],
+        payload['guild_id'] == null ? payload['user']['id'] : payload['member']?['user']?['id'],
+        payload['guild_id'],
+        payload['data']['name'],
+        payload['channel_id'],
+        payload['data'],
+        params
+    );
+  }
+}

--- a/lib/src/api/interactions/guild_command_interaction.dart
+++ b/lib/src/api/interactions/guild_command_interaction.dart
@@ -1,0 +1,53 @@
+import 'package:mineral/core/api.dart';
+
+class GuildCommandInteraction extends CommandInteraction {
+  GuildCommandInteraction(
+    super.id,
+    super.label,
+    super.applicationId,
+    super.version,
+    super.typeId,
+    super.token,
+    super.userId,
+    super.guildId,
+    super.identifier,
+    super.channelId,
+    super.data,
+    super.params
+  );
+
+  @override
+  TextBasedChannel? get channel => super.channel as TextBasedChannel;
+
+  factory GuildCommandInteraction.fromPayload(dynamic payload) {
+    final Map<String, dynamic> params = {};
+    void walk (List<dynamic> options) {
+      for (final option in options) {
+        if (option['options'] != null) {
+          walk(option['options']);
+        } else {
+          params.putIfAbsent(option['name'], () => option['value']);
+        }
+      }
+    }
+
+    if (payload['data']?['options'] != null) {
+      walk(payload['data']['options']);
+    }
+
+    return GuildCommandInteraction(
+        payload['id'],
+        payload['data']['name'],
+        payload['application_id'],
+        payload['version'],
+        payload['type'],
+        payload['token'],
+        payload['guild_id'] == null ? payload['user']['id'] : payload['member']?['user']?['id'],
+        payload['guild_id'],
+        payload['data']['name'],
+        payload['channel_id'],
+        payload['data'],
+        params
+    );
+  }
+}

--- a/lib/src/api/interactions/modal_interaction.dart
+++ b/lib/src/api/interactions/modal_interaction.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 
 import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
+import 'package:mineral_ioc/ioc.dart';
 
 class ModalInteraction extends Interaction {
   Snowflake _customId;
@@ -23,7 +24,9 @@ class ModalInteraction extends Interaction {
   );
 
   Snowflake get customId => _customId;
-  TextChannel? get channel => guild?.channels.cache.get(_channelId);
+  PartialChannel? get channel => guild != null
+    ? guild?.channels.cache.get(_channelId)
+    : ioc.use<MineralClient>().dmChannels.cache.get(_channelId);
 
   /// ### Return an [String] if the modal has the designed field
   ///

--- a/lib/src/api/interactions/select_menu_interaction.dart
+++ b/lib/src/api/interactions/select_menu_interaction.dart
@@ -2,9 +2,11 @@ import 'dart:core';
 
 import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
+import 'package:mineral/src/api/messages/partial_message.dart';
+import 'package:mineral_ioc/ioc.dart';
 
 class SelectMenuInteraction extends Interaction {
-  Message? _message;
+  Snowflake? _messageId;
   Snowflake _customId;
   Snowflake _channelId;
 
@@ -19,14 +21,18 @@ class SelectMenuInteraction extends Interaction {
     super._token,
     super._user,
     super._guild,
-    this._message,
+    this._messageId,
     this._customId,
     this._channelId,
   );
 
-  Message? get message => _message;
+  PartialMessage? get message => guild != null
+    ? (guild?.channels.cache.get(_channelId) as dynamic)?.messages.cache[_messageId]
+    : ioc.use<MineralClient>().dmChannels.cache.get(_channelId)?.messages.cache.getOrFail(_messageId);
   Snowflake get customId => _customId;
-  TextBasedChannel? get channel => guild?.channels.cache.get(_channelId);
+  PartialChannel? get channel => guild != null
+      ? guild?.channels.cache.get(_channelId)
+      : ioc.use<MineralClient>().dmChannels.cache.get(_channelId);
 
   /// ### Return an [List] of [T] if this has the designed field
   ///
@@ -46,7 +52,7 @@ class SelectMenuInteraction extends Interaction {
   /// ```
   T getValue<T> () => data.first as T;
 
-  factory SelectMenuInteraction.from({ required Message? message, required dynamic payload }) {
+  factory SelectMenuInteraction.from({ required dynamic payload }) {
     return SelectMenuInteraction(
       payload['id'],
       null,
@@ -56,7 +62,7 @@ class SelectMenuInteraction extends Interaction {
       payload['token'],
       payload['member']?['user']?['id'],
       payload['guild_id'],
-      message,
+      payload['message']?['id'],
       payload['data']['custom_id'],
       payload['channel_id'],
     );

--- a/lib/src/api/managers/message_manager.dart
+++ b/lib/src/api/managers/message_manager.dart
@@ -8,6 +8,7 @@ import 'package:mineral/framework.dart';
 import 'package:mineral/src/api/managers/cache_manager.dart';
 import 'package:mineral/src/api/messages/dm_message.dart';
 import 'package:mineral/src/api/messages/partial_message.dart';
+import 'package:mineral_cli/mineral_cli.dart';
 import 'package:mineral_ioc/ioc.dart';
 
 class MessageManager<T extends PartialMessage> extends CacheManager<T>  {

--- a/lib/src/internal/entities/command.dart
+++ b/lib/src/internal/entities/command.dart
@@ -9,17 +9,20 @@ class Scope {
   static Scope get guild => Scope('GUILD');
   static Scope get global => Scope('GLOBAL');
 
+  bool get isGlobal => mode == 'GLOBAL';
+  bool get isGuild => !isGlobal;
+
   Scope(this.mode);
 }
 
-abstract class MineralCommand {
+abstract class MineralCommand<T extends CommandInteraction> {
   late final CommandBuilder command;
 
   void register(CommandBuilder builder) {
     command = builder;
   }
 
-  Future<void> handle (CommandInteraction interaction) async {
+  Future<void> handle (T interaction) async {
     throw MissingMethodException('The handle method does not exist on your command ${command.label}');
   }
 }

--- a/lib/src/internal/websockets/events/button_create_event.dart
+++ b/lib/src/internal/websockets/events/button_create_event.dart
@@ -8,5 +8,5 @@ class ButtonCreateEvent extends Event {
 
   ButtonInteraction get interaction => _interaction;
   GuildMember get sender => _interaction.member!;
-  TextBasedChannel get channel => _interaction.channel;
+  PartialChannel get channel => _interaction.channel;
 }

--- a/lib/src/internal/websockets/events/channel_create_event.dart
+++ b/lib/src/internal/websockets/events/channel_create_event.dart
@@ -2,9 +2,9 @@ import 'package:mineral/core/api.dart';
 import 'package:mineral/framework.dart';
 
 class ChannelCreateEvent extends Event {
-  final GuildChannel _channel;
+  final PartialChannel _channel;
 
   ChannelCreateEvent(this._channel);
 
-  GuildChannel get channel => _channel;
+  PartialChannel get channel => _channel;
 }

--- a/lib/src/internal/websockets/events/command_create_event.dart
+++ b/lib/src/internal/websockets/events/command_create_event.dart
@@ -3,9 +3,16 @@ import 'package:mineral/framework.dart';
 
 class CommandCreateEvent extends Event {
   final CommandInteraction _interaction;
+  final dynamic _payload;
 
-  CommandCreateEvent(this._interaction);
+  CommandCreateEvent(this._interaction, this._payload);
 
   CommandInteraction get interaction => _interaction;
   GuildMember get sender => _interaction.member!;
+
+  T? getInteraction<T extends CommandInteraction>(Scope scope) {
+    return scope.isGuild
+        ? GuildCommandInteraction.fromPayload(_payload) as T
+        : GlobalCommandInteraction.fromPayload(_payload) as T;
+  }
 }

--- a/lib/src/internal/websockets/packets/channel_create_packet.dart
+++ b/lib/src/internal/websockets/packets/channel_create_packet.dart
@@ -15,21 +15,13 @@ class ChannelCreatePacket with Container, Console implements WebsocketPacket {
 
     dynamic payload = websocketResponse.payload;
 
-    final ChannelType? channelType = ChannelType.values.firstWhere((element) => element.value == payload['type']);
-    Guild? guild = client.guilds.cache.get(payload['guild_id']);
+    PartialChannel channel = ChannelWrapper.create(payload);
 
-    final channel = ChannelWrapper.create(payload);
-
-    if (channelType == null || channelType == ChannelType.groupDm) {
-      return;
+    if(payload['guild_id'] != null) {
+      Guild? guild = client.guilds.cache.get(payload['guild_id']);
+      guild?.channels.cache.set(channel.id, channel as GuildChannel);
     }
 
-    guild?.channels.cache.set(channel.id, channel);
-    
-    // if (channelType is ChannelType.private) {
-    //   eventService.controller.add(DMChannelCreateEvent(channel));
-    // } else {
-      eventService.controller.add(ChannelCreateEvent(channel));
-    // }
+    eventService.controller.add(ChannelCreateEvent(channel));
   }
 }

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -96,12 +96,10 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
       ? await guild?.channels.resolve(payload['channel_id'])
       : await container.use<MineralClient>().dmChannels.resolve(payload['channel_id']);
 
-    if(channel is DmChannel) {
-      DmMessage? message = await channel.messages.resolve(payload['message']['id']);
-      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
-    } else if(channel is PartialTextChannel) {
-      Message? message = await channel.messages.resolve(payload['message']['id']);
-      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
+    if (channel is DmChannel || channel is PartialTextChannel) {
+      try {
+        await (channel as dynamic).messages.resolve(payload['message']['id']);
+      } catch(_) { }
     }
 
     ButtonInteraction buttonInteraction = ButtonInteraction.fromPayload(payload);

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -49,7 +49,7 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     }
 
     if (payload['type'] == InteractionType.modalSubmit.value) {
-      _executeModalInteraction(guild!, member!, payload);
+      _executeModalInteraction(payload);
     }
 
     if (member != null) {
@@ -108,7 +108,7 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     eventService.controller.add(ButtonCreateEvent(buttonInteraction));
   }
 
-  _executeModalInteraction (Guild guild, GuildMember member, dynamic payload) {
+  _executeModalInteraction (dynamic payload) {
     EventService eventService = container.use<EventService>();
     ModalInteraction modalInteraction = ModalInteraction.from(payload: payload);
 

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -6,7 +6,10 @@ import 'package:mineral/core/api.dart';
 import 'package:mineral/core/events.dart';
 import 'package:mineral/framework.dart';
 import 'package:mineral/src/api/builders/component_builder.dart';
+import 'package:mineral/src/api/channels/dm_channel.dart';
 import 'package:mineral/src/api/channels/partial_channel.dart';
+import 'package:mineral/src/api/messages/dm_message.dart';
+import 'package:mineral/src/api/messages/partial_message.dart';
 import 'package:mineral/src/internal/mixins/container.dart';
 import 'package:mineral/src/internal/services/command_service.dart';
 import 'package:mineral/src/internal/services/context_menu_service.dart';
@@ -39,7 +42,7 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     }
 
     if (payload['type'] == InteractionType.messageComponent.value && payload['data']['component_type'] == ComponentType.button.value) {
-      _executeButtonInteraction(guild!, member!, payload);
+      _executeButtonInteraction(guild, payload);
     }
 
     if (payload['type'] == InteractionType.messageComponent.value && payload['data']['component_type'] == ComponentType.selectMenu.value) {
@@ -87,33 +90,47 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     }
   }
 
-  _executeButtonInteraction (Guild guild, GuildMember member, dynamic payload) async {
-    if (payload['guild_id'] == null) {
-        return;
-    }
-
+  _executeButtonInteraction (Guild? guild, dynamic payload) async {
     EventService eventService = container.use<EventService>();
 
-    dynamic channel = guild.channels.cache.get(payload['channel_id']);
-    if (channel == null) {
-      final Response response = await container.use<DiscordApiHttpService>()
-        .get(url: '/channels/${payload['channel_id']}')
-        .build();
+    dynamic channel;
 
-      channel = ChannelWrapper.create(jsonDecode(response.body));
+    if (payload['guild_id'] != null) {
+      channel = guild?.channels.cache.get(payload['channel_id']);
+      if (channel == null) {
+        final Response response = await container.use<DiscordApiHttpService>()
+            .get(url: '/channels/${payload['channel_id']}')
+            .build();
 
-      guild.channels.cache.putIfAbsent(channel.id, () => channel);
+        channel = ChannelWrapper.create(jsonDecode(response.body));
+        if(channel != null) guild?.channels.cache.putIfAbsent(channel.id, () => channel as TextBasedChannel);
+      }
+    } else {
+      channel = container.use<MineralClient>().dmChannels.cache.get(payload['channel_id']);
+      if (channel == null) {
+        final Response response = await container.use<DiscordApiHttpService>()
+            .get(url: '/channels/${payload['channel_id']}')
+            .build();
+
+        channel = ChannelWrapper.create(jsonDecode(response.body));
+        if(channel != null) container.use<MineralClient>().dmChannels.cache.putIfAbsent(channel.id, () => channel as DmChannel);
+      }
     }
 
-    Message? message = channel?.messages.cache[payload['message']['id']];
+    PartialMessage<PartialChannel>? message = channel?.messages.cache[payload['message']['id']];
     if (message == null) {
       final Response response = await container.use<DiscordApiHttpService>()
         .get(url: '/channels/${payload['channel_id']}/messages/${payload['message']?['id']}')
         .build();
 
-      message = Message.from(channel: channel, payload: jsonDecode(response.body));
-
-      channel.messages.cache.putIfAbsent(message.id, () => message!);
+      if(channel is DmChannel) {
+        message = DmMessage.from(channel: channel, payload: jsonDecode(response.body));
+        channel.messages.cache.putIfAbsent(message.id, () => message as DmMessage);
+        print(message.id);
+      } else if (channel is TextBasedChannel){
+        message = Message.from(channel: channel, payload: jsonDecode(response.body));
+        channel.messages.cache.putIfAbsent(message.id, () => message as Message);
+      }
     }
 
     ButtonInteraction buttonInteraction = ButtonInteraction.fromPayload(payload);

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -123,16 +123,14 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     EventService eventService = container.use<EventService>();
 
 
-    PartialChannel? channel = payload['guild_id'] != null
-        ? await guild?.channels.resolve(payload['channel_id'])
+    PartialChannel channel = payload['guild_id'] != null && guild != null
+        ? await guild.channels.resolve(payload['channel_id'])
         : await container.use<MineralClient>().dmChannels.resolve(payload['channel_id']);
 
-    if(channel is DmChannel) {
-      DmMessage? message = await channel.messages.resolve(payload['message']['id']);
-      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
-    } else if(channel is PartialTextChannel) {
-      Message? message = await channel.messages.resolve(payload['message']['id']);
-      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
+    if (channel is DmChannel || channel is PartialTextChannel) {
+      try {
+        await (channel as dynamic).messages.resolve(payload['message']['id']);
+      } catch(_) { }
     }
 
     SelectMenuInteraction interaction = SelectMenuInteraction.from(

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -27,7 +27,7 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     GuildMember? member = guild?.members.cache.get(payload['member']['user']['id']);
 
     if (payload['type'] == InteractionType.applicationCommand.value && payload['data']['type'] == ApplicationCommandType.chatInput.value) {
-      _executeCommandInteraction(guild!, member!, payload);
+      _executeCommandInteraction(payload);
     }
 
     if (payload['type'] == InteractionType.applicationCommand.value && payload['data']['type'] == ApplicationCommandType.user.value) {
@@ -56,9 +56,9 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     }
   }
 
-  _executeCommandInteraction (Guild guild, GuildMember member, dynamic payload) {
+  _executeCommandInteraction (dynamic payload) {
     CommandInteraction interaction = CommandInteraction.fromPayload(payload);
-    container.use<CommandService>().controller.add(CommandCreateEvent(interaction));
+    container.use<CommandService>().controller.add(CommandCreateEvent(interaction, payload));
   }
 
   _executeContextMenuInteraction (Guild guild, GuildMember member, dynamic payload) async {

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -97,11 +97,11 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
       : await container.use<MineralClient>().dmChannels.get(payload['channel_id']);
 
     if(channel is DmChannel) {
-      DmMessage message = await channel.messages.get(payload['message']['id']);
-      channel.messages.cache.putIfAbsent(message.id, () => message);
+      DmMessage? message = await channel.messages.get(payload['message']['id']);
+      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     } else if(channel is PartialTextChannel) {
-      Message message = await channel.messages.get(payload['message']['id']);
-      channel.messages.cache.putIfAbsent(message.id, () => message);
+      Message? message = await channel.messages.get(payload['message']['id']);
+      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     }
 
     ButtonInteraction buttonInteraction = ButtonInteraction.fromPayload(payload);
@@ -130,11 +130,11 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
         : await container.use<MineralClient>().dmChannels.get(payload['channel_id']);
 
     if(channel is DmChannel) {
-      DmMessage message = await channel.messages.get(payload['message']['id']);
-      channel.messages.cache.putIfAbsent(message.id, () => message);
+      DmMessage? message = await channel.messages.get(payload['message']['id']);
+      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     } else if(channel is PartialTextChannel) {
-      Message message = await channel.messages.get(payload['message']['id']);
-      channel.messages.cache.putIfAbsent(message.id, () => message);
+      Message? message = await channel.messages.get(payload['message']['id']);
+      if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     }
 
     SelectMenuInteraction interaction = SelectMenuInteraction.from(

--- a/lib/src/internal/websockets/packets/interaction_create_packet.dart
+++ b/lib/src/internal/websockets/packets/interaction_create_packet.dart
@@ -93,14 +93,14 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
     EventService eventService = container.use<EventService>();
 
     PartialChannel? channel = payload['guild_id'] != null
-      ? await guild?.channels.get(payload['channel_id'])
-      : await container.use<MineralClient>().dmChannels.get(payload['channel_id']);
+      ? await guild?.channels.resolve(payload['channel_id'])
+      : await container.use<MineralClient>().dmChannels.resolve(payload['channel_id']);
 
     if(channel is DmChannel) {
-      DmMessage? message = await channel.messages.get(payload['message']['id']);
+      DmMessage? message = await channel.messages.resolve(payload['message']['id']);
       if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     } else if(channel is PartialTextChannel) {
-      Message? message = await channel.messages.get(payload['message']['id']);
+      Message? message = await channel.messages.resolve(payload['message']['id']);
       if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     }
 
@@ -126,14 +126,14 @@ class InteractionCreatePacket with Container implements WebsocketPacket {
 
 
     PartialChannel? channel = payload['guild_id'] != null
-        ? await guild?.channels.get(payload['channel_id'])
-        : await container.use<MineralClient>().dmChannels.get(payload['channel_id']);
+        ? await guild?.channels.resolve(payload['channel_id'])
+        : await container.use<MineralClient>().dmChannels.resolve(payload['channel_id']);
 
     if(channel is DmChannel) {
-      DmMessage? message = await channel.messages.get(payload['message']['id']);
+      DmMessage? message = await channel.messages.resolve(payload['message']['id']);
       if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     } else if(channel is PartialTextChannel) {
-      Message? message = await channel.messages.get(payload['message']['id']);
+      Message? message = await channel.messages.resolve(payload['message']['id']);
       if(message != null) channel.messages.cache.putIfAbsent(message.id, () => message);
     }
 


### PR DESCRIPTION
- [x] Add global and guild command interactions
- [x] Implement command interactions in dm channels 
- [x] Implement button interactions in dm channels
- [x] Implement select menu interactions in dm channels

### Breaking change
- `<CommandInteraction>.channel` return `PartialChannel` instead of `PartialTextChannel`. 

### New command system
The command class extends `MineralCommand<GuildCommandInteraction>` or `MineralCommand<GlobalCommandInteraction>`. Use the first one with guild scope (default) and the second one with global scope. 
- `<GuildCommandInteraction>.channel` return `PartialTextChannel`
- `<GlobalCommandInteraction>.channel` return `PartialChannel` (DmChannel or PartialTextChannel)