### PR TITLE
feat: implement auto moderation

### DIFF
--- a/lib/src/api/server/managers/rules_manager.dart
+++ b/lib/src/api/server/managers/rules_manager.dart
@@ -1,0 +1,58 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/container.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/src/api/server/moderation/action.dart';
+import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
+import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
+import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
+
+final class RulesManager {
+  DataStoreContract get _datastore => ioc.resolve<DataStoreContract>();
+
+  final Snowflake _serverId;
+
+  RulesManager(this._serverId);
+
+  /// Fetch the server's channels.
+  /// ```dart
+  /// final channels = await server.channels.fetch();
+  /// ```
+  Future<Map<Snowflake, AutoModerationRule>> fetch({bool force = false}) =>
+      _datastore.rules.fetch(_serverId.value, force);
+
+  /// Get a channel by its id.
+  /// ```dart
+  /// final channel = await server.channels.get('1091121140090535956');
+  /// ```
+  Future<AutoModerationRule?> get(String id, {bool force = false}) =>
+      _datastore.rules.get(_serverId.value, id, force);
+
+  /// Create a new emoji.
+  /// ```dart
+  /// final emoji = await server.emojis.create(name: 'New Emoji', );
+  /// ```
+  Future<AutoModerationRule> create(
+      {required Object serverId,
+      required String name,
+      required AutoModerationEventType eventType,
+      required TriggerType triggerType,
+      required List<Action> actions,
+      TriggerMetadata? triggerMetadata,
+      List<Snowflake> exemptRoles = const [],
+      List<Snowflake> exemptChannels = const [],
+      bool enabled = true,
+      String? reason,
+      }) =>  _datastore.rules.create(
+        serverId: serverId,
+        name: name,
+        eventType: eventType,
+        triggerType: triggerType,
+        actions: actions,
+        triggerMetadata: triggerMetadata,
+        exemptRoles: exemptRoles,
+        exemptChannels: exemptChannels,
+        enabled: enabled,
+        reason: reason,
+      );
+}

--- a/lib/src/api/server/moderation/action.dart
+++ b/lib/src/api/server/moderation/action.dart
@@ -1,0 +1,12 @@
+import 'package:mineral/src/api/server/moderation/action_metadata.dart';
+import 'package:mineral/src/api/server/moderation/enums/action_type.dart';
+
+final class Action {
+  final ActionType type;
+  final ActionMetadata? metadata;
+
+  Action({
+    required this.type,
+    this.metadata,
+  });
+}

--- a/lib/src/api/server/moderation/action_metadata.dart
+++ b/lib/src/api/server/moderation/action_metadata.dart
@@ -1,0 +1,13 @@
+import 'package:mineral/api.dart';
+
+final class ActionMetadata {
+  final Snowflake channelId;
+  final int duration;
+  final String? customMessage;
+
+  ActionMetadata({
+    required this.channelId,
+    required this.duration,
+    this.customMessage,
+  });
+}

--- a/lib/src/api/server/moderation/auto_moderation_rule.dart
+++ b/lib/src/api/server/moderation/auto_moderation_rule.dart
@@ -1,0 +1,33 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/src/api/server/moderation/action.dart';
+import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
+import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
+
+final class AutoModerationRule {
+  final Snowflake id;
+  final Snowflake serverId;
+  final String name;
+  final Snowflake creatorId;
+  final AutoModerationEventType eventTypes;
+  final TriggerType triggerTypes;
+  final TriggerMetadata triggerMetadata;
+  final List<Action> action;
+  final bool enabled;
+  final List<Snowflake> exemptRoles;
+  final List<Snowflake> exemptChannels;
+
+  AutoModerationRule({
+    required this.id,
+    required this.serverId,
+    required this.name,
+    required this.creatorId,
+    required this.eventTypes,
+    required this.triggerTypes,
+    required this.triggerMetadata,
+    required this.action,
+    required this.enabled,
+    required this.exemptRoles,
+    required this.exemptChannels,
+  });
+}

