### PR TITLE
chore: add createdAt getter to Interaction class

### DIFF
--- a/lib/src/domains/services/interactions/interaction_contract.dart
+++ b/lib/src/domains/services/interactions/interaction_contract.dart
@@ -1,6 +1,8 @@
 import 'package:mineral/api.dart';
 
 abstract class InteractionContract {
+  DateTime get createdAt;
+
   /// Use to reply to the interaction.
   /// Usage:
   ///

--- a/lib/src/infrastructure/internals/interactions/interaction.dart
+++ b/lib/src/infrastructure/internals/interactions/interaction.dart
@@ -12,6 +12,9 @@ final class Interaction implements InteractionContract {
   Interaction(this._token, this._id);
 
   @override
+  DateTime get createdAt => _id.createdAt;
+
+  @override
   Future<InteractionContract> reply(
       {required MessageBuilder builder,
       bool ephemeral = false}) async {


### PR DESCRIPTION
This pull request introduces a new `createdAt` property to the `InteractionContract` interface and implements it in the `Interaction` class. This addition allows consumers of the interaction API to easily access the creation timestamp of an interaction.

New property addition:

* Added a `createdAt` getter to the `InteractionContract` interface, providing a standard way to access the creation time of an interaction.
* Implemented the `createdAt` getter in the `Interaction` class to return the creation time from the underlying `_id` object.