### PR TITLE
fix: set serverId to nullable snowflake for private issues

### DIFF
--- a/lib/src/api/common/message_reaction.dart
+++ b/lib/src/api/common/message_reaction.dart
@@ -30,7 +30,7 @@ abstract class BaseMessageReaction {
 }
 
 abstract interface class ServerMessageReaction extends BaseMessageReaction {
-  Snowflake get serverId;
+  Snowflake? get serverId;
 
   Future<Member?> resolveMember();
 }
@@ -43,7 +43,7 @@ final class MessageReaction implements ServerMessageReaction, PrivateMessageReac
   DataStoreContract get _datastore => ioc.resolve<DataStoreContract>();
 
   @override
-  final Snowflake serverId;
+  final Snowflake? serverId;
 
   @override
   final Snowflake channelId;
@@ -88,7 +88,7 @@ final class MessageReaction implements ServerMessageReaction, PrivateMessageReac
   /// final member = await reaction.resolveMember();
   /// ```
   @override
-  Future<Member?> resolveMember() => _datastore.member.get(serverId.value, userId.value, true);
+  Future<Member?> resolveMember() => _datastore.member.get(serverId!.value, userId.value, true);
 
   /// Get related [ServerVoiceChannel]
   /// ```dart

--- a/lib/src/infrastructure/internals/marshaller/serializers/message_reaction_serializer.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializers/message_reaction_serializer.dart
@@ -25,7 +25,7 @@ final class MessageReactionSerializer<T extends Message>
   @override
   Future<MessageReaction> serialize(Map<String, dynamic> json) async {
     return MessageReaction(
-        serverId: Snowflake.parse(json['server_id']),
+        serverId: Snowflake.nullable(json['server_id']),
         channelId: Snowflake.parse(json['channel_id']),
         userId: Snowflake.parse(json['author_id']),
         messageId: Snowflake.parse(json['message_id']),
@@ -38,7 +38,7 @@ final class MessageReactionSerializer<T extends Message>
   @override
   Future<Map<String, dynamic>> deserialize(MessageReaction object) async {
     return {
-      'id': object.serverId.value,
+      'id': object.serverId?.value,
       'author_id': object.channelId.value,
       'content': object.userId.value,
       'embeds': object.messageId.value,


### PR DESCRIPTION
This pull request updates the handling of `serverId` in the `MessageReaction` model to support cases where a reaction may not be associated with a server. The changes make `serverId` nullable throughout the codebase and update related serialization logic to handle this new type.

Model updates:

* Changed the `serverId` property in both the `ServerMessageReaction` interface and the `MessageReaction` class to be nullable (`Snowflake?` instead of `Snowflake`). [[1]](diffhunk://#diff-0ad2f7da48509aa9a461b9d82e80b3a2f8d24e1b438f9ceb31cad52db4c4e23bL33-R33) [[2]](diffhunk://#diff-0ad2f7da48509aa9a461b9d82e80b3a2f8d24e1b438f9ceb31cad52db4c4e23bL46-R46)

Serialization improvements:

* Updated the serializer to use `Snowflake.nullable` when parsing the `server_id` field, allowing for null values.
* Modified the deserializer to safely access the `value` property of `serverId` only if it is non-null.

API usage changes:

* Updated the `resolveMember` method to use a non-null assertion (`serverId!.value`), ensuring that member resolution only proceeds when `serverId` is present.