### PR TITLE
feat: override toString method in User class for easy mention

### DIFF
--- a/lib/src/api/private/user.dart
+++ b/lib/src/api/private/user.dart
@@ -47,4 +47,7 @@ final class User implements UserClient {
   /// final member = await user.toMember('240561194958716928');
   /// ```
   Future<Member?> toMember(String serverId) => _datastore.member.get(serverId, id.value, false);
+
+  @override
+  String toString() => '<@$id>';
 }


### PR DESCRIPTION
This pull request makes a minor update to the `User` class by implementing a custom `toString` method.

- Added a `toString` override to the `User` class to return a Discord-style mention string using the user's ID.