### PR TITLE
chore: add export for voice state in API

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -129,6 +129,7 @@ export 'package:mineral/src/api/server/server_settings.dart';
 export 'package:mineral/src/api/server/server_subscription.dart';
 export 'package:mineral/src/api/server/threads/thread_channel.dart';
 export 'package:mineral/src/api/server/threads/thread_result.dart';
+export 'package:mineral/src/api/server/voice_state.dart';
 export 'package:mineral/src/domains/client/client.dart';
 export 'package:mineral/src/domains/client/client_builder.dart';
 export 'package:mineral/src/domains/commands/command_context.dart';


### PR DESCRIPTION
This pull request makes a small change to the `lib/api.dart` file by adding an export for the `voice_state.dart` module. This update allows other parts of the codebase to access server voice state functionality through the main API entry point.

That is useful for things like:
```dart
import 'dart:async';

import 'package:mineral/events.dart';
import 'package:mineral/api.dart';

final class OnVoiceJoinEvent extends VoiceJoinEvent {
  @override
  FutureOr<void> handle(VoiceState state) { // ⇽ VoiceState needed here 
    
  }
}
```