--- a/lib/src/api/server/moderation/enums/action_type.dart
+++ b/lib/src/api/server/moderation/enums/action_type.dart
@@ -1,0 +1,12 @@
+import 'package:mineral/api.dart';
+
+enum ActionType implements EnhancedEnum<int>  {
+  blockMessage(1),
+  sendAlertMessage(2),
+  timeout(3),
+  blockMemberInteraction(4);
+
+  @override
+  final int value;
+  const ActionType(this.value);
+}

--- a/lib/src/api/server/moderation/enums/auto_moderation_event_type.dart
+++ b/lib/src/api/server/moderation/enums/auto_moderation_event_type.dart
@@ -1,0 +1,10 @@
+import 'package:mineral/api.dart';
+
+enum AutoModerationEventType implements EnhancedEnum<int>  {
+  messageSend(1),
+  memberUpdate(2);
+
+  @override
+  final int value;
+  const AutoModerationEventType(this.value);
+}

--- a/lib/src/api/server/moderation/enums/keyword_preset_type.dart
+++ b/lib/src/api/server/moderation/enums/keyword_preset_type.dart
@@ -1,0 +1,11 @@
+import 'package:mineral/api.dart';
+
+enum KeywordPresetType implements EnhancedEnum<int>  {
+  profanity(1),
+  sexualContent(2),
+  slurs(3);
+
+  @override
+  final int value;
+  const KeywordPresetType(this.value);
+}

--- a/lib/src/api/server/moderation/enums/trigger_type.dart
+++ b/lib/src/api/server/moderation/enums/trigger_type.dart
@@ -1,0 +1,13 @@
+import 'package:mineral/api.dart';
+
+enum TriggerType implements EnhancedEnum<int>  {
+  keyword(1),
+  spam(3),
+  keywordPreset(4),
+  mentionSpam(5),
+  memberProfile(6);
+
+  @override
+  final int value;
+  const TriggerType(this.value);
+}

--- a/lib/src/api/server/moderation/trigger_metadata.dart
+++ b/lib/src/api/server/moderation/trigger_metadata.dart
@@ -1,4 +1,5 @@
 import 'package:mineral/src/api/server/moderation/enums/keyword_preset_type.dart';
+import 'package:mineral/src/domains/commons/utils/utils.dart';
 
 final class TriggerMetadata {
   final List<String> keywordFilter;
@@ -16,4 +17,19 @@ final class TriggerMetadata {
     this.mentionTotalLimit,
     this.mentionRaidProtectionEnabled,
   });
+
+  static fromJson(Map<String, dynamic> json) {
+    return TriggerMetadata(
+      keywordFilter: List<String>.from(json['keyword_filter'] ?? []),
+      regexPatterns: List<String>.from(json['regex_patterns'] ?? []),
+      presets: (json['presets'] as List<dynamic>?)
+              ?.map((e) => findInEnum(KeywordPresetType.values, e))
+              .whereType<KeywordPresetType>()
+              .toList() ??
+          [],
+      allowList: List<String>.from(json['allow_list'] ?? []),
+      mentionTotalLimit: json['mention_total_limit'],
+      mentionRaidProtectionEnabled: json['mention_raid_protection_enabled'],
+    );
+  }
 }

--- a/lib/src/api/server/moderation/trigger_metadata.dart
+++ b/lib/src/api/server/moderation/trigger_metadata.dart
@@ -1,0 +1,19 @@
+import 'package:mineral/src/api/server/moderation/enums/keyword_preset_type.dart';
+
+final class TriggerMetadata {
+  final List<String> keywordFilter;
+  final List<String> regexPatterns;
+  final List<KeywordPresetType> presets;
+  final List<String> allowList;
+  final int? mentionTotalLimit;
+  final bool? mentionRaidProtectionEnabled;
+
+  TriggerMetadata({
+    required this.keywordFilter,
+    required this.regexPatterns,
+    required this.presets,
+    required this.allowList,
+    this.mentionTotalLimit,
+    this.mentionRaidProtectionEnabled,
+  });
+}

