### PR TITLE
Fix

### DIFF
--- a/lib/src/infrastructure/internals/packets/listeners/channel_update_packet.dart
+++ b/lib/src/infrastructure/internals/packets/listeners/channel_update_packet.dart
@@ -24,7 +24,10 @@ final class ChannelUpdatePacket implements ListenablePacket {
         : null;
 
     final rawChannel =
-        await marshaller.serializers.channels.normalize(message.payload);
+        await marshaller.serializers.channels.normalize({
+          'server_id': message.payload['guild_id'],
+          ...message.payload
+        });
     final channel = await marshaller.serializers.channels.serialize(rawChannel);
 
     return switch (channel) {


### PR DESCRIPTION
## Description

### Change in Channel Handling

This PR modifies the channel processing logic to include additional information in the payload. Previously, we were using `message.payload` as-is for normalizing the channel, but now we explicitly add the server ID (`guild_id`) to the normalized data.

### Key Changes:

- Previously, the channel was normalized using just `message.payload`.
- Now, we explicitly add `server_id: message.payload['guild_id']` to the data before normalizing.

### Code Before:

```dart
final rawChannel =
    await marshaller.serializers.channels.normalize(message.payload);
```

### Code After

```dart
final rawChannel =
    await marshaller.serializers.channels.normalize({
      'server_id': message.payload['guild_id'],
      ...message.payload
    });
```

This ensures that the server ID is always present during the channel normalization process.