### PR TITLE
feat: implement MESSAGE_UPDATE gateway event

### DIFF
--- a/packages/core/lib/src/domains/events/buckets/private_bucket.dart
+++ b/packages/core/lib/src/domains/events/buckets/private_bucket.dart
@@ -15,6 +15,12 @@ final class PrivateBucket {
       _events.make(Event.privateMessageCreate,
           (PrivateMessageCreateArgs p) => handle(p.message));
 
+  void messageUpdate(
+          FutureOr<void> Function(PrivateMessage? before, PrivateMessage after)
+              handle) =>
+      _events.make(Event.privateMessageUpdate,
+          (PrivateMessageUpdateArgs p) => handle(p.before, p.after));
+
   void messageDelete(
           FutureOr<void> Function(PrivateChannel channel, Snowflake messageId,
                   Message? message)

--- a/packages/core/lib/src/domains/events/buckets/server_bucket.dart
+++ b/packages/core/lib/src/domains/events/buckets/server_bucket.dart
@@ -27,6 +27,12 @@ final class ServerBucket {
       _events.make(Event.serverMessageCreate,
           (ServerMessageCreateArgs p) => handle(p.message));
 
+  void messageUpdate(
+          FutureOr<void> Function(ServerMessage? before, ServerMessage after)
+              handle) =>
+      _events.make(Event.serverMessageUpdate,
+          (ServerMessageUpdateArgs p) => handle(p.before, p.after));
+
   void messageDelete(
           FutureOr<void> Function(Server server, ServerChannel channel,
                   Snowflake messageId, Message? message)

--- a/packages/core/lib/src/domains/events/contracts/private_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/private_events.dart
@@ -81,6 +81,19 @@ abstract class PrivateMessageCreateEvent extends BaseListenableEvent {
   FutureOr<void> handle(PrivateMessage message);
 }
 
+typedef PrivateMessageUpdateArgs = ({PrivateMessage? before, PrivateMessage after});
+
+abstract class PrivateMessageUpdateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.privateMessageUpdate;
+
+  @override
+  Function get handler =>
+      (PrivateMessageUpdateArgs p) => handle(p.before, p.after);
+
+  FutureOr<void> handle(PrivateMessage? before, PrivateMessage after);
+}
+
 typedef PrivateMessageDeleteArgs = ({
   PrivateChannel channel,
   Snowflake messageId,

--- a/packages/core/lib/src/domains/events/contracts/server_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/server_events.dart
@@ -232,6 +232,19 @@ abstract class ServerMessageCreateEvent extends BaseListenableEvent {
   FutureOr<void> handle(ServerMessage message);
 }
 
+typedef ServerMessageUpdateArgs = ({ServerMessage? before, ServerMessage after});
+
+abstract class ServerMessageUpdateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverMessageUpdate;
+
+  @override
+  Function get handler =>
+      (ServerMessageUpdateArgs p) => handle(p.before, p.after);
+
+  FutureOr<void> handle(ServerMessage? before, ServerMessage after);
+}
+
 typedef ServerMessageDeleteArgs = ({
   Server server,
   ServerChannel channel,

--- a/packages/core/lib/src/domains/events/event.dart
+++ b/packages/core/lib/src/domains/events/event.dart
@@ -39,6 +39,10 @@ enum Event implements EnhancedEnum<Type>, EventType {
   serverMessageCreate(ServerMessageCreateEvent, [
     ['ServerMessage', 'message']
   ]),
+  serverMessageUpdate(ServerMessageUpdateEvent, [
+    ['ServerMessage?', 'before'],
+    ['ServerMessage', 'after']
+  ]),
   serverMessageDelete(ServerMessageDeleteEvent, [
     ['Server', 'server'],
     ['ServerChannel', 'channel'],
@@ -212,6 +216,10 @@ enum Event implements EnhancedEnum<Type>, EventType {
   // private
   privateMessageCreate(PrivateMessageCreateEvent, [
     ['PrivateMessage', 'message']
+  ]),
+  privateMessageUpdate(PrivateMessageUpdateEvent, [
+    ['PrivateMessage?', 'before'],
+    ['PrivateMessage', 'after']
   ]),
   privateMessageDelete(PrivateMessageDeleteEvent, [
     ['PrivateChannel', 'channel'],

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/message_update_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/message_update_packet.dart
@@ -1,0 +1,48 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class MessageUpdatePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.messageUpdate;
+
+  final MarshallerContract _marshaller;
+
+  MessageUpdatePacket({required MarshallerContract marshaller})
+      : _marshaller = marshaller;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final payload = message.payload as Map<String, dynamic>;
+    final messageId = payload['id'] as String;
+    final channelId = payload['channel_id'] as String;
+
+    // Read cached message as `before` (nullable — cache miss is expected)
+    final messageCacheKey =
+        _marshaller.cacheKey.message(channelId, messageId);
+    final rawBefore = await _marshaller.cache?.get(messageCacheKey);
+    final before = rawBefore != null
+        ? await _marshaller.serializers.message.serialize(rawBefore)
+        : null;
+
+    // Normalize + serialize the incoming payload as `after`
+    final rawAfter = await _marshaller.serializers.message
+        .normalize(payload);
+    final after = await _marshaller.serializers.message.serialize(rawAfter);
+
+    final serverId = Snowflake.nullable(payload['guild_id']);
+    switch (serverId) {
+      case String():
+        dispatch<ServerMessageUpdateArgs>(
+            event: Event.serverMessageUpdate,
+            payload: (before: before as ServerMessage?, after: after as ServerMessage));
+      default:
+        dispatch<PrivateMessageUpdateArgs>(
+            event: Event.privateMessageUpdate,
+            payload: (before: before as PrivateMessage?, after: after as PrivateMessage));
+    }
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -41,6 +41,7 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/message_p
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_add_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_all_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/message_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/presence_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/ready_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_create_packet.dart';
@@ -94,6 +95,7 @@ final class PacketListener implements PacketListenerContract {
         runtimeState: runtimeState,
         cacheConfig: cacheConfig));
     subscribe(MessageCreatePacket(marshaller: m));
+    subscribe(MessageUpdatePacket(marshaller: m));
     subscribe(GuildCreatePacket(
         marshaller: m, commandManager: cm, runtimeState: runtimeState));
     subscribe(GuildUpdatePacket(marshaller: m));

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
@@ -7,6 +7,7 @@ enum PacketType implements PacketTypeContract {
   interactionCreate('INTERACTION_CREATE'),
 
   messageCreate('MESSAGE_CREATE'),
+  messageUpdate('MESSAGE_UPDATE'),
   messageDelete('MESSAGE_DELETE'),
   messageDeleteBulk('MESSAGE_DELETE_BULK'),
   messageReactionAdd('MESSAGE_REACTION_ADD'),

--- a/packages/core/test/packets/message_update_packet_test.dart
+++ b/packages/core/test/packets/message_update_packet_test.dart
@@ -1,0 +1,242 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/message_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_cache_provider.dart';
+import '../helpers/fake_marshaller.dart';
+
+void main() {
+  group('MessageUpdatePacket', () {
+    late FakeCacheProvider cache;
+    late FakeMarshaller marshaller;
+    late MessageUpdatePacket packet;
+
+    /// A minimal raw Discord MESSAGE_UPDATE payload for a server (guild) message.
+    Map<String, dynamic> rawServerPayload() => {
+          'id': '111222333444555666',
+          'channel_id': '777888999000111222',
+          'guild_id': '123456789012345678',
+          'author': {
+            'id': '987654321098765432',
+            'bot': false,
+          },
+          'content': 'edited content',
+          'embeds': <Map<String, dynamic>>[],
+          'timestamp': '2024-06-01T12:00:00.000Z',
+          'edited_timestamp': '2024-06-01T12:05:00.000Z',
+        };
+
+    /// A minimal raw Discord MESSAGE_UPDATE payload for a private (DM) message.
+    Map<String, dynamic> rawPrivatePayload() => {
+          'id': '111222333444555666',
+          'channel_id': '777888999000111222',
+          // no guild_id → private message
+          'author': {
+            'id': '987654321098765432',
+            'bot': false,
+          },
+          'content': 'edited DM content',
+          'embeds': <Map<String, dynamic>>[],
+          'timestamp': '2024-06-01T12:00:00.000Z',
+          'edited_timestamp': '2024-06-01T12:05:00.000Z',
+        };
+
+    ShardMessage<dynamic> buildMessage(Map<String, dynamic> payload) =>
+        ShardMessage(
+          type: 'MESSAGE_UPDATE',
+          opCode: OpCode.dispatch,
+          sequence: 1,
+          payload: payload,
+        );
+
+    setUp(() {
+      cache = FakeCacheProvider();
+      marshaller = FakeMarshaller(cache: cache);
+      packet = MessageUpdatePacket(marshaller: marshaller);
+    });
+
+    // ── packetType identity ──────────────────────────────────────────────────
+
+    test('packetType is PacketType.messageUpdate', () {
+      expect(packet.packetType, equals(PacketType.messageUpdate));
+      expect(packet.packetType.name, equals('MESSAGE_UPDATE'));
+    });
+
+    // ── server branch ────────────────────────────────────────────────────────
+
+    test('dispatches Event.serverMessageUpdate for guild messages', () async {
+      Event? capturedEvent;
+      Object? capturedPayload;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+        capturedPayload = payload;
+      }
+
+      await packet.listen(buildMessage(rawServerPayload()), dispatch);
+
+      expect(capturedEvent, equals(Event.serverMessageUpdate));
+      expect(capturedPayload, isA<ServerMessageUpdateArgs>());
+
+      final args = capturedPayload as ServerMessageUpdateArgs;
+      expect(args.after.id, equals(Snowflake('111222333444555666')));
+      expect(args.after.content, equals('edited content'));
+    });
+
+    test('before is null on cache miss (server message)', () async {
+      ServerMessageUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverMessageUpdate) {
+          capturedArgs = payload as ServerMessageUpdateArgs;
+        }
+      }
+
+      await packet.listen(buildMessage(rawServerPayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNull);
+    });
+
+    test('before is populated when server message is already in cache',
+        () async {
+      // Pre-populate the cache with the old message state (normalized format).
+      final messageCacheKey = marshaller.cacheKey
+          .message('777888999000111222', '111222333444555666');
+      await cache.put(messageCacheKey, {
+        'id': '111222333444555666',
+        'author_id': '987654321098765432',
+        'content': 'original content',
+        'embeds': <Map<String, dynamic>>[],
+        'channel_id': '777888999000111222',
+        'server_id': '123456789012345678',
+        'author_is_bot': false,
+        'timestamp': '2024-06-01T12:00:00.000Z',
+        'edited_timestamp': null,
+      });
+
+      ServerMessageUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverMessageUpdate) {
+          capturedArgs = payload as ServerMessageUpdateArgs;
+        }
+      }
+
+      await packet.listen(buildMessage(rawServerPayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNotNull);
+      expect(capturedArgs!.before!.content, equals('original content'));
+      expect(capturedArgs!.after.content, equals('edited content'));
+    });
+
+    // ── private branch ───────────────────────────────────────────────────────
+
+    test('dispatches Event.privateMessageUpdate for DM messages', () async {
+      Event? capturedEvent;
+      Object? capturedPayload;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+        capturedPayload = payload;
+      }
+
+      await packet.listen(buildMessage(rawPrivatePayload()), dispatch);
+
+      expect(capturedEvent, equals(Event.privateMessageUpdate));
+      expect(capturedPayload, isA<PrivateMessageUpdateArgs>());
+
+      final args = capturedPayload as PrivateMessageUpdateArgs;
+      expect(args.after.id, equals(Snowflake('111222333444555666')));
+      expect(args.after.content, equals('edited DM content'));
+    });
+
+    test('before is null on cache miss (private message)', () async {
+      PrivateMessageUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.privateMessageUpdate) {
+          capturedArgs = payload as PrivateMessageUpdateArgs;
+        }
+      }
+
+      await packet.listen(buildMessage(rawPrivatePayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNull);
+    });
+
+    test('before is populated when private message is already in cache',
+        () async {
+      final messageCacheKey = marshaller.cacheKey
+          .message('777888999000111222', '111222333444555666');
+      await cache.put(messageCacheKey, {
+        'id': '111222333444555666',
+        'author_id': '987654321098765432',
+        'content': 'original DM content',
+        'embeds': <Map<String, dynamic>>[],
+        'channel_id': '777888999000111222',
+        'server_id': null,
+        'author_is_bot': false,
+        'timestamp': '2024-06-01T12:00:00.000Z',
+        'edited_timestamp': null,
+      });
+
+      PrivateMessageUpdateArgs? capturedArgs;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.privateMessageUpdate) {
+          capturedArgs = payload as PrivateMessageUpdateArgs;
+        }
+      }
+
+      await packet.listen(buildMessage(rawPrivatePayload()), dispatch);
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.before, isNotNull);
+      expect(capturedArgs!.before!.content, equals('original DM content'));
+      expect(capturedArgs!.after.content, equals('edited DM content'));
+    });
+
+    // ── cache updated after dispatch ─────────────────────────────────────────
+
+    test('cache is updated with new message data after dispatch', () async {
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {}
+
+      await packet.listen(buildMessage(rawServerPayload()), dispatch);
+
+      final messageCacheKey = marshaller.cacheKey
+          .message('777888999000111222', '111222333444555666');
+      final cached = await cache.get(messageCacheKey);
+
+      expect(cached, isNotNull);
+      expect(cached!['content'], equals('edited content'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds support for the Discord `MESSAGE_UPDATE` gateway event (message edits), with server and private (DM) variants.

- New `MessageUpdatePacket` listener: `before` from cache (nullable), `after` from the incoming payload; server/private split via `guild_id` (mirrors `MessageCreatePacket`)
- `PacketType.messageUpdate`; `Event.serverMessageUpdate` / `Event.privateMessageUpdate` + contracts + bucket methods
- Registered in `packet_listener.dart`

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New listener tests pass (8/8): packetType, server/private dispatch, before null on cache miss, before populated on hit, cache updated

Closes #377