### PR TITLE
feat: implement USER_UPDATE gateway event

### DIFF
--- a/packages/core/lib/src/domains/events/contracts/common_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/common_events.dart
@@ -4,6 +4,18 @@ import 'package:mineral/api.dart';
 import 'package:mineral/src/domains/events/event.dart';
 import 'package:mineral/src/domains/events/types/base_listenable_event.dart';
 
+typedef UserUpdateArgs = ({User? before, User after});
+
+abstract class UserUpdateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.userUpdate;
+
+  @override
+  Function get handler => (UserUpdateArgs p) => handle(p.before, p.after);
+
+  FutureOr<void> handle(User? before, User after);
+}
+
 typedef InviteCreateArgs = ({Invite invite});
 
 abstract class InviteCreateEvent extends BaseListenableEvent {

--- a/packages/core/lib/src/domains/events/event.dart
+++ b/packages/core/lib/src/domains/events/event.dart
@@ -9,6 +9,10 @@ enum Event implements EnhancedEnum<Type>, EventType {
   ready(ReadyEvent, [
     ['Bot', 'bot']
   ]),
+  userUpdate(UserUpdateEvent, [
+    ['User?', 'before'],
+    ['User', 'after']
+  ]),
   inviteCreate(InviteCreateEvent, [
     ['Invite', 'invite']
   ]),

--- a/packages/core/lib/src/domains/events/event_bucket.dart
+++ b/packages/core/lib/src/domains/events/event_bucket.dart
@@ -24,6 +24,11 @@ final class EventBucket {
       _registerEvent(event: Event.ready,
           handle: (ReadyArgs p) => handle(p.bot));
 
+  void userUpdate(
+          FutureOr<void> Function(User? before, User after) handle) =>
+      _registerEvent(event: Event.userUpdate,
+          handle: (UserUpdateArgs p) => handle(p.before, p.after));
+
   void voiceStateUpdate(FutureOr<void> Function(VoiceState state) handle) =>
       _registerEvent(event: Event.voiceStateUpdate,
           handle: (VoiceStateUpdateArgs p) => handle(p.state));

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/user_update_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/user_update_packet.dart
@@ -1,0 +1,33 @@
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class UserUpdatePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.userUpdate;
+
+  final MarshallerContract _marshaller;
+
+  UserUpdatePacket({required MarshallerContract marshaller})
+      : _marshaller = marshaller;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final payload = message.payload as Map<String, dynamic>;
+    final userId = payload['id'] as String;
+
+    final userCacheKey = _marshaller.cacheKey.user(userId);
+    final rawUser = await _marshaller.cache?.get(userCacheKey);
+    final before =
+        rawUser != null ? await _marshaller.serializers.user.serialize(rawUser) : null;
+
+    final rawAfter =
+        await _marshaller.serializers.user.normalize(payload);
+    final after = await _marshaller.serializers.user.serialize(rawAfter);
+
+    dispatch<UserUpdateArgs>(
+        event: Event.userUpdate, payload: (before: before, after: after));
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -48,6 +48,7 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_de
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_members_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/typing_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/user_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/voice_connect_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/voice_disconnect_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/voice_join_packet.dart';
@@ -97,6 +98,7 @@ final class PacketListener implements PacketListenerContract {
         marshaller: m, commandManager: cm, runtimeState: runtimeState));
     subscribe(GuildUpdatePacket(marshaller: m));
     subscribe(GuildDeletePacket(marshaller: m));
+    subscribe(UserUpdatePacket(marshaller: m));
     subscribe(ChannelCreatePacket(logger: logger, marshaller: m));
     subscribe(ChannelUpdatePacket(logger: logger, marshaller: m));
     subscribe(ChannelDeletePacket(marshaller: m));

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
@@ -57,6 +57,8 @@ enum PacketType implements PacketTypeContract {
   voiceStateUpdate('VOICE_STATE_UPDATE'),
   voiceChannelStatusUpdate('VOICE_CHANNEL_STATUS_UPDATE'),
 
+  userUpdate('USER_UPDATE'),
+
   inviteCreate('INVITE_CREATE'),
   inviteDelete('INVITE_DELETE'),
 

--- a/packages/core/test/packets/user_update_packet_test.dart
+++ b/packages/core/test/packets/user_update_packet_test.dart
@@ -1,0 +1,149 @@
+import 'package:mineral/events.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/user_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_cache_provider.dart';
+import '../helpers/fake_marshaller.dart';
+
+void main() {
+  group('UserUpdatePacket', () {
+    late FakeCacheProvider cache;
+    late FakeMarshaller marshaller;
+    late UserUpdatePacket packet;
+
+    /// A minimal raw Discord USER_UPDATE payload.
+    Map<String, dynamic> rawPayload() => {
+          'id': '123456789',
+          'username': 'updated_user',
+          'discriminator': '0042',
+          'flags': 0,
+          'public_flags': 0,
+          'avatar': null,
+          'bot': false,
+          'system': false,
+          'mfa_enabled': false,
+          'locale': null,
+          'verified': false,
+          'email': null,
+          'premium_type': null,
+          'avatar_decoration_data': null,
+          'banner': null,
+        };
+
+    ShardMessage<dynamic> buildMessage(Map<String, dynamic> payload) =>
+        ShardMessage(
+          type: 'USER_UPDATE',
+          opCode: OpCode.dispatch,
+          sequence: 1,
+          payload: payload,
+        );
+
+    setUp(() {
+      cache = FakeCacheProvider();
+      marshaller = FakeMarshaller(cache: cache);
+      packet = UserUpdatePacket(marshaller: marshaller);
+    });
+
+    test('packetType is PacketType.userUpdate', () {
+      expect(packet.packetType.name, equals('USER_UPDATE'));
+    });
+
+    test('dispatches Event.userUpdate with a correctly-deserialized after user',
+        () async {
+      Event? capturedEvent;
+      Object? capturedPayload;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+        capturedPayload = payload;
+      }
+
+      await packet.listen(buildMessage(rawPayload()), dispatch);
+
+      expect(capturedEvent, equals(Event.userUpdate));
+
+      final args = capturedPayload as UserUpdateArgs;
+      expect(args.after.id, equals('123456789'));
+      expect(args.after.username, equals('updated_user'));
+      expect(args.after.discriminator, equals('0042'));
+    });
+
+    test('before is null when user is not in cache', () async {
+      UserUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedArgs = payload as UserUpdateArgs;
+      }
+
+      await packet.listen(buildMessage(rawPayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNull);
+    });
+
+    test('before is populated when user is already in cache', () async {
+      // Pre-populate the cache with the old user state.
+      final userCacheKey = marshaller.cacheKey.user('123456789');
+      await cache.put(userCacheKey, {
+        'id': '123456789',
+        'username': 'old_user',
+        'discriminator': '0001',
+        'flags': 0,
+        'public_flags': 0,
+        'avatar': null,
+        'is_bot': false,
+        'system': false,
+        'mfa_enabled': false,
+        'locale': null,
+        'verified': false,
+        'email': null,
+        'premium_type': null,
+        'assets': {
+          'user_id': '123456789',
+          'avatar': null,
+          'avatar_decoration': null,
+          'banner': null,
+        },
+      });
+
+      UserUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedArgs = payload as UserUpdateArgs;
+      }
+
+      await packet.listen(buildMessage(rawPayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNotNull);
+      expect(capturedArgs!.before!.username, equals('old_user'));
+      expect(capturedArgs!.after.username, equals('updated_user'));
+    });
+
+    test('updates cache with new user data after dispatch', () async {
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {}
+
+      await packet.listen(buildMessage(rawPayload()), dispatch);
+
+      final userCacheKey = marshaller.cacheKey.user('123456789');
+      final cached = await cache.get(userCacheKey);
+
+      expect(cached, isNotNull);
+      expect(cached!['username'], equals('updated_user'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds support for the Discord `USER_UPDATE` gateway event (fired when the bot's own user object changes).

- New `UserUpdatePacket` listener (before/after via cache, mirroring `GuildUpdatePacket`)
- `PacketType.userUpdate`, `Event.userUpdate`, `UserUpdateEvent` contract + `EventBucket.userUpdate(...)`
- Registered in `packet_listener.dart`

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New listener tests pass (5/5): packetType identity, after deserialization, before null on cache miss, before populated on cache hit, cache updated

Closes #379