### PR TITLE
feat: implement MESSAGE_REACTION_REMOVE_EMOJI gateway event

### DIFF
--- a/packages/core/lib/src/domains/events/buckets/private_bucket.dart
+++ b/packages/core/lib/src/domains/events/buckets/private_bucket.dart
@@ -84,6 +84,15 @@ final class PrivateBucket {
           (PrivateMessageReactionRemoveAllArgs p) =>
               handle(p.channel, p.message));
 
+  void messageReactionRemoveEmoji(
+          FutureOr<void> Function(
+                  PrivateChannel channel, Message message, PartialEmoji emoji)
+              handle) =>
+      _events.make(
+          Event.privateMessageReactionRemoveEmoji,
+          (PrivateMessageReactionRemoveEmojiArgs p) =>
+              handle(p.channel, p.message, p.emoji));
+
   void pollVoteAdd(
           FutureOr<void> Function(PollAnswerVote<Message> answer, User user)
               handle) =>

--- a/packages/core/lib/src/domains/events/buckets/server_bucket.dart
+++ b/packages/core/lib/src/domains/events/buckets/server_bucket.dart
@@ -241,6 +241,15 @@ final class ServerBucket {
           (ServerMessageReactionRemoveAllArgs p) =>
               handle(p.server, p.channel, p.message));
 
+  void messageReactionRemoveEmoji(
+          FutureOr<void> Function(Server server, ServerTextChannel channel,
+                  Message message, PartialEmoji emoji)
+              handle) =>
+      _events.make(
+          Event.serverMessageReactionRemoveEmoji,
+          (ServerMessageReactionRemoveEmojiArgs p) =>
+              handle(p.server, p.channel, p.message, p.emoji));
+
   void auditLog(FutureOr<void> Function(AuditLog audit) handle) => _events.make(
       Event.serverAuditLog, (ServerAuditLogArgs p) => handle(p.audit));
 

--- a/packages/core/lib/src/domains/events/contracts/private_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/private_events.dart
@@ -155,6 +155,24 @@ abstract class PrivateMessageReactionRemoveAllEvent
   FutureOr<void> handle(PrivateChannel channel, Message message);
 }
 
+typedef PrivateMessageReactionRemoveEmojiArgs = ({
+  PrivateChannel channel,
+  Message message,
+  PartialEmoji emoji
+});
+
+abstract class PrivateMessageReactionRemoveEmojiEvent
+    extends BaseListenableEvent {
+  @override
+  Event get event => Event.privateMessageReactionRemoveEmoji;
+
+  @override
+  Function get handler => (PrivateMessageReactionRemoveEmojiArgs p) =>
+      handle(p.channel, p.message, p.emoji);
+
+  FutureOr<void> handle(PrivateChannel channel, Message message, PartialEmoji emoji);
+}
+
 typedef PrivateModalSubmitArgs<T> = ({PrivateModalContext ctx, T data});
 
 abstract class PrivateModalSubmitEvent<T> extends BaseListenableEvent {

--- a/packages/core/lib/src/domains/events/contracts/server_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/server_events.dart
@@ -327,6 +327,26 @@ abstract class ServerMessageReactionRemoveAllEvent extends BaseListenableEvent {
       Server server, ServerTextChannel channel, Message message);
 }
 
+typedef ServerMessageReactionRemoveEmojiArgs = ({
+  Server server,
+  ServerTextChannel channel,
+  Message message,
+  PartialEmoji emoji
+});
+
+abstract class ServerMessageReactionRemoveEmojiEvent
+    extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverMessageReactionRemoveEmoji;
+
+  @override
+  Function get handler => (ServerMessageReactionRemoveEmojiArgs p) =>
+      handle(p.server, p.channel, p.message, p.emoji);
+
+  FutureOr<void> handle(
+      Server server, ServerTextChannel channel, Message message, PartialEmoji emoji);
+}
+
 typedef ServerModalSubmitArgs<T> = ({ServerModalContext ctx, T data});
 
 abstract class ServerModalSubmitEvent<T> extends BaseListenableEvent {

--- a/packages/core/lib/src/domains/events/event.dart
+++ b/packages/core/lib/src/domains/events/event.dart
@@ -191,6 +191,12 @@ enum Event implements EnhancedEnum<Type>, EventType {
     ['ServerTextChannel', 'channel'],
     ['Message', 'message']
   ]),
+  serverMessageReactionRemoveEmoji(ServerMessageReactionRemoveEmojiEvent, [
+    ['Server', 'server'],
+    ['ServerTextChannel', 'channel'],
+    ['Message', 'message'],
+    ['PartialEmoji', 'emoji']
+  ]),
   serverPollVoteAdd(ServerPollVoteAddEvent, [
     ['PollAnswerVote<ServerMessage>', 'message'],
     ['User', 'user']
@@ -271,6 +277,11 @@ enum Event implements EnhancedEnum<Type>, EventType {
   privateMessageReactionRemoveAll(PrivateMessageReactionRemoveAllEvent, [
     ['PrivateChannel', 'channel'],
     ['Message', 'message']
+  ]),
+  privateMessageReactionRemoveEmoji(PrivateMessageReactionRemoveEmojiEvent, [
+    ['PrivateChannel', 'channel'],
+    ['Message', 'message'],
+    ['PartialEmoji', 'emoji']
   ]),
   voiceStateUpdate(VoiceStateUpdateEvent, [
     ['VoiceState', 'before'],

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart
@@ -1,0 +1,74 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class MessageReactionRemoveEmojiPacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.messageReactionRemoveEmoji;
+
+  final DataStoreContract _dataStore;
+
+  MessageReactionRemoveEmojiPacket({required DataStoreContract dataStore})
+      : _dataStore = dataStore;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final serverId = Snowflake.nullable(message.payload['guild_id']);
+    final channelId = Snowflake.parse(message.payload['channel_id']);
+    final messageId = Snowflake.parse(message.payload['message_id']);
+    final emojiPayload = message.payload['emoji'] as Map<String, dynamic>?;
+    final emoji = PartialEmoji(
+      Snowflake.nullable(emojiPayload?['id']),
+      (emojiPayload?['name'] as String?) ?? '',
+      (emojiPayload?['animated'] as bool?) ?? false,
+    );
+
+    if (serverId != null) {
+      await _server(dispatch, serverId, channelId, messageId, emoji);
+    } else {
+      await _private(dispatch, channelId, messageId, emoji);
+    }
+  }
+
+  Future<void> _server(
+      DispatchEvent dispatch,
+      Snowflake serverId,
+      Snowflake channelId,
+      Snowflake messageId,
+      PartialEmoji emoji) async {
+    final channel =
+        await _dataStore.channel.get<ServerTextChannel>(channelId.value, false);
+    final message = await channel?.messages.get(messageId);
+    final server = await _dataStore.server.get(serverId.value, false);
+
+    dispatch<ServerMessageReactionRemoveEmojiArgs>(
+        event: Event.serverMessageReactionRemoveEmoji,
+        payload: (
+          server: server,
+          channel: channel!,
+          message: message! as Message,
+          emoji: emoji
+        ));
+  }
+
+  Future<void> _private(
+      DispatchEvent dispatch,
+      Snowflake channelId,
+      Snowflake messageId,
+      PartialEmoji emoji) async {
+    final channel =
+        await _dataStore.channel.get<PrivateChannel>(channelId.value, false);
+    final message = await channel?.messages.get(messageId);
+
+    dispatch<PrivateMessageReactionRemoveEmojiArgs>(
+        event: Event.privateMessageReactionRemoveEmoji,
+        payload: (
+          channel: channel!,
+          message: message! as Message,
+          emoji: emoji
+        ));
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -40,6 +40,7 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/message_p
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_poll_vote_remove_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_add_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_all_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/presence_update_packet.dart';
@@ -125,6 +126,7 @@ final class PacketListener implements PacketListenerContract {
     subscribe(MessageReactionAddPacket(marshaller: m));
     subscribe(MessageReactionRemovePacket(marshaller: m));
     subscribe(MessageReactionRemoveAllPacket(dataStore: ds));
+    subscribe(MessageReactionRemoveEmojiPacket(dataStore: ds));
 
     subscribe(ButtonInteractionCreatePacket(
         logger: logger, interactiveComponent: ic, ctx: entityContext));

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
@@ -13,6 +13,7 @@ enum PacketType implements PacketTypeContract {
   messageReactionAdd('MESSAGE_REACTION_ADD'),
   messageReactionRemove('MESSAGE_REACTION_REMOVE'),
   messageReactionRemoveAll('MESSAGE_REACTION_REMOVE_ALL'),
+  messageReactionRemoveEmoji('MESSAGE_REACTION_REMOVE_EMOJI'),
 
   threadCreate('THREAD_CREATE'),
   threadUpdate('THREAD_UPDATE'),

--- a/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
+++ b/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
@@ -1,0 +1,742 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/api/server/managers/rules_manager.dart';
+import 'package:mineral/src/api/server/managers/threads_manager.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
+import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_logger.dart';
+import '../helpers/fake_websocket_orchestrator.dart';
+
+// ── Test IDs ─────────────────────────────────────────────────────────────────
+
+const _channelId = '111222333444555666';
+const _messageId = '777888999000111222';
+const _serverId = '123456789012345678';
+
+// ── Fake data store helpers ───────────────────────────────────────────────────
+
+/// Delegates every accessor to a lazily-resolved [DataStoreContract].
+/// Used to break the circular dependency: EntityContext → DataStoreContract →
+/// channels/messages built with EntityContext.
+final class _DeferredDataStore implements DataStoreContract {
+  final DataStoreContract Function() _resolve;
+
+  _DeferredDataStore(this._resolve);
+
+  @override
+  ChannelPartContract get channel => _resolve().channel;
+  @override
+  ServerPartContract get server => _resolve().server;
+  @override
+  MessagePartContract get message => _resolve().message;
+  @override
+  MemberPartContract get member => _resolve().member;
+  @override
+  UserPartContract get user => _resolve().user;
+  @override
+  RolePartContract get role => _resolve().role;
+  @override
+  InteractionPartContract get interaction => _resolve().interaction;
+  @override
+  StickerPartContract get sticker => _resolve().sticker;
+  @override
+  EmojiPartContract get emoji => _resolve().emoji;
+  @override
+  RulesPartContract get rules => _resolve().rules;
+  @override
+  ReactionPartContract get reaction => _resolve().reaction;
+  @override
+  ThreadPart get thread => _resolve().thread;
+  @override
+  InvitePartContract get invite => _resolve().invite;
+  @override
+  WebhookPartContract get webhook => _resolve().webhook;
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      _resolve().scheduledEvent;
+  @override
+  RequestBucket get requestBucket => _resolve().requestBucket;
+  @override
+  HttpClientContract get client => _resolve().client;
+}
+
+/// Minimal [DataStoreContract] that wires channel, server, and message parts.
+final class _FakeDataStore implements DataStoreContract {
+  final ChannelPartContract _channelPart;
+  final ServerPartContract _serverPart;
+  final MessagePartContract _messagePart;
+
+  _FakeDataStore({
+    required ChannelPartContract channelPart,
+    required ServerPartContract serverPart,
+    required MessagePartContract messagePart,
+  })  : _channelPart = channelPart,
+        _serverPart = serverPart,
+        _messagePart = messagePart;
+
+  @override
+  ChannelPartContract get channel => _channelPart;
+  @override
+  ServerPartContract get server => _serverPart;
+  @override
+  MessagePartContract get message => _messagePart;
+
+  @override
+  RequestBucket get requestBucket => throw UnimplementedError();
+  @override
+  HttpClientContract get client => throw UnimplementedError();
+  @override
+  MemberPartContract get member => throw UnimplementedError();
+  @override
+  UserPartContract get user => throw UnimplementedError();
+  @override
+  RolePartContract get role => throw UnimplementedError();
+  @override
+  InteractionPartContract get interaction => throw UnimplementedError();
+  @override
+  StickerPartContract get sticker => throw UnimplementedError();
+  @override
+  EmojiPartContract get emoji => throw UnimplementedError();
+  @override
+  RulesPartContract get rules => throw UnimplementedError();
+  @override
+  ReactionPartContract get reaction => throw UnimplementedError();
+  @override
+  ThreadPart get thread => throw UnimplementedError();
+  @override
+  InvitePartContract get invite => throw UnimplementedError();
+  @override
+  WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+}
+
+/// [ChannelPartContract] that returns a pre-built [Channel].
+final class _FakeChannelPart implements ChannelPartContract {
+  final Channel _channel;
+
+  _FakeChannelPart(this._channel);
+
+  @override
+  Future<T?> get<T extends Channel>(Object id, bool force) async {
+    if (_channel is T) {
+      // ignore: unnecessary_cast
+      return _channel as T;
+    }
+    return null;
+  }
+
+  @override
+  Future<Map<Snowflake, T>> fetch<T extends Channel>(
+          Object serverId, bool force) async =>
+      {};
+
+  @override
+  Future<T> create<T extends Channel>(
+          Object? serverId, ChannelBuilderContract builder,
+          {String? reason}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<PrivateChannel?> createPrivateChannel(
+          Object id, String recipientId) async =>
+      null;
+
+  @override
+  Future<T?> update<T extends Channel>(
+          Object id, ChannelBuilderContract builder,
+          {Object? serverId, String? reason}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> delete(Object id, String? reason) async {}
+}
+
+/// [ServerPartContract] that returns a pre-built [Server].
+final class _FakeServerPart implements ServerPartContract {
+  final Server _server;
+
+  _FakeServerPart(this._server);
+
+  @override
+  Future<Server> get(Object id, bool force) async => _server;
+
+  @override
+  Future<Server> update(Object id, Map<String, dynamic> payload,
+          [String? reason]) =>
+      throw UnimplementedError();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+/// [MessagePartContract] that returns a pre-built [Message].
+final class _FakeMessagePart implements MessagePartContract {
+  final Message _message;
+
+  _FakeMessagePart(this._message);
+
+  @override
+  Future<T?> get<T extends BaseMessage>(
+          Object channelId, Object messageId, bool force) async =>
+      _message as T?;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+/// Stub [ServerPartContract] for tests that never hit the server branch.
+final class _NoopServerPart implements ServerPartContract {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+/// Stub [MessagePartContract] for tests that skip message resolution.
+final class _NoopMessagePart implements MessagePartContract {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+// ── Domain object builders ────────────────────────────────────────────────────
+
+EntityContext _buildCtx(DataStoreContract dataStore) => EntityContext(
+      datastore: dataStore,
+      wss: FakeWebsocketOrchestrator(),
+      logger: FakeLogger(),
+      runtimeState: RuntimeState(),
+    );
+
+Message _buildMessage(EntityContext ctx) => Message(
+      MessageProperties(
+        id: Snowflake.parse(_messageId),
+        content: 'test message',
+        channelId: Snowflake.parse(_channelId),
+        authorId: null,
+        serverId: Snowflake.parse(_serverId),
+        authorIsBot: false,
+        embeds: [],
+        createdAt: DateTime.now(),
+        updatedAt: null,
+      ),
+      ctx: ctx,
+    );
+
+ServerTextChannel _buildServerTextChannel(EntityContext ctx) =>
+    ServerTextChannel(
+      ChannelProperties(
+        ctx: ctx,
+        id: Snowflake.parse(_channelId),
+        type: ChannelType.guildText,
+        name: 'general',
+        description: null,
+        serverId: Snowflake.parse(_serverId),
+        categoryId: null,
+        position: null,
+        nsfw: false,
+        lastMessageId: null,
+        bitrate: null,
+        userLimit: null,
+        rateLimitPerUser: null,
+        recipients: [],
+        icon: null,
+        ownerId: null,
+        applicationId: null,
+        lastPinTimestamp: null,
+        rtcRegion: null,
+        videoQualityMode: null,
+        messageCount: null,
+        memberCount: null,
+        defaultAutoArchiveDuration: null,
+        permissions: [],
+        flags: null,
+        totalMessageSent: null,
+        available: null,
+        appliedTags: [],
+        defaultReactions: null,
+        defaultSortOrder: null,
+        defaultForumLayout: null,
+        threads: ThreadsManager(
+          Snowflake.parse(_serverId),
+          Snowflake.parse(_channelId),
+          ctx: ctx,
+        ),
+      ),
+    );
+
+PrivateChannel _buildPrivateChannel(EntityContext ctx) => PrivateChannel(
+      ChannelProperties(
+        ctx: ctx,
+        id: Snowflake.parse(_channelId),
+        type: ChannelType.dm,
+        name: 'dm',
+        description: null,
+        serverId: null,
+        categoryId: null,
+        position: null,
+        nsfw: false,
+        lastMessageId: null,
+        bitrate: null,
+        userLimit: null,
+        rateLimitPerUser: null,
+        recipients: [],
+        icon: null,
+        ownerId: null,
+        applicationId: null,
+        lastPinTimestamp: null,
+        rtcRegion: null,
+        videoQualityMode: null,
+        messageCount: null,
+        memberCount: null,
+        defaultAutoArchiveDuration: null,
+        permissions: [],
+        flags: null,
+        totalMessageSent: null,
+        available: null,
+        appliedTags: [],
+        defaultReactions: null,
+        defaultSortOrder: null,
+        defaultForumLayout: null,
+        threads: ThreadsManager(null, null, ctx: ctx),
+      ),
+    );
+
+Server _buildServer(EntityContext ctx) {
+  final id = Snowflake.parse(_serverId);
+  return Server(
+    ctx: ctx,
+    id: id,
+    name: 'Test Server',
+    ownerId: Snowflake.parse('000000000000000001'),
+    description: null,
+    applicationId: null,
+    members: MemberManager(id, ctx: ctx),
+    settings: ServerSettings(
+      bitfieldPermission: null,
+      afkTimeout: null,
+      hasWidgetEnabled: false,
+      verificationLevel: VerificationLevel.none,
+      defaultMessageNotifications: DefaultMessageNotification.allMessages,
+      explicitContentFilter: ExplicitContentFilter.disabled,
+      features: [],
+      mfaLevel: MfaLevel.none,
+      systemChannelFlags: [],
+      vanityUrlCode: null,
+      subscription: ServerSubscription(
+        tier: PremiumTier.none,
+        subscriptionCount: null,
+        hasEnabledProgressBar: false,
+      ),
+      preferredLocale: 'en-US',
+      maxVideoChannelUsers: null,
+      nsfwLevel: NsfwLevel.none,
+      rulesManager: RulesManager(id, ctx: ctx),
+    ),
+    roles: RoleManager(id, ctx: ctx),
+    channels: ChannelManager(
+      id,
+      ctx: ctx,
+      afkChannelId: null,
+      systemChannelId: null,
+      rulesChannelId: null,
+      publicUpdatesChannelId: null,
+      safetyAlertsChannelId: null,
+    ),
+    threads: ThreadsManager(id, null, ctx: ctx),
+    assets: ServerAsset(
+      id,
+      ctx: ctx,
+      emojis: EmojiManager(id, ctx: ctx),
+      stickers: StickerManager(id, ctx: ctx),
+      icon: null,
+      splash: null,
+      banner: null,
+      discoverySplash: null,
+    ),
+  );
+}
+
+// ── Shard message factories ───────────────────────────────────────────────────
+
+ShardMessage<dynamic> _serverShardMessage(Map<String, dynamic> emojiPayload) =>
+    ShardMessage(
+      type: 'MESSAGE_REACTION_REMOVE_EMOJI',
+      opCode: OpCode.dispatch,
+      sequence: 1,
+      payload: {
+        'channel_id': _channelId,
+        'guild_id': _serverId,
+        'message_id': _messageId,
+        'emoji': emojiPayload,
+      },
+    );
+
+ShardMessage<dynamic> _privateShardMessage(
+        Map<String, dynamic> emojiPayload) =>
+    ShardMessage(
+      type: 'MESSAGE_REACTION_REMOVE_EMOJI',
+      opCode: OpCode.dispatch,
+      sequence: 1,
+      payload: {
+        'channel_id': _channelId,
+        // no guild_id → private / DM
+        'message_id': _messageId,
+        'emoji': emojiPayload,
+      },
+    );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('MessageReactionRemoveEmojiPacket', () {
+    // ── packetType identity ─────────────────────────────────────────────────
+
+    test('packetType is messageReactionRemoveEmoji', () {
+      // Construct the packet with a do-nothing dataStore; we only check identity.
+      final ds = _FakeDataStore(
+        channelPart: _FakeChannelPart(
+            _buildPrivateChannel(_buildCtx(_FakeDataStore(
+          channelPart: _FakeChannelPart(PrivateChannel(ChannelProperties(
+            ctx: EntityContext(
+              datastore: _FakeDataStore(
+                channelPart: _FakeChannelPart(PrivateChannel(
+                    ChannelProperties(
+                        ctx: EntityContext(
+                          datastore: _NoopDs(),
+                          wss: FakeWebsocketOrchestrator(),
+                          logger: FakeLogger(),
+                          runtimeState: RuntimeState(),
+                        ),
+                        id: Snowflake.parse(_channelId),
+                        type: ChannelType.dm,
+                        name: null,
+                        description: null,
+                        serverId: null,
+                        categoryId: null,
+                        position: null,
+                        nsfw: false,
+                        lastMessageId: null,
+                        bitrate: null,
+                        userLimit: null,
+                        rateLimitPerUser: null,
+                        recipients: [],
+                        icon: null,
+                        ownerId: null,
+                        applicationId: null,
+                        lastPinTimestamp: null,
+                        rtcRegion: null,
+                        videoQualityMode: null,
+                        messageCount: null,
+                        memberCount: null,
+                        defaultAutoArchiveDuration: null,
+                        permissions: [],
+                        flags: null,
+                        totalMessageSent: null,
+                        available: null,
+                        appliedTags: [],
+                        defaultReactions: null,
+                        defaultSortOrder: null,
+                        defaultForumLayout: null,
+                        threads: ThreadsManager(null, null,
+                            ctx: EntityContext(
+                              datastore: _NoopDs(),
+                              wss: FakeWebsocketOrchestrator(),
+                              logger: FakeLogger(),
+                              runtimeState: RuntimeState(),
+                            ))))),
+                serverPart: _NoopServerPart(),
+                messagePart: _NoopMessagePart(),
+              ),
+              wss: FakeWebsocketOrchestrator(),
+              logger: FakeLogger(),
+              runtimeState: RuntimeState(),
+            ),
+            id: Snowflake.parse(_channelId),
+            type: ChannelType.dm,
+            name: null,
+            description: null,
+            serverId: null,
+            categoryId: null,
+            position: null,
+            nsfw: false,
+            lastMessageId: null,
+            bitrate: null,
+            userLimit: null,
+            rateLimitPerUser: null,
+            recipients: [],
+            icon: null,
+            ownerId: null,
+            applicationId: null,
+            lastPinTimestamp: null,
+            rtcRegion: null,
+            videoQualityMode: null,
+            messageCount: null,
+            memberCount: null,
+            defaultAutoArchiveDuration: null,
+            permissions: [],
+            flags: null,
+            totalMessageSent: null,
+            available: null,
+            appliedTags: [],
+            defaultReactions: null,
+            defaultSortOrder: null,
+            defaultForumLayout: null,
+            threads: ThreadsManager(null, null,
+                ctx: EntityContext(
+                  datastore: _NoopDs(),
+                  wss: FakeWebsocketOrchestrator(),
+                  logger: FakeLogger(),
+                  runtimeState: RuntimeState(),
+                )),
+          ))),
+          serverPart: _NoopServerPart(),
+          messagePart: _NoopMessagePart(),
+        )))),
+        serverPart: _NoopServerPart(),
+        messagePart: _NoopMessagePart(),
+      );
+      final packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
+
+      expect(packet.packetType,
+          equals(PacketType.messageReactionRemoveEmoji));
+      expect(packet.packetType.name,
+          equals('MESSAGE_REACTION_REMOVE_EMOJI'));
+    });
+
+    // ── server branch ───────────────────────────────────────────────────────
+
+    group('server branch (guild_id present)', () {
+      late MessageReactionRemoveEmojiPacket packet;
+
+      setUp(() {
+        // Use a deferred dataStore so that the EntityContext used to build
+        // domain objects can reference the same dataStore that the packet uses.
+        late _FakeDataStore ds;
+
+        final ctx = EntityContext(
+          datastore: _DeferredDataStore(() => ds),
+          wss: FakeWebsocketOrchestrator(),
+          logger: FakeLogger(),
+          runtimeState: RuntimeState(),
+        );
+
+        final message = _buildMessage(ctx);
+        final channel = _buildServerTextChannel(ctx);
+        final server = _buildServer(ctx);
+
+        ds = _FakeDataStore(
+          channelPart: _FakeChannelPart(channel),
+          serverPart: _FakeServerPart(server),
+          messagePart: _FakeMessagePart(message),
+        );
+
+        packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
+      });
+
+      test('dispatches Event.serverMessageReactionRemoveEmoji', () async {
+        Event? capturedEvent;
+        Object? capturedPayload;
+
+        void dispatch<T extends Object>(
+            {required Event event,
+            required T payload,
+            bool Function(String?)? constraint}) {
+          capturedEvent = event;
+          capturedPayload = payload;
+        }
+
+        await packet.listen(
+            _serverShardMessage({'id': null, 'name': '👍', 'animated': false}),
+            dispatch);
+
+        expect(capturedEvent,
+            equals(Event.serverMessageReactionRemoveEmoji));
+        expect(capturedPayload,
+            isA<ServerMessageReactionRemoveEmojiArgs>());
+      });
+
+      test('payload carries correct unicode emoji', () async {
+        ServerMessageReactionRemoveEmojiArgs? args;
+
+        void dispatch<T extends Object>(
+            {required Event event,
+            required T payload,
+            bool Function(String?)? constraint}) {
+          if (event == Event.serverMessageReactionRemoveEmoji) {
+            args = payload as ServerMessageReactionRemoveEmojiArgs;
+          }
+        }
+
+        await packet.listen(
+            _serverShardMessage({'id': null, 'name': '👍', 'animated': false}),
+            dispatch);
+
+        expect(args, isNotNull);
+        expect(args!.emoji, isA<PartialEmoji>());
+        expect(args!.emoji.name, equals('👍'));
+        expect(args!.emoji.id, isNull);
+        expect(args!.emoji.animated, isFalse);
+      });
+
+      test('payload carries correct custom animated emoji', () async {
+        ServerMessageReactionRemoveEmojiArgs? args;
+
+        void dispatch<T extends Object>(
+            {required Event event,
+            required T payload,
+            bool Function(String?)? constraint}) {
+          if (event == Event.serverMessageReactionRemoveEmoji) {
+            args = payload as ServerMessageReactionRemoveEmojiArgs;
+          }
+        }
+
+        await packet.listen(
+            _serverShardMessage({
+              'id': '999888777666555444',
+              'name': 'cool',
+              'animated': true,
+            }),
+            dispatch);
+
+        expect(args, isNotNull);
+        expect(args!.emoji.name, equals('cool'));
+        expect(args!.emoji.id,
+            equals(Snowflake.parse('999888777666555444')));
+        expect(args!.emoji.animated, isTrue);
+      });
+    });
+
+    // ── private branch ──────────────────────────────────────────────────────
+
+    group('private branch (no guild_id)', () {
+      late MessageReactionRemoveEmojiPacket packet;
+
+      setUp(() {
+        late _FakeDataStore ds;
+
+        final ctx = EntityContext(
+          datastore: _DeferredDataStore(() => ds),
+          wss: FakeWebsocketOrchestrator(),
+          logger: FakeLogger(),
+          runtimeState: RuntimeState(),
+        );
+
+        final message = _buildMessage(ctx);
+        final channel = _buildPrivateChannel(ctx);
+
+        ds = _FakeDataStore(
+          channelPart: _FakeChannelPart(channel),
+          serverPart: _NoopServerPart(),
+          messagePart: _FakeMessagePart(message),
+        );
+
+        packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
+      });
+
+      test('dispatches Event.privateMessageReactionRemoveEmoji', () async {
+        Event? capturedEvent;
+        Object? capturedPayload;
+
+        void dispatch<T extends Object>(
+            {required Event event,
+            required T payload,
+            bool Function(String?)? constraint}) {
+          capturedEvent = event;
+          capturedPayload = payload;
+        }
+
+        await packet.listen(
+            _privateShardMessage(
+                {'id': null, 'name': '🔥', 'animated': false}),
+            dispatch);
+
+        expect(capturedEvent,
+            equals(Event.privateMessageReactionRemoveEmoji));
+        expect(capturedPayload,
+            isA<PrivateMessageReactionRemoveEmojiArgs>());
+      });
+
+      test('payload carries correct unicode emoji', () async {
+        PrivateMessageReactionRemoveEmojiArgs? args;
+
+        void dispatch<T extends Object>(
+            {required Event event,
+            required T payload,
+            bool Function(String?)? constraint}) {
+          if (event == Event.privateMessageReactionRemoveEmoji) {
+            args = payload as PrivateMessageReactionRemoveEmojiArgs;
+          }
+        }
+
+        await packet.listen(
+            _privateShardMessage(
+                {'id': null, 'name': '🔥', 'animated': false}),
+            dispatch);
+
+        expect(args, isNotNull);
+        expect(args!.emoji, isA<PartialEmoji>());
+        expect(args!.emoji.name, equals('🔥'));
+        expect(args!.emoji.id, isNull);
+        expect(args!.emoji.animated, isFalse);
+      });
+    });
+  });
+}
+
+// ── No-op stubs used in packetType identity test ──────────────────────────────
+
+final class _NoopDs implements DataStoreContract {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+
+  @override
+  ChannelPartContract get channel => throw UnimplementedError();
+  @override
+  ServerPartContract get server => throw UnimplementedError();
+  @override
+  MessagePartContract get message => throw UnimplementedError();
+  @override
+  MemberPartContract get member => throw UnimplementedError();
+  @override
+  UserPartContract get user => throw UnimplementedError();
+  @override
+  RolePartContract get role => throw UnimplementedError();
+  @override
+  InteractionPartContract get interaction => throw UnimplementedError();
+  @override
+  StickerPartContract get sticker => throw UnimplementedError();
+  @override
+  EmojiPartContract get emoji => throw UnimplementedError();
+  @override
+  RulesPartContract get rules => throw UnimplementedError();
+  @override
+  ReactionPartContract get reaction => throw UnimplementedError();
+  @override
+  ThreadPart get thread => throw UnimplementedError();
+  @override
+  InvitePartContract get invite => throw UnimplementedError();
+  @override
+  WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  RequestBucket get requestBucket => throw UnimplementedError();
+  @override
+  HttpClientContract get client => throw UnimplementedError();
+}


### PR DESCRIPTION
## Summary
Adds the Discord `MESSAGE_REACTION_REMOVE_EMOJI` gateway event (all reactions for a single emoji removed from a message), with server and private variants.

- New `MessageReactionRemoveEmojiPacket` listener (mirrors `MessageReactionRemoveAllPacket`, parses the removed `PartialEmoji`)
- `PacketType.messageReactionRemoveEmoji`; `Event.serverMessageReactionRemoveEmoji` / `privateMessageReactionRemoveEmoji` + contracts + bucket methods

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New listener tests pass (6/6): packetType, server dispatch (unicode + custom/animated emoji), private dispatch

Closes #378