--- a/lib/src/api/server/server_settings.dart
+++ b/lib/src/api/server/server_settings.dart
@@ -1,4 +1,5 @@
 import 'package:mineral/api.dart';
+import 'package:mineral/src/api/server/managers/rules_manager.dart';
 
 final class ServerSettings {
   final String? bitfieldPermission;
@@ -15,6 +16,7 @@ final class ServerSettings {
   final String preferredLocale;
   final int? maxVideoChannelUsers;
   final NsfwLevel nsfwLevel;
+  final RulesManager rulesManager;
 
   ServerSettings({
     required this.bitfieldPermission,
@@ -31,5 +33,6 @@ final class ServerSettings {
     required this.preferredLocale,
     required this.maxVideoChannelUsers,
     required this.nsfwLevel,
+    required this.rulesManager,
   });
 }

--- a/lib/src/domains/services/datastore/datastore.dart
+++ b/lib/src/domains/services/datastore/datastore.dart
@@ -26,6 +26,8 @@ abstract class DataStoreContract {
 
   EmojiPartContract get emoji;
 
+  RulesPartContract get rules;
+
   ReactionPartContract get reaction;
 
   ThreadPart get thread;

--- a/lib/src/domains/services/datastore/parts.dart
+++ b/lib/src/domains/services/datastore/parts.dart
@@ -2,6 +2,11 @@ import 'package:mineral/api.dart';
 import 'package:mineral/src/api/common/polls/poll_answer_vote.dart';
 import 'package:mineral/src/api/server/channels/private_thread_channel.dart';
 import 'package:mineral/src/api/server/channels/public_thread_channel.dart';
+import 'package:mineral/src/api/server/moderation/action.dart';
+import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
+import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
+import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
 import 'package:mineral/src/api/server/voice_state.dart';
 
 abstract interface class DataStorePart {}
@@ -230,6 +235,32 @@ abstract interface class EmojiPartContract implements DataStorePart {
       required String? reason});
 
   Future<void> delete(Object serverId, String emojiId, {String? reason});
+}
+
+abstract interface class RulesPartContract implements DataStorePart {
+  Future<Map<Snowflake, AutoModerationRule>> fetch(Object serverId, bool force);
+
+  Future<AutoModerationRule?> get(Object serverId, Object id, bool force);
+
+  Future<AutoModerationRule> create(
+      {required Object serverId,
+      required String name,
+      required AutoModerationEventType eventType,
+      required TriggerType triggerType,
+      required List<Action> actions,
+      TriggerMetadata? triggerMetadata,
+      List<Snowflake> exemptRoles = const [],
+      List<Snowflake> exemptChannels = const [],
+      bool enabled = true,
+      String? reason});
+
+  Future<AutoModerationRule?> update(
+      {required Object id,
+      required Object serverId,
+      required Map<String, dynamic> payload,
+      required String? reason});
+
+  Future<void> delete(Object serverId, Object ruleId, {String? reason});
 }
 
 abstract interface class ReactionPartContract implements DataStorePart {

--- a/lib/src/infrastructure/internals/datastore/datastore.dart
+++ b/lib/src/infrastructure/internals/datastore/datastore.dart
@@ -8,6 +8,7 @@ import 'package:mineral/src/infrastructure/internals/datastore/parts/member_part
 import 'package:mineral/src/infrastructure/internals/datastore/parts/message_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/reaction_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/role_part.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/rules_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/server_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/sticker_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
@@ -60,6 +61,10 @@ final class DataStore implements DataStoreContract {
   @override
   late final InvitePart invite;
 
+  @override
+  // TODO: implement rules
+  late final RulesPart rules;
+
   DataStore(this.client)
       : channel = ChannelPart(),
         server = ServerPart(),
@@ -72,5 +77,6 @@ final class DataStore implements DataStoreContract {
         emoji = EmojiPart(),
         reaction = ReactionPart(),
         thread = ThreadPart(),
+        rules = RulesPart(),
         invite = InvitePart();
 }

--- a/lib/src/infrastructure/internals/datastore/parts/rules_part.dart
+++ b/lib/src/infrastructure/internals/datastore/parts/rules_part.dart
@@ -24,7 +24,7 @@ final class RulesPart implements RulesPartContract {
 
     final req = Request.json(endpoint: '/guilds/$serverId/auto-moderation/rules');
     final result = await _dataStore.requestBucket
-        .query<List<Map<String, dynamic>>>(req)
+        .query<List<dynamic>>(req)
         .run(_dataStore.client.get);
 
     final rules = await result.map((element) async {

--- a/lib/src/infrastructure/internals/datastore/parts/rules_part.dart
+++ b/lib/src/infrastructure/internals/datastore/parts/rules_part.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:mineral/api.dart';
+import 'package:mineral/container.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/api/server/moderation/action.dart';
+import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
+import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
+import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
+import 'package:mineral/src/infrastructure/internals/http/discord_header.dart';
+
+final class RulesPart implements RulesPartContract {
+  MarshallerContract get _marshaller => ioc.resolve<MarshallerContract>();
+
+  DataStoreContract get _dataStore => ioc.resolve<DataStoreContract>();
+
+  HttpClientStatus get status => _dataStore.client.status;
+
+  @override
+  Future<Map<Snowflake, AutoModerationRule>> fetch(Object serverId, bool force) async {
+    final completer = Completer<Map<Snowflake, AutoModerationRule>>();
+
+    final req = Request.json(endpoint: '/guilds/$serverId/auto-moderation/rules');
+    final result = await _dataStore.requestBucket
+        .query<List<Map<String, dynamic>>>(req)
+        .run(_dataStore.client.get);
+
+    final rules = await result.map((element) async {
+      final raw = await _marshaller.serializers.rules.normalize(element);
+      return _marshaller.serializers.rules.serialize(raw);
+    }).wait;
+
+    completer
+        .complete(rules.asMap().map((_, value) => MapEntry(value.id!, value)));
+
+    return completer.future;
+  }
+
+  @override
+  Future<AutoModerationRule?> get(Object serverId, Object rulesId, bool force) async {
+    final completer = Completer<AutoModerationRule>();
+    final String key = _marshaller.cacheKey.serverRules(serverId, rulesId);
+
+    final cachedEmoji = await _marshaller.cache?.get(key);
+    if (!force && cachedEmoji != null) {
+      final rule = await _marshaller.serializers.rules.serialize(cachedEmoji);
+      completer.complete(rule);
+
+      return completer.future;
+    }
+
+    final req = Request.json(endpoint: '/guilds/$serverId/auto-moderation/rules/$rulesId');
+    final result = await _dataStore.requestBucket
+        .query<Map<String, dynamic>>(req)
+        .run(_dataStore.client.get);
+
+    final raw = await _marshaller.serializers.rules.normalize(result);
+    final rule = await _marshaller.serializers.rules.serialize(raw);
+
+    completer.complete(rule);
+
+    return completer.future;
+  }
+
+  @override
+  Future<AutoModerationRule> create({
+    required Object serverId,
+    required String name,
+    required AutoModerationEventType eventType,
+    required TriggerType triggerType,
+    required List<Action> actions,
+    TriggerMetadata? triggerMetadata,
+    List<Snowflake> exemptRoles = const [],
+    List<Snowflake> exemptChannels = const [],
+    bool enabled = true,
+    String? reason,
+}) async {
+    final completer = Completer<AutoModerationRule>();
+
+    final req = Request.json(endpoint: '/guilds/$serverId/auto-moderation/rules', body: {
+      'name': name,
+      'event_type': eventType.value,
+      'trigger_type': triggerType.value,
+      'trigger_metadata': triggerMetadata != null ? {
+        'keyword_filter': triggerMetadata.keywordFilter,
+        'regex_patterns': triggerMetadata.regexPatterns,
+        'presets': triggerMetadata.presets.map((e) => e.value).toList(),
+        'allow_list': triggerMetadata.allowList,
+        'mention_total_limit': triggerMetadata.mentionTotalLimit,
+        'mention_raid_protection_enabled': triggerMetadata.mentionRaidProtectionEnabled,
+      } : null,
+      'actions': actions.map((action) => {
+        'type': action.type.value,
+        if (action.metadata != null) 'metadata': action.metadata,
+      }).toList(),
+      'exempt_roles': exemptRoles.map((e) => e.toString()).toList(),
+      'exempt_channels': exemptChannels.map((e) => e.toString()).toList(),
+      'enabled': enabled,
+    }, headers: {
+      DiscordHeader.auditLogReason(reason)
+    });
+    final result = await _dataStore.requestBucket
+        .query<Map<String, dynamic>>(req)
+        .run(_dataStore.client.post);
+
+    final raw = await _marshaller.serializers.channels.normalize(result);
+    final rule = await _marshaller.serializers.rules.serialize({
+      ...raw,
+      'guild_id': serverId,
+    });
+
+    completer.complete(rule);
+
+    return completer.future;
+  }
+
+  @override
+  Future<AutoModerationRule?> update(
+      {required Object id,
+      required Object serverId,
+      required Map<String, dynamic> payload,
+      required String? reason}) async {
+    final completer = Completer<AutoModerationRule>();
+
+    final req = Request.json(
+        endpoint: '/guilds/$serverId/auto-moderation/rules/$id',
+        body: payload,
+        headers: {DiscordHeader.auditLogReason(reason)});
+
+    final result = await _dataStore.requestBucket
+        .query<Map<String, dynamic>>(req)
+        .run(_dataStore.client.patch);
+
+    final raw = await _marshaller.serializers.rules.normalize({
+      ...result,
+      'guild_id': serverId,
+    });
+    final rule = await _marshaller.serializers.rules.serialize(raw);
+
+    completer.complete(rule);
+    return completer.future;
+  }
+
+  @override
+  Future<void> delete(Object serverId, Object ruleId, {String? reason}) async {
+    final req = Request.json(
+        endpoint: '/guilds/$serverId/auto-moderation/rules/$ruleId',
+        headers: {DiscordHeader.auditLogReason(reason)});
+
+    await _dataStore.requestBucket
+        .query<Map<String, dynamic>>(req)
+        .run(_dataStore.client.delete);
+  }
+}

--- a/lib/src/infrastructure/internals/marshaller/cache_key.dart
+++ b/lib/src/infrastructure/internals/marshaller/cache_key.dart
@@ -13,6 +13,11 @@ final class CacheKey {
     return ref ? 'ref:$key' : key;
   }
 
+  String serverRules(Object serverId, Object ruleId, {bool ref = false}) {
+    final key = '${server(serverId)}/rules/$ruleId';
+    return ref ? 'ref:$key' : key;
+  }
+
   String serverSubscription(String serverId, {bool ref = false}) {
     final key = '${server(serverId)}/subscriptions';
     return ref ? 'ref:$key' : key;

--- a/lib/src/infrastructure/internals/marshaller/serializer_bucket.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializer_bucket.dart
@@ -10,6 +10,7 @@ import 'package:mineral/src/api/common/sticker.dart';
 import 'package:mineral/src/api/private/user.dart';
 import 'package:mineral/src/api/server/invite.dart';
 import 'package:mineral/src/api/server/member.dart';
+import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
 import 'package:mineral/src/api/server/role.dart';
 import 'package:mineral/src/api/server/server.dart';
 import 'package:mineral/src/api/server/voice_state.dart';
@@ -25,6 +26,7 @@ import 'package:mineral/src/infrastructure/internals/marshaller/serializers/mess
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/poll_answer_vote_serializer.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/poll_serializer.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/role_serializer.dart';
+import 'package:mineral/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/server_serializer.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/sticker_serializer.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializers/user_serializer.dart';
@@ -63,6 +65,8 @@ final class SerializerBucket {
 
   final SerializerContract<PollAnswerVote> pollAnswerVote;
 
+  final SerializerContract<AutoModerationRule> rules;
+
   SerializerBucket(MarshallerContract marshaller)
       : channels = ChannelSerializer(),
         server = ServerSerializer(),
@@ -78,5 +82,6 @@ final class SerializerBucket {
         voice = VoiceStateSerializer(),
         reaction = MessageReactionSerializer(),
         pollAnswerVote = PollAnswerVoteSerializer(),
+        rules = RuleSerializer(),
         invite = InviteSerializer();
 }

--- a/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
@@ -1,0 +1,94 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/src/api/server/invite.dart';
+import 'package:mineral/src/api/server/moderation/action.dart';
+import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
+import 'package:mineral/src/api/server/moderation/enums/action_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
+import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
+import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
+import 'package:mineral/src/domains/commons/utils/helper.dart';
+import 'package:mineral/src/domains/commons/utils/utils.dart';
+import 'package:mineral/src/domains/container/ioc_container.dart';
+import 'package:mineral/src/domains/services/marshaller/marshaller.dart';
+import 'package:mineral/src/infrastructure/internals/marshaller/types/serializer.dart';
+
+final class RuleSerializer implements SerializerContract<AutoModerationRule> {
+  MarshallerContract get _marshaller => ioc.resolve<MarshallerContract>();
+
+  @override
+  Future<Map<String, dynamic>> normalize(Map<String, dynamic> json) async {
+    final payload = {
+      'id': json['id'],
+      'serverId': json['guild_id'],
+      'name': json['name'],
+      'creatorId': json['creator_id'],
+      'eventType': json['event_type'],
+      'triggerType': json['trigger_type'],
+      'triggerMetadata': json['trigger_metadata'],
+      'actions': json['actions'],
+      'enabled': json['enabled'],
+      'exemptRoles': List<Snowflake>.from(
+          (json['exempt_roles'] as List).map((e) => Snowflake.parse(e))),
+      'exemptChannels': List<Snowflake>.from(
+          (json['exempt_channels'] as List).map((e) => Snowflake.parse(e))),
+      'createdAt': DateTime.parse(json['created_at']),
+      'updatedAt': DateTime.parse(json['updated_at']),
+    };
+
+    final cacheKey = _marshaller.cacheKey
+        .serverRules(json['guild_id'], json['id']);
+    await _marshaller.cache?.put(cacheKey, payload);
+
+    return payload;
+  }
+
+  @override
+  Future<AutoModerationRule> serialize(Map<String, dynamic> json) async {
+    return AutoModerationRule(
+        id: json['id'],
+        serverId: Snowflake.parse(json['serverId']),
+        name: json['name'],
+        creatorId: Snowflake.parse(json['creatorId']),
+        eventTypes: findInEnum(AutoModerationEventType.values, json['eventType']),
+        triggerMetadata: TriggerMetadata.fromJson(json['triggerMetadata']),
+        action: (json['actions'] as List).map((action) {
+          final type = findInEnum(ActionType.values, action['type']);
+          return Action(type: type);
+        }).toList(),
+        enabled: json['enabled'] ?? true,
+        exemptRoles: List<Snowflake>.from(
+            (json['exemptRoles'] as List).map(Snowflake.parse)),
+        exemptChannels: List<Snowflake>.from((json['exemptChannels'] as List).map(Snowflake.parse)),
+        triggerTypes: findInEnum(TriggerType.values, json['triggerType']),
+            );
+  }
+
+  @override
+  Map<String, dynamic> deserialize(AutoModerationRule rule) {
+    return {
+       'id': rule.id,
+      'server_id': rule.serverId.toString(),
+      'name': rule.name,
+      'creator_id': rule.creatorId.toString(),
+      'event_type': rule.eventTypes.value,
+      'trigger_type': rule.triggerTypes.value,
+      'trigger_metadata': {
+        'keyword_filter': rule.triggerMetadata.keywordFilter,
+        'regex_patterns': rule.triggerMetadata.regexPatterns,
+        'presets': rule.triggerMetadata.presets.map((e) => e.value).toList(),
+        'allow_list': rule.triggerMetadata.allowList,
+        'mention_total_limit': rule.triggerMetadata.mentionTotalLimit,
+        'mention_raid_protection_enabled':
+            rule.triggerMetadata.mentionRaidProtectionEnabled,
+      },
+      'actions': rule.action
+          .map((action) => {
+                'type': action.type.value,
+              })
+          .toList(),
+      'enabled': rule.enabled,
+      'exempt_roles': rule.exemptRoles.map((e) => e.toString()).toList(),
+      'exempt_channels': rule.exemptChannels.map((e) => e.toString()).toList(),
+    };
+  }
+}

--- a/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
@@ -1,12 +1,10 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/src/api/server/invite.dart';
 import 'package:mineral/src/api/server/moderation/action.dart';
 import 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
 import 'package:mineral/src/api/server/moderation/enums/action_type.dart';
 import 'package:mineral/src/api/server/moderation/enums/auto_moderation_event_type.dart';
 import 'package:mineral/src/api/server/moderation/enums/trigger_type.dart';
 import 'package:mineral/src/api/server/moderation/trigger_metadata.dart';
-import 'package:mineral/src/domains/commons/utils/helper.dart';
 import 'package:mineral/src/domains/commons/utils/utils.dart';
 import 'package:mineral/src/domains/container/ioc_container.dart';
 import 'package:mineral/src/domains/services/marshaller/marshaller.dart';
@@ -43,7 +41,7 @@ final class RuleSerializer implements SerializerContract<AutoModerationRule> {
   @override
   Future<AutoModerationRule> serialize(Map<String, dynamic> json) async {
     return AutoModerationRule(
-        id: json['id'],
+        id: Snowflake.parse(json['id']),
         serverId: Snowflake.parse(json['serverId']),
         name: json['name'],
         creatorId: Snowflake.parse(json['creatorId']),

--- a/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializers/rule_serializer.dart
@@ -31,8 +31,6 @@ final class RuleSerializer implements SerializerContract<AutoModerationRule> {
           (json['exempt_roles'] as List).map((e) => Snowflake.parse(e))),
       'exemptChannels': List<Snowflake>.from(
           (json['exempt_channels'] as List).map((e) => Snowflake.parse(e))),
-      'createdAt': DateTime.parse(json['created_at']),
-      'updatedAt': DateTime.parse(json['updated_at']),
     };
 
     final cacheKey = _marshaller.cacheKey

--- a/lib/src/infrastructure/internals/marshaller/serializers/server_serializer.dart
+++ b/lib/src/infrastructure/internals/marshaller/serializers/server_serializer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:mineral/api.dart';
+import 'package:mineral/src/api/server/managers/rules_manager.dart';
 import 'package:mineral/src/api/server/managers/threads_manager.dart';
 import 'package:mineral/src/domains/commons/utils/helper.dart';
 import 'package:mineral/src/domains/commons/utils/utils.dart';
@@ -120,7 +121,9 @@ final class ServerSerializer implements SerializerContract<Server> {
         preferredLocale: payload['settings']['preferred_locale'],
         maxVideoChannelUsers: payload['max_video_channel_users'],
         nsfwLevel:
-            findInEnum(NsfwLevel.values, payload['settings']['nsfw_level']));
+            findInEnum(NsfwLevel.values, payload['settings']['nsfw_level']),
+        rulesManager: RulesManager(Snowflake.parse(payload['id'])));
+
 
     return Server(
       id: Snowflake.parse(payload['id']),


### PR DESCRIPTION
This pull request introduces a new auto-moderation rules system for servers, adding support for managing Discord-style moderation rules, triggers, and actions. The implementation includes new domain models, enums, data store contracts, and infrastructure for CRUD operations on moderation rules.

**Auto-Moderation Rules System**

* Added core domain models for auto-moderation rules, actions, action metadata, and trigger metadata in the `moderation` module. These models define the structure and types for rules, actions, and triggers. [[1]](diffhunk://#diff-e21b53585f78a243672a9fea6980745941fb26c335c2f4221d7a6472b6def8ceR1-R33) [[2]](diffhunk://#diff-c35ad0ec49b92b53c4f2834290f6aa6291eafccb08f67c0d35c4e370310864b1R1-R12) [[3]](diffhunk://#diff-5d11949d7b1ca7144e1bf84458b0ab4aaf66f93071c55730bd111475b55bddb2R1-R13) [[4]](diffhunk://#diff-9284f323c4c42f3269c09dfa365d311bab5d3bebc6b327c7ab4ddcbc00c0df8bR1-R35)

* Introduced enums for moderation event types, trigger types, action types, and keyword preset types to support rule configuration and serialization. [[1]](diffhunk://#diff-987943bf261ca950e6614c6398604ef46ac78f7b6777842b15a2450dd420465dR1-R10) [[2]](diffhunk://#diff-c41a0c2c9db908690888c213890fc65b4314887b5259bb5f74dce29fc3caa383R1-R13) [[3]](diffhunk://#diff-3cd643de3777b12383af9b947456975fbd5037d0541e173313a7ec6bcb7a1af2R1-R12) [[4]](diffhunk://#diff-baf66a9bb58d2e29cbb60e8ae175ba593bbd58ee583ba154def49b5bddfd3fe9R1-R11)

**Data Store and Infrastructure Integration**

* Added `RulesPartContract` to the data store contracts and implemented the `RulesPart` class for fetching, creating, updating, and deleting auto-moderation rules through the Discord API. This includes cache key support and marshalling logic for rule objects. [[1]](diffhunk://#diff-d7e42a8c74bd15376b6dd5e52e14bda9188e17901f58a1a86cf408e2f490a679R240-R265) [[2]](diffhunk://#diff-504fa9026ece5f3f44ff171b14965a07d1ce7cdf1aef1d77f57419ff903ff0efR1-R156) [[3]](diffhunk://#diff-f62b5e56f364d67017fc6da96a1eec19cb1a33ccb3b4e507c62f3dbdde9a45aaR16-R20)

* Registered the new rules part in the main data store and hooked up marshaller serialization for auto-moderation rules. [[1]](diffhunk://#diff-7e04cba0be873565a03af3499f235c4ea501b50714a1a98404e9fc6e75768e38R11) [[2]](diffhunk://#diff-7e04cba0be873565a03af3499f235c4ea501b50714a1a98404e9fc6e75768e38R64-R67) [[3]](diffhunk://#diff-7e04cba0be873565a03af3499f235c4ea501b50714a1a98404e9fc6e75768e38R80) [[4]](diffhunk://#diff-8a7be4612cd969b8366c4bd1bd24f93d3d044b6f2021fdc635ff8df102cc79d2R13) [[5]](diffhunk://#diff-8a7be4612cd969b8366c4bd1bd24f93d3d044b6f2021fdc635ff8df102cc79d2R29) [[6]](diffhunk://#diff-8a7be4612cd969b8366c4bd1bd24f93d3d044b6f2021fdc635ff8df102cc79d2R68-R69)

**Server API Extension**

* Added `RulesManager` to the server API, providing high-level methods for managing moderation rules. Integrated `RulesManager` into `ServerSettings` for easy access. [[1]](diffhunk://#diff-8efa1eb4a13a39870da1ba304cb8cbb7e054f6a19574693c4ec5f75abc41da4fR1-R58) [[2]](diffhunk://#diff-eaf9a013d0a5503b0d8d6d7685f0ab57d5b7ad46422211aa8d1dc22172079300R2) [[3]](diffhunk://#diff-eaf9a013d0a5503b0d8d6d7685f0ab57d5b7ad46422211aa8d1dc22172079300R19) [[4]](diffhunk://#diff-eaf9a013d0a5503b0d8d6d7685f0ab57d5b7ad46422211aa8d1dc22172079300R36)