### PR TITLE
fix: add missing export for voice_move_event

### DIFF
--- a/lib/events.dart
+++ b/lib/events.dart
@@ -4,6 +4,7 @@ library events;
 export 'package:mineral/src/domains/events/contracts/common/ready_event.dart';
 export 'package:mineral/src/domains/events/contracts/common/voice_join_event.dart';
 export 'package:mineral/src/domains/events/contracts/common/voice_leave_event.dart';
+export 'package:mineral/src/domains/events/contracts/common/voice_move_event.dart';
 export 'package:mineral/src/domains/events/contracts/common/voice_state_update_event.dart';
 export 'package:mineral/src/domains/events/contracts/private/private_button_click_event.dart';
 export 'package:mineral/src/domains/events/contracts/private/private_channel_create_event.dart';


### PR DESCRIPTION
This pull request adds support for a new voice event to the `lib/events.dart` export list, enhancing the event handling capabilities related to voice channel activities.

Voice event support:

* Added export for `voice_move_event.dart`, enabling handling of voice channel movement events in the application.