### PR TITLE
feat: added member voices states from cache for voices

### DIFF
--- a/lib/src/api/server/channels/server_voice_channel.dart
+++ b/lib/src/api/server/channels/server_voice_channel.dart
@@ -33,7 +33,7 @@ final class ServerVoiceChannel extends ServerChannel {
 
   late final ServerCategoryChannel? category;
 
-  late final List<VoiceState> voices;
+  late final List<VoiceState> members;
 
   ServerVoiceChannel(this._properties) {
     _methods = ChannelMethods(_properties.serverId!, _properties.id);

--- a/lib/src/infrastructure/internals/marshaller/factories/channels/server_voice_channel_factory.dart
+++ b/lib/src/infrastructure/internals/marshaller/factories/channels/server_voice_channel_factory.dart
@@ -34,17 +34,17 @@ final class ServerVoiceChannelFactory
       MarshallerContract marshaller, Map<String, dynamic> json) async {
     final properties = await ChannelProperties.serializeCache(marshaller, json);
     final voices = await marshaller.cache!.whereKeyStartsWith('voice_states/server/${properties.serverId}') ?? {};
-    final List<VoiceState> voicesStates = [];
+    final List<VoiceState> members = [];
 
     for (final voice in voices.values) {
       if (voice['channel_id'].toString() == properties.id.value) {
         final voiceState = await marshaller.serializers.voice.serialize(voice);
-        voicesStates.add(voiceState);
+        members.add(voiceState);
       }
     }
 
     return ServerVoiceChannel(properties)
-    ..voices = voicesStates;
+    ..members = members;
   }
 
   @override


### PR DESCRIPTION
This pull request enhances the handling of voice states within server voice channels by updating both the `ServerVoiceChannel` model and its factory serialization logic. The main focus is to ensure that each `ServerVoiceChannel` instance accurately reflects the current voice states associated with it.

**Enhancements to voice state management:**

* Added a `voices` property of type `List<VoiceState>` to the `ServerVoiceChannel` class to store active voice states for the channel.
* Updated the `ServerVoiceChannelFactory.serialize` method to fetch relevant voice states from the cache, filter them by channel ID, serialize them, and assign them to the `voices` property of the channel.

**General improvements:**

* Added a missing import for `mineral/api.dart` in the `server_voice_channel_factory.dart` file.