### PR TITLE
Fix missing server_id during member normalization in GuildMemberAddPacket

### DIFF
--- a/lib/src/infrastructure/internals/packets/listeners/guild_member_add_packet.dart
+++ b/lib/src/infrastructure/internals/packets/listeners/guild_member_add_packet.dart
@@ -19,8 +19,11 @@ final class GuildMemberAddPacket implements ListenablePacket {
     final server = await marshaller.dataStore.server
         .getServer(message.payload['guild_id']);
 
-    final rawMember =
-        await marshaller.serializers.member.normalize(message.payload);
+    final rawMember = await marshaller.serializers.member.normalize({
+      'server_id': server.id,
+      ...message.payload,
+    });
+
     final member = await marshaller.serializers.member.serialize(rawMember);
 
     server.members.list.putIfAbsent(member.id, () => member);


### PR DESCRIPTION
### **Problem**

When a new member is added to a server (during the `GuildMemberAddPacket` event), the `server_id` was not being included in the member normalization process. This led to potential errors or inconsistencies during member serialization, particularly when updating the server cache or processing member-related operations.

This issue was confirmed by the following error (see screenshot for reference):
![image](https://github.com/user-attachments/assets/befb6122-5f14-4169-b082-1a136af42dd0)

### **Solution**

This pull request addresses the issue by explicitly including the `server_id` in the member normalization data. This ensures that the member is properly linked to the correct server, and all subsequent operations, such as updating the server cache or dispatching events, can proceed as expected.

The change was implemented by modifying the `listen` method in the `GuildMemberAddPacket` class:

```dart
final rawMember = await marshaller.serializers.member.normalize({
  'server_id': server.id,
  ...message.payload
});
```
### **Changes**

Added server_id to the payload during member normalization in GuildMemberAddPacket.

### **Impact**

This fix improves the reliability of member-related events and ensures that the member data is handled properly within the server context. It eliminates errors caused by missing server_id during member processing.