### PR TITLE
fix: bind bot class to ioc services.

### DIFF
--- a/lib/src/api/common/bot/bot.dart
+++ b/lib/src/api/common/bot/bot.dart
@@ -33,7 +33,9 @@ final class Bot {
     required this.presences,
     required this.guildIds,
     required this.application,
-  });
+  }) {
+    ioc.bind<Bot>(() => this);
+  }
 
   /// Updates presence of this
   void setPresence({List<BotActivity>? activities, StatusType? status, bool? afk}) =>


### PR DESCRIPTION
This pull request introduces a small but important change to the `Bot` class constructor in `bot.dart`. The change ensures that the `Bot` instance is registered with the inversion of control (IoC) container upon creation, making it easier to retrieve the current bot instance elsewhere in the application.

- Dependency injection improvement:
  * The `Bot` constructor now binds the created instance to the IoC container using `ioc.bind<Bot>(() => this);`, allowing other parts of the application to access the current bot instance through dependency injection.