### PR TITLE
feat: add isEmpty getter to ServerVoiceChannel

### DIFF
--- a/lib/src/api/server/channels/server_voice_channel.dart
+++ b/lib/src/api/server/channels/server_voice_channel.dart
@@ -35,6 +35,8 @@ final class ServerVoiceChannel extends ServerChannel {
 
   late final List<VoiceState> members;
 
+  bool get isEmpty => members.isEmpty;
+
   ServerVoiceChannel(this._properties) {
     _methods = ChannelMethods(_properties.serverId!, _properties.id);
     messages = MessageManager(_properties.id);


### PR DESCRIPTION
This pull request adds a new convenience property to the `ServerVoiceChannel` class, making it easier to check if the channel has any members.

* Channel member utilities:
  * Added an `isEmpty` getter to the `ServerVoiceChannel` class, which returns `true` if the `members` list is empty.