### PR TITLE
feat: add resolveServer method to voice state

### DIFF
--- a/lib/src/api/server/voice_state.dart
+++ b/lib/src/api/server/voice_state.dart
@@ -73,4 +73,8 @@ final class VoiceState {
     final voiceState = await _datastore.member.getVoiceState(serverId.value, userId.value, force);
     return MemberVoiceManager(serverId, userId, voiceState);
   }
+
+  Future<Server> resolveServer({bool force = false}) {
+    return _datastore.server.get(serverId!.value, force);
+  }
 }


### PR DESCRIPTION
This pull request introduces a new method to the `VoiceState` class to improve server data retrieval functionality.

Enhancement to server data access:

* Added the `resolveServer` method to the `VoiceState` class in `lib/src/api/server/voice_state.dart`, allowing retrieval of the associated `Server` object, with an optional `force` parameter to bypass cache if needed.