### PR TITLE
fix: resolve in GlobalStateManager instead of Service.

### DIFF
--- a/lib/container.dart
+++ b/lib/container.dart
@@ -17,7 +17,7 @@ mixin Logger {
 }
 
 mixin State {
-  GlobalStateService get state => ioc.resolve<GlobalStateService>();
+  GlobalStateService get state => ioc.resolve<GlobalStateManager>();
 }
 
 mixin Components {


### PR DESCRIPTION
This pull request makes a minor update to the `State` mixin in `lib/container.dart` to use `GlobalStateManager` instead of `GlobalStateService` for dependency resolution. This change ensures that the correct class is being injected throughout the codebase.