### PR TITLE
feat: implement guild integration gateway events

### DIFF
--- a/packages/core/lib/api.dart
+++ b/packages/core/lib/api.dart
@@ -109,6 +109,7 @@ export 'package:mineral/src/api/server/enums/application_command_permission_type
 export 'package:mineral/src/api/server/enums/default_message_notification.dart';
 export 'package:mineral/src/api/server/enums/explicit_content_filter.dart';
 export 'package:mineral/src/api/server/enums/forum_layout_types.dart';
+export 'package:mineral/src/api/server/enums/integration_expire_behavior.dart';
 export 'package:mineral/src/api/server/enums/member_flag.dart';
 export 'package:mineral/src/api/server/enums/mfa_level.dart';
 export 'package:mineral/src/api/server/enums/nsfw_level.dart';
@@ -117,6 +118,7 @@ export 'package:mineral/src/api/server/enums/system_channel_flag.dart';
 export 'package:mineral/src/api/server/enums/verification_level.dart';
 export 'package:mineral/src/api/server/guild_application_command_permissions.dart';
 export 'package:mineral/src/api/server/guild_scheduled_event.dart';
+export 'package:mineral/src/api/server/integration.dart';
 export 'package:mineral/src/api/server/invite.dart';
 export 'package:mineral/src/api/server/managers/channel_manager.dart';
 export 'package:mineral/src/api/server/managers/emoji_manager.dart';

--- a/packages/core/lib/src/api/server/enums/integration_expire_behavior.dart
+++ b/packages/core/lib/src/api/server/enums/integration_expire_behavior.dart
@@ -1,0 +1,11 @@
+import 'package:mineral/src/api/common/types/enhanced_enum.dart';
+
+enum IntegrationExpireBehavior implements EnhancedEnum<int> {
+  removeRole(0),
+  kick(1);
+
+  @override
+  final int value;
+
+  const IntegrationExpireBehavior(this.value);
+}

--- a/packages/core/lib/src/api/server/integration.dart
+++ b/packages/core/lib/src/api/server/integration.dart
@@ -1,0 +1,143 @@
+import 'package:mineral/src/api/common/snowflake.dart';
+import 'package:mineral/src/api/server/enums/integration_expire_behavior.dart';
+
+/// Minimal account info bundled with every Integration.
+final class IntegrationAccount {
+  /// The account id (string — not a snowflake on Discord's side).
+  final String id;
+
+  /// The account name.
+  final String name;
+
+  const IntegrationAccount({required this.id, required this.name});
+
+  factory IntegrationAccount.fromJson(Map<String, dynamic> json) {
+    return IntegrationAccount(
+      id: json['id'] as String,
+      name: json['name'] as String,
+    );
+  }
+}
+
+/// Minimal application info optionally bundled with an Integration.
+final class IntegrationApplication {
+  /// The application id.
+  final Snowflake id;
+
+  /// The application name.
+  final String name;
+
+  /// Optional icon hash.
+  final String? icon;
+
+  /// The application description.
+  final String description;
+
+  const IntegrationApplication({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.icon,
+  });
+
+  factory IntegrationApplication.fromJson(Map<String, dynamic> json) {
+    return IntegrationApplication(
+      id: Snowflake.parse(json['id']),
+      name: json['name'] as String,
+      icon: json['icon'] as String?,
+      description: json['description'] as String,
+    );
+  }
+}
+
+/// A Discord guild integration (Twitch, YouTube, Discord, guild_subscription…).
+final class Integration {
+  final Snowflake id;
+  final String name;
+
+  /// Type string: `twitch`, `youtube`, `discord`, or `guild_subscription`.
+  final String type;
+
+  final bool enabled;
+  final bool? syncing;
+  final Snowflake? roleId;
+  final bool? enableEmoticons;
+  final IntegrationExpireBehavior? expireBehavior;
+  final int? expireGracePeriod;
+
+  /// The id of the user associated with the integration (if any).
+  final Snowflake? userId;
+
+  final IntegrationAccount account;
+  final DateTime? syncedAt;
+  final int? subscriberCount;
+  final bool? revoked;
+  final IntegrationApplication? application;
+  final List<String>? scopes;
+
+  const Integration({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.enabled,
+    required this.account,
+    this.syncing,
+    this.roleId,
+    this.enableEmoticons,
+    this.expireBehavior,
+    this.expireGracePeriod,
+    this.userId,
+    this.syncedAt,
+    this.subscriberCount,
+    this.revoked,
+    this.application,
+    this.scopes,
+  });
+
+  factory Integration.fromJson(Map<String, dynamic> json) {
+    final expireBehaviorRaw = json['expire_behavior'] as int?;
+    final expireBehavior = expireBehaviorRaw == null
+        ? null
+        : IntegrationExpireBehavior.values.firstWhere(
+            (e) => e.value == expireBehaviorRaw,
+            orElse: () => throw ArgumentError(
+                'Unknown IntegrationExpireBehavior value: $expireBehaviorRaw'),
+          );
+
+    final userRaw = json['user'] as Map<String, dynamic>?;
+    final userId =
+        userRaw != null ? Snowflake.nullable(userRaw['id']) : null;
+
+    final applicationRaw = json['application'] as Map<String, dynamic>?;
+    final application = applicationRaw != null
+        ? IntegrationApplication.fromJson(applicationRaw)
+        : null;
+
+    final syncedAtRaw = json['synced_at'] as String?;
+    final syncedAt =
+        syncedAtRaw != null ? DateTime.parse(syncedAtRaw) : null;
+
+    final rawScopes = json['scopes'] as List<dynamic>?;
+    final scopes = rawScopes?.cast<String>();
+
+    return Integration(
+      id: Snowflake.parse(json['id']),
+      name: json['name'] as String,
+      type: json['type'] as String,
+      enabled: json['enabled'] as bool,
+      syncing: json['syncing'] as bool?,
+      roleId: Snowflake.nullable(json['role_id']),
+      enableEmoticons: json['enable_emoticons'] as bool?,
+      expireBehavior: expireBehavior,
+      expireGracePeriod: json['expire_grace_period'] as int?,
+      userId: userId,
+      account: IntegrationAccount.fromJson(
+          Map<String, dynamic>.from(json['account'] as Map)),
+      syncedAt: syncedAt,
+      subscriberCount: json['subscriber_count'] as int?,
+      revoked: json['revoked'] as bool?,
+      application: application,
+      scopes: scopes,
+    );
+  }
+}

--- a/packages/core/lib/src/domains/events/buckets/server_bucket.dart
+++ b/packages/core/lib/src/domains/events/buckets/server_bucket.dart
@@ -290,6 +290,31 @@ final class ServerBucket {
       _events.make(Event.serverRuleExecution,
           (ServerRuleExecutionArgs p) => handle(p.execution));
 
+  void integrationsUpdate(FutureOr<void> Function(Server server) handle) =>
+      _events.make(Event.serverIntegrationsUpdate,
+          (ServerIntegrationsUpdateArgs p) => handle(p.server));
+
+  void integrationCreate(
+          FutureOr<void> Function(Server server, Integration integration)
+              handle) =>
+      _events.make(Event.serverIntegrationCreate,
+          (ServerIntegrationCreateArgs p) => handle(p.server, p.integration));
+
+  void integrationUpdate(
+          FutureOr<void> Function(Server server, Integration integration)
+              handle) =>
+      _events.make(Event.serverIntegrationUpdate,
+          (ServerIntegrationUpdateArgs p) => handle(p.server, p.integration));
+
+  void integrationDelete(
+          FutureOr<void> Function(Server server, Snowflake integrationId,
+                  Snowflake? applicationId)
+              handle) =>
+      _events.make(
+          Event.serverIntegrationDelete,
+          (ServerIntegrationDeleteArgs p) =>
+              handle(p.server, p.integrationId, p.applicationId));
+
   void applicationCommandPermissionsUpdate(
           FutureOr<void> Function(Server server,
                   GuildApplicationCommandPermissions permissions)

--- a/packages/core/lib/src/domains/events/contracts/server_events.dart
+++ b/packages/core/lib/src/domains/events/contracts/server_events.dart
@@ -691,6 +691,63 @@ abstract class ServerApplicationCommandPermissionsUpdateEvent
       Server server, GuildApplicationCommandPermissions permissions);
 }
 
+typedef ServerIntegrationsUpdateArgs = ({Server server});
+
+abstract class ServerIntegrationsUpdateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverIntegrationsUpdate;
+
+  @override
+  Function get handler =>
+      (ServerIntegrationsUpdateArgs p) => handle(p.server);
+
+  FutureOr<void> handle(Server server);
+}
+
+typedef ServerIntegrationCreateArgs = ({Server server, Integration integration});
+
+abstract class ServerIntegrationCreateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverIntegrationCreate;
+
+  @override
+  Function get handler =>
+      (ServerIntegrationCreateArgs p) => handle(p.server, p.integration);
+
+  FutureOr<void> handle(Server server, Integration integration);
+}
+
+typedef ServerIntegrationUpdateArgs = ({Server server, Integration integration});
+
+abstract class ServerIntegrationUpdateEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverIntegrationUpdate;
+
+  @override
+  Function get handler =>
+      (ServerIntegrationUpdateArgs p) => handle(p.server, p.integration);
+
+  FutureOr<void> handle(Server server, Integration integration);
+}
+
+typedef ServerIntegrationDeleteArgs = ({
+  Server server,
+  Snowflake integrationId,
+  Snowflake? applicationId
+});
+
+abstract class ServerIntegrationDeleteEvent extends BaseListenableEvent {
+  @override
+  Event get event => Event.serverIntegrationDelete;
+
+  @override
+  Function get handler => (ServerIntegrationDeleteArgs p) =>
+      handle(p.server, p.integrationId, p.applicationId);
+
+  FutureOr<void> handle(
+      Server server, Snowflake integrationId, Snowflake? applicationId);
+}
+
 typedef ServerVoiceChannelEffectSendArgs = ({
   Server server,
   ServerChannel channel,

--- a/packages/core/lib/src/domains/events/event.dart
+++ b/packages/core/lib/src/domains/events/event.dart
@@ -313,6 +313,22 @@ enum Event implements EnhancedEnum<Type>, EventType {
         ['Server', 'server'],
         ['GuildApplicationCommandPermissions', 'permissions']
       ]),
+  serverIntegrationsUpdate(ServerIntegrationsUpdateEvent, [
+    ['Server', 'server']
+  ]),
+  serverIntegrationCreate(ServerIntegrationCreateEvent, [
+    ['Server', 'server'],
+    ['Integration', 'integration']
+  ]),
+  serverIntegrationUpdate(ServerIntegrationUpdateEvent, [
+    ['Server', 'server'],
+    ['Integration', 'integration']
+  ]),
+  serverIntegrationDelete(ServerIntegrationDeleteEvent, [
+    ['Server', 'server'],
+    ['Snowflake', 'integrationId'],
+    ['Snowflake?', 'applicationId']
+  ]),
   serverVoiceChannelEffectSend(ServerVoiceChannelEffectSendEvent, [
     ['Server', 'server'],
     ['ServerChannel', 'channel'],

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart
@@ -1,0 +1,26 @@
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class GuildIntegrationsUpdatePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.guildIntegrationsUpdate;
+
+  final DataStoreContract _dataStore;
+
+  GuildIntegrationsUpdatePacket({required DataStoreContract dataStore})
+      : _dataStore = dataStore;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final server = await _dataStore.server
+        .get(message.payload['guild_id'] as Object, false);
+
+    dispatch<ServerIntegrationsUpdateArgs>(
+      event: Event.serverIntegrationsUpdate,
+      payload: (server: server),
+    );
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_create_packet.dart
@@ -1,0 +1,30 @@
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/api/server/integration.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class IntegrationCreatePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.integrationCreate;
+
+  final DataStoreContract _dataStore;
+
+  IntegrationCreatePacket({required DataStoreContract dataStore})
+      : _dataStore = dataStore;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final server = await _dataStore.server
+        .get(message.payload['guild_id'] as Object, false);
+
+    final integration = Integration.fromJson(
+        Map<String, dynamic>.from(message.payload as Map));
+
+    dispatch<ServerIntegrationCreateArgs>(
+      event: Event.serverIntegrationCreate,
+      payload: (server: server, integration: integration),
+    );
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_delete_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_delete_packet.dart
@@ -1,0 +1,34 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class IntegrationDeletePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.integrationDelete;
+
+  final DataStoreContract _dataStore;
+
+  IntegrationDeletePacket({required DataStoreContract dataStore})
+      : _dataStore = dataStore;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final server = await _dataStore.server
+        .get(message.payload['guild_id'] as Object, false);
+
+    final integrationId = Snowflake.parse(message.payload['id']);
+    final applicationId = Snowflake.nullable(message.payload['application_id']);
+
+    dispatch<ServerIntegrationDeleteArgs>(
+      event: Event.serverIntegrationDelete,
+      payload: (
+        server: server,
+        integrationId: integrationId,
+        applicationId: applicationId
+      ),
+    );
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_update_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/integration_update_packet.dart
@@ -1,0 +1,30 @@
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/api/server/integration.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+
+final class IntegrationUpdatePacket implements ListenablePacket {
+  @override
+  PacketType get packetType => PacketType.integrationUpdate;
+
+  final DataStoreContract _dataStore;
+
+  IntegrationUpdatePacket({required DataStoreContract dataStore})
+      : _dataStore = dataStore;
+
+  @override
+  Future<void> listen(ShardMessage message, DispatchEvent dispatch) async {
+    final server = await _dataStore.server
+        .get(message.payload['guild_id'] as Object, false);
+
+    final integration = Integration.fromJson(
+        Map<String, dynamic>.from(message.payload as Map));
+
+    dispatch<ServerIntegrationUpdateArgs>(
+      event: Event.serverIntegrationUpdate,
+      payload: (server: server, integration: integration),
+    );
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -19,6 +19,7 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_ban
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_emojis_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_add_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_chunk_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_remove_packet.dart';
@@ -28,6 +29,9 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_rol
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_role_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_stickers_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_create_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_delete_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/interactions/command_interaction_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/interactions/modal_interaction_create_packet.dart';
@@ -169,6 +173,11 @@ final class PacketListener implements PacketListenerContract {
 
     subscribe(
         ApplicationCommandPermissionsUpdatePacket(dataStore: ds));
+
+    subscribe(GuildIntegrationsUpdatePacket(dataStore: ds));
+    subscribe(IntegrationCreatePacket(dataStore: ds));
+    subscribe(IntegrationUpdatePacket(dataStore: ds));
+    subscribe(IntegrationDeletePacket(dataStore: ds));
 
     subscribe(AutomoderationRuleCreatePacket(marshaller: m));
     subscribe(AutoModerationRuleUpdatePacket(marshaller: m));

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_type.dart
@@ -73,7 +73,12 @@ enum PacketType implements PacketTypeContract {
   webhooksUpdate('WEBHOOKS_UPDATE'),
 
   applicationCommandPermissionsUpdate(
-      'APPLICATION_COMMAND_PERMISSIONS_UPDATE');
+      'APPLICATION_COMMAND_PERMISSIONS_UPDATE'),
+
+  guildIntegrationsUpdate('GUILD_INTEGRATIONS_UPDATE'),
+  integrationCreate('INTEGRATION_CREATE'),
+  integrationUpdate('INTEGRATION_UPDATE'),
+  integrationDelete('INTEGRATION_DELETE');
 
   @override
   final String name;

--- a/packages/core/test/packets/integration_packets_test.dart
+++ b/packages/core/test/packets/integration_packets_test.dart
@@ -1,0 +1,563 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/api/server/managers/rules_manager.dart';
+import 'package:mineral/src/api/server/managers/threads_manager.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
+import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_create_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_delete_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_update_packet.dart';
+import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_logger.dart';
+import '../helpers/fake_websocket_orchestrator.dart';
+
+// ── Test IDs ──────────────────────────────────────────────────────────────────
+
+const _serverId = '123456789012345678';
+const _integrationId = '111222333444555666';
+const _applicationId = '999888777666555444';
+const _roleId = '333444555666777888';
+const _userId = '444555666777888999';
+
+// ── Stub DataStore ────────────────────────────────────────────────────────────
+
+final class _FakeDataStore implements DataStoreContract {
+  final ServerPartContract _serverPart;
+
+  _FakeDataStore({required ServerPartContract serverPart})
+      : _serverPart = serverPart;
+
+  @override
+  ServerPartContract get server => _serverPart;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+
+  @override
+  ChannelPartContract get channel => throw UnimplementedError();
+  @override
+  MessagePartContract get message => throw UnimplementedError();
+  @override
+  MemberPartContract get member => throw UnimplementedError();
+  @override
+  UserPartContract get user => throw UnimplementedError();
+  @override
+  RolePartContract get role => throw UnimplementedError();
+  @override
+  InteractionPartContract get interaction => throw UnimplementedError();
+  @override
+  StickerPartContract get sticker => throw UnimplementedError();
+  @override
+  EmojiPartContract get emoji => throw UnimplementedError();
+  @override
+  RulesPartContract get rules => throw UnimplementedError();
+  @override
+  ReactionPartContract get reaction => throw UnimplementedError();
+  @override
+  ThreadPart get thread => throw UnimplementedError();
+  @override
+  InvitePartContract get invite => throw UnimplementedError();
+  @override
+  WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  RequestBucket get requestBucket => throw UnimplementedError();
+  @override
+  HttpClientContract get client => throw UnimplementedError();
+}
+
+// ── Deferred DataStore (for breaking circular dep in EntityContext setup) ─────
+
+final class _DeferredDataStore implements DataStoreContract {
+  final DataStoreContract Function() _resolve;
+
+  _DeferredDataStore(this._resolve);
+
+  @override
+  ServerPartContract get server => _resolve().server;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+
+  @override
+  ChannelPartContract get channel => throw UnimplementedError();
+  @override
+  MessagePartContract get message => throw UnimplementedError();
+  @override
+  MemberPartContract get member => throw UnimplementedError();
+  @override
+  UserPartContract get user => throw UnimplementedError();
+  @override
+  RolePartContract get role => throw UnimplementedError();
+  @override
+  InteractionPartContract get interaction => throw UnimplementedError();
+  @override
+  StickerPartContract get sticker => throw UnimplementedError();
+  @override
+  EmojiPartContract get emoji => throw UnimplementedError();
+  @override
+  RulesPartContract get rules => throw UnimplementedError();
+  @override
+  ReactionPartContract get reaction => throw UnimplementedError();
+  @override
+  ThreadPart get thread => throw UnimplementedError();
+  @override
+  InvitePartContract get invite => throw UnimplementedError();
+  @override
+  WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  RequestBucket get requestBucket => throw UnimplementedError();
+  @override
+  HttpClientContract get client => throw UnimplementedError();
+}
+
+// ── Fake server part ──────────────────────────────────────────────────────────
+
+final class _FakeServerPart implements ServerPartContract {
+  final Server _server;
+
+  _FakeServerPart(this._server);
+
+  @override
+  Future<Server> get(Object id, bool force) async => _server;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+// ── Domain object builder ─────────────────────────────────────────────────────
+
+Server _buildServer(EntityContext ctx) {
+  final id = Snowflake.parse(_serverId);
+  return Server(
+    ctx: ctx,
+    id: id,
+    name: 'Test Server',
+    ownerId: Snowflake.parse('000000000000000001'),
+    description: null,
+    applicationId: null,
+    members: MemberManager(id, ctx: ctx),
+    settings: ServerSettings(
+      bitfieldPermission: null,
+      afkTimeout: null,
+      hasWidgetEnabled: false,
+      verificationLevel: VerificationLevel.none,
+      defaultMessageNotifications: DefaultMessageNotification.allMessages,
+      explicitContentFilter: ExplicitContentFilter.disabled,
+      features: [],
+      mfaLevel: MfaLevel.none,
+      systemChannelFlags: [],
+      vanityUrlCode: null,
+      subscription: ServerSubscription(
+        tier: PremiumTier.none,
+        subscriptionCount: null,
+        hasEnabledProgressBar: false,
+      ),
+      preferredLocale: 'en-US',
+      maxVideoChannelUsers: null,
+      nsfwLevel: NsfwLevel.none,
+      rulesManager: RulesManager(id, ctx: ctx),
+    ),
+    roles: RoleManager(id, ctx: ctx),
+    channels: ChannelManager(
+      id,
+      ctx: ctx,
+      afkChannelId: null,
+      systemChannelId: null,
+      rulesChannelId: null,
+      publicUpdatesChannelId: null,
+      safetyAlertsChannelId: null,
+    ),
+    threads: ThreadsManager(id, null, ctx: ctx),
+    assets: ServerAsset(
+      id,
+      ctx: ctx,
+      emojis: EmojiManager(id, ctx: ctx),
+      stickers: StickerManager(id, ctx: ctx),
+      icon: null,
+      splash: null,
+      banner: null,
+      discoverySplash: null,
+    ),
+  );
+}
+
+// ── Shard message factories ───────────────────────────────────────────────────
+
+ShardMessage<dynamic> _buildGuildIntegrationsUpdateMessage() => ShardMessage(
+      type: 'GUILD_INTEGRATIONS_UPDATE',
+      opCode: OpCode.dispatch,
+      sequence: 1,
+      payload: {'guild_id': _serverId},
+    );
+
+Map<String, dynamic> _integrationPayload({bool withApplicationId = false}) => {
+      'id': _integrationId,
+      'name': 'Test Integration',
+      'type': 'twitch',
+      'enabled': true,
+      'syncing': false,
+      'role_id': _roleId,
+      'enable_emoticons': true,
+      'expire_behavior': 0,
+      'expire_grace_period': 7,
+      'user': {'id': _userId, 'username': 'testuser', 'discriminator': '0000'},
+      'account': {'id': 'acc-123', 'name': 'TwitchAccount'},
+      'synced_at': '2024-01-15T12:00:00.000Z',
+      'subscriber_count': 42,
+      'revoked': false,
+      'application': {
+        'id': _applicationId,
+        'name': 'TestApp',
+        'description': 'A test app',
+      },
+      'scopes': ['bot', 'applications.commands'],
+      'guild_id': _serverId,
+      if (withApplicationId) 'application_id': _applicationId,
+    };
+
+ShardMessage<dynamic> _buildIntegrationCreateMessage() => ShardMessage(
+      type: 'INTEGRATION_CREATE',
+      opCode: OpCode.dispatch,
+      sequence: 2,
+      payload: _integrationPayload(),
+    );
+
+ShardMessage<dynamic> _buildIntegrationUpdateMessage() => ShardMessage(
+      type: 'INTEGRATION_UPDATE',
+      opCode: OpCode.dispatch,
+      sequence: 3,
+      payload: _integrationPayload(),
+    );
+
+ShardMessage<dynamic> _buildIntegrationDeleteMessage(
+        {bool withApplicationId = false}) =>
+    ShardMessage(
+      type: 'INTEGRATION_DELETE',
+      opCode: OpCode.dispatch,
+      sequence: 4,
+      payload: {
+        'id': _integrationId,
+        'guild_id': _serverId,
+        if (withApplicationId) 'application_id': _applicationId,
+      },
+    );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  // ── PacketType identity ──────────────────────────────────────────────────
+
+  group('PacketType identity', () {
+    test('GuildIntegrationsUpdatePacket has correct packetType', () {
+      final packet = GuildIntegrationsUpdatePacket(
+          dataStore: _FakeDataStore(serverPart: _DummyServerPart()));
+      expect(packet.packetType, equals(PacketType.guildIntegrationsUpdate));
+      expect(packet.packetType.name, equals('GUILD_INTEGRATIONS_UPDATE'));
+    });
+
+    test('IntegrationCreatePacket has correct packetType', () {
+      final packet = IntegrationCreatePacket(
+          dataStore: _FakeDataStore(serverPart: _DummyServerPart()));
+      expect(packet.packetType, equals(PacketType.integrationCreate));
+      expect(packet.packetType.name, equals('INTEGRATION_CREATE'));
+    });
+
+    test('IntegrationUpdatePacket has correct packetType', () {
+      final packet = IntegrationUpdatePacket(
+          dataStore: _FakeDataStore(serverPart: _DummyServerPart()));
+      expect(packet.packetType, equals(PacketType.integrationUpdate));
+      expect(packet.packetType.name, equals('INTEGRATION_UPDATE'));
+    });
+
+    test('IntegrationDeletePacket has correct packetType', () {
+      final packet = IntegrationDeletePacket(
+          dataStore: _FakeDataStore(serverPart: _DummyServerPart()));
+      expect(packet.packetType, equals(PacketType.integrationDelete));
+      expect(packet.packetType.name, equals('INTEGRATION_DELETE'));
+    });
+  });
+
+  // ── GUILD_INTEGRATIONS_UPDATE ────────────────────────────────────────────
+
+  group('GuildIntegrationsUpdatePacket', () {
+    late _FakeDataStore ds;
+
+    setUp(() {
+      final ctx = EntityContext(
+        datastore: _DeferredDataStore(() => ds),
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        runtimeState: RuntimeState(),
+      );
+      final server = _buildServer(ctx);
+      ds = _FakeDataStore(serverPart: _FakeServerPart(server));
+    });
+
+    test('dispatches Event.serverIntegrationsUpdate', () async {
+      final packet = GuildIntegrationsUpdatePacket(dataStore: ds);
+      Event? capturedEvent;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+      }
+
+      await packet.listen(_buildGuildIntegrationsUpdateMessage(), dispatch);
+
+      expect(capturedEvent, equals(Event.serverIntegrationsUpdate));
+    });
+
+    test('payload carries the resolved server', () async {
+      final packet = GuildIntegrationsUpdatePacket(dataStore: ds);
+      ServerIntegrationsUpdateArgs? args;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverIntegrationsUpdate) {
+          args = payload as ServerIntegrationsUpdateArgs;
+        }
+      }
+
+      await packet.listen(_buildGuildIntegrationsUpdateMessage(), dispatch);
+
+      expect(args, isNotNull);
+      expect(args!.server.id, equals(Snowflake.parse(_serverId)));
+      expect(args!.server.name, equals('Test Server'));
+    });
+  });
+
+  // ── INTEGRATION_CREATE ───────────────────────────────────────────────────
+
+  group('IntegrationCreatePacket', () {
+    late _FakeDataStore ds;
+
+    setUp(() {
+      final ctx = EntityContext(
+        datastore: _DeferredDataStore(() => ds),
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        runtimeState: RuntimeState(),
+      );
+      final server = _buildServer(ctx);
+      ds = _FakeDataStore(serverPart: _FakeServerPart(server));
+    });
+
+    test('dispatches Event.serverIntegrationCreate', () async {
+      final packet = IntegrationCreatePacket(dataStore: ds);
+      Event? capturedEvent;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+      }
+
+      await packet.listen(_buildIntegrationCreateMessage(), dispatch);
+
+      expect(capturedEvent, equals(Event.serverIntegrationCreate));
+    });
+
+    test('payload carries server and correctly parsed integration', () async {
+      final packet = IntegrationCreatePacket(dataStore: ds);
+      ServerIntegrationCreateArgs? args;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverIntegrationCreate) {
+          args = payload as ServerIntegrationCreateArgs;
+        }
+      }
+
+      await packet.listen(_buildIntegrationCreateMessage(), dispatch);
+
+      expect(args, isNotNull);
+      expect(args!.server.id, equals(Snowflake.parse(_serverId)));
+
+      final i = args!.integration;
+      expect(i.id, equals(Snowflake.parse(_integrationId)));
+      expect(i.name, equals('Test Integration'));
+      expect(i.type, equals('twitch'));
+      expect(i.enabled, isTrue);
+      expect(i.account.id, equals('acc-123'));
+      expect(i.account.name, equals('TwitchAccount'));
+      expect(i.expireBehavior, equals(IntegrationExpireBehavior.removeRole));
+      expect(i.userId, equals(Snowflake.parse(_userId)));
+      expect(i.application?.id, equals(Snowflake.parse(_applicationId)));
+      expect(i.application?.name, equals('TestApp'));
+      expect(i.scopes, containsAll(['bot', 'applications.commands']));
+    });
+  });
+
+  // ── INTEGRATION_UPDATE ───────────────────────────────────────────────────
+
+  group('IntegrationUpdatePacket', () {
+    late _FakeDataStore ds;
+
+    setUp(() {
+      final ctx = EntityContext(
+        datastore: _DeferredDataStore(() => ds),
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        runtimeState: RuntimeState(),
+      );
+      final server = _buildServer(ctx);
+      ds = _FakeDataStore(serverPart: _FakeServerPart(server));
+    });
+
+    test('dispatches Event.serverIntegrationUpdate', () async {
+      final packet = IntegrationUpdatePacket(dataStore: ds);
+      Event? capturedEvent;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+      }
+
+      await packet.listen(_buildIntegrationUpdateMessage(), dispatch);
+
+      expect(capturedEvent, equals(Event.serverIntegrationUpdate));
+    });
+
+    test('payload carries server and correctly parsed integration', () async {
+      final packet = IntegrationUpdatePacket(dataStore: ds);
+      ServerIntegrationUpdateArgs? args;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverIntegrationUpdate) {
+          args = payload as ServerIntegrationUpdateArgs;
+        }
+      }
+
+      await packet.listen(_buildIntegrationUpdateMessage(), dispatch);
+
+      expect(args, isNotNull);
+      expect(args!.server.id, equals(Snowflake.parse(_serverId)));
+
+      final i = args!.integration;
+      expect(i.id, equals(Snowflake.parse(_integrationId)));
+      expect(i.name, equals('Test Integration'));
+      expect(i.type, equals('twitch'));
+      expect(i.enabled, isTrue);
+      expect(i.account.id, equals('acc-123'));
+      expect(i.account.name, equals('TwitchAccount'));
+      expect(i.expireBehavior, equals(IntegrationExpireBehavior.removeRole));
+    });
+  });
+
+  // ── INTEGRATION_DELETE ───────────────────────────────────────────────────
+
+  group('IntegrationDeletePacket', () {
+    late _FakeDataStore ds;
+
+    setUp(() {
+      final ctx = EntityContext(
+        datastore: _DeferredDataStore(() => ds),
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        runtimeState: RuntimeState(),
+      );
+      final server = _buildServer(ctx);
+      ds = _FakeDataStore(serverPart: _FakeServerPart(server));
+    });
+
+    test('dispatches Event.serverIntegrationDelete', () async {
+      final packet = IntegrationDeletePacket(dataStore: ds);
+      Event? capturedEvent;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        capturedEvent = event;
+      }
+
+      await packet.listen(_buildIntegrationDeleteMessage(), dispatch);
+
+      expect(capturedEvent, equals(Event.serverIntegrationDelete));
+    });
+
+    test('payload carries server and integrationId, applicationId is null',
+        () async {
+      final packet = IntegrationDeletePacket(dataStore: ds);
+      ServerIntegrationDeleteArgs? args;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverIntegrationDelete) {
+          args = payload as ServerIntegrationDeleteArgs;
+        }
+      }
+
+      await packet.listen(_buildIntegrationDeleteMessage(), dispatch);
+
+      expect(args, isNotNull);
+      expect(args!.server.id, equals(Snowflake.parse(_serverId)));
+      expect(args!.integrationId, equals(Snowflake.parse(_integrationId)));
+      expect(args!.applicationId, isNull);
+    });
+
+    test('payload carries applicationId when present', () async {
+      final packet = IntegrationDeletePacket(dataStore: ds);
+      ServerIntegrationDeleteArgs? args;
+
+      void dispatch<T extends Object>(
+          {required Event event,
+          required T payload,
+          bool Function(String?)? constraint}) {
+        if (event == Event.serverIntegrationDelete) {
+          args = payload as ServerIntegrationDeleteArgs;
+        }
+      }
+
+      await packet.listen(
+          _buildIntegrationDeleteMessage(withApplicationId: true), dispatch);
+
+      expect(args, isNotNull);
+      expect(args!.integrationId, equals(Snowflake.parse(_integrationId)));
+      expect(args!.applicationId, equals(Snowflake.parse(_applicationId)));
+    });
+  });
+}
+
+// ── Dummy server part (for packetType identity tests that don't dispatch) ─────
+
+final class _DummyServerPart implements ServerPartContract {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+
+  @override
+  Future<Server> get(Object id, bool force) => throw UnimplementedError();
+}


### PR DESCRIPTION
## Summary
Adds guild integration support: the `Integration` entity and the four gateway events.

- New `Integration` entity (+ `IntegrationAccount`, `IntegrationApplication`, `IntegrationExpireBehavior`), factory `fromJson`, exported from `api.dart`
- Events `GUILD_INTEGRATIONS_UPDATE`, `INTEGRATION_CREATE/UPDATE/DELETE` → `serverIntegrationsUpdate` / `serverIntegrationCreate` / `serverIntegrationUpdate` / `serverIntegrationDelete` + contracts + bucket methods
- 4 new listeners registered in `packet_listener.dart`
- `user` exposed as `userId` (Snowflake); `application` as a minimal `IntegrationApplication`

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New listener tests pass (13/13): packetType identities, integrations-update, create/update parsing, delete with nullable applicationId

Closes #382