### PR TITLE
feat: implement slash command option autocomplete

### DIFF
--- a/packages/core/lib/api.dart
+++ b/packages/core/lib/api.dart
@@ -150,6 +150,7 @@ export 'package:mineral/src/domains/commands/command_handler.dart';
 export 'package:mineral/src/domains/commands/command_options.dart';
 export 'package:mineral/src/domains/commands/command_registration.dart';
 export 'package:mineral/src/domains/commands/command_result.dart';
+export 'package:mineral/src/domains/commands/contexts/autocomplete_context.dart';
 export 'package:mineral/src/domains/commands/contexts/global_command_context.dart';
 export 'package:mineral/src/domains/commands/contexts/message_command_context.dart';
 export 'package:mineral/src/domains/commands/contexts/server_command_context.dart';

--- a/packages/core/lib/src/api/common/commands/command_option.dart
+++ b/packages/core/lib/src/api/common/commands/command_option.dart
@@ -1,5 +1,13 @@
+import 'dart:async';
+
+import 'package:mineral/src/api/common/commands/command_choice_option.dart';
 import 'package:mineral/src/api/common/commands/command_option_type.dart';
 import 'package:mineral/src/api/common/types/channel_type.dart';
+import 'package:mineral/src/domains/commands/contexts/autocomplete_context.dart';
+
+/// Handler signature for autocomplete options.
+typedef AutocompleteHandler = FutureOr<List<Choice>> Function(
+    AutocompleteContext ctx);
 
 abstract interface class CommandOption {
   String get name;
@@ -31,8 +39,13 @@ final class Option implements CommandOption {
   @override
   final List<ChannelType>? channelTypes;
 
+  final bool autocomplete;
+
+  final AutocompleteHandler? onAutocomplete;
+
   const Option._(this.name, this.description, this.type, this.channelTypes,
-      this.isRequired);
+      this.isRequired,
+      {this.autocomplete = false, this.onAutocomplete});
 
   @override
   Map<String, dynamic> toJson() {
@@ -42,26 +55,54 @@ final class Option implements CommandOption {
       'type': type.value,
       'required': isRequired,
       'channel_types': channelTypes?.map((e) => e.value).toList(),
+      if (autocomplete) 'autocomplete': true,
     };
   }
 
-  factory Option.string(
-          {required String name,
-          required String description,
-          bool required = false}) =>
-      Option._(name, description, CommandOptionType.string, null, required);
+  factory Option.string({
+    required String name,
+    required String description,
+    bool required = false,
+    bool autocomplete = false,
+    AutocompleteHandler? onAutocomplete,
+  }) {
+    if (autocomplete && onAutocomplete == null) {
+      throw ArgumentError(
+          'Option "$name": onAutocomplete handler is required when autocomplete is true');
+    }
+    return Option._(name, description, CommandOptionType.string, null, required,
+        autocomplete: autocomplete, onAutocomplete: onAutocomplete);
+  }
 
-  factory Option.integer(
-          {required String name,
-          required String description,
-          bool required = false}) =>
-      Option._(name, description, CommandOptionType.integer, null, required);
+  factory Option.integer({
+    required String name,
+    required String description,
+    bool required = false,
+    bool autocomplete = false,
+    AutocompleteHandler? onAutocomplete,
+  }) {
+    if (autocomplete && onAutocomplete == null) {
+      throw ArgumentError(
+          'Option "$name": onAutocomplete handler is required when autocomplete is true');
+    }
+    return Option._(name, description, CommandOptionType.integer, null, required,
+        autocomplete: autocomplete, onAutocomplete: onAutocomplete);
+  }
 
-  factory Option.double(
-          {required String name,
-          required String description,
-          bool required = false}) =>
-      Option._(name, description, CommandOptionType.double, null, required);
+  factory Option.double({
+    required String name,
+    required String description,
+    bool required = false,
+    bool autocomplete = false,
+    AutocompleteHandler? onAutocomplete,
+  }) {
+    if (autocomplete && onAutocomplete == null) {
+      throw ArgumentError(
+          'Option "$name": onAutocomplete handler is required when autocomplete is true');
+    }
+    return Option._(name, description, CommandOptionType.double, null, required,
+        autocomplete: autocomplete, onAutocomplete: onAutocomplete);
+  }
 
   factory Option.boolean(
           {required String name,

--- a/packages/core/lib/src/domains/commands/command_interaction_manager.dart
+++ b/packages/core/lib/src/domains/commands/command_interaction_manager.dart
@@ -7,11 +7,14 @@ import 'package:mineral/src/api/common/commands/builder/command_definition_build
 import 'package:mineral/src/api/common/commands/builder/message_command_builder.dart';
 import 'package:mineral/src/api/common/commands/builder/user_command_builder.dart';
 import 'package:mineral/src/api/common/commands/command_context_type.dart';
+import 'package:mineral/src/api/common/commands/command_option.dart';
+import 'package:mineral/src/api/common/snowflake.dart';
 import 'package:mineral/src/api/server/server.dart';
 import 'package:mineral/src/domains/commands/command_builder.dart';
 import 'package:mineral/src/domains/commands/command_interaction_dispatcher.dart';
 import 'package:mineral/src/domains/commands/command_registration.dart';
 import 'package:mineral/src/domains/commands/command_result.dart';
+import 'package:mineral/src/domains/commands/contexts/autocomplete_context.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/invalid_command_exception.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/missing_property_exception.dart';
@@ -28,6 +31,8 @@ abstract class CommandInteractionManagerContract {
   Future<void> registerServer(Bot bot, Server server);
 
   void addCommand(CommandBuilder command);
+
+  Future<void> handleAutocomplete(Map<String, dynamic> payload);
 }
 
 final class CommandInteractionManager
@@ -47,6 +52,11 @@ final class CommandInteractionManager
   DataStoreContract get _dataStore => _dataStoreRef;
   late final DataStoreContract _dataStoreRef;
 
+  late final MarshallerContract _marshaller;
+
+  /// Registry: root command name → option name → handler.
+  final Map<String, Map<String, AutocompleteHandler>> _autocompleteHandlers = {};
+
   CommandInteractionManager._();
 
   factory CommandInteractionManager({
@@ -55,7 +65,8 @@ final class CommandInteractionManager
     required EntityContext ctx,
   }) {
     final manager = CommandInteractionManager._()
-      .._dataStoreRef = dataStore;
+      .._dataStoreRef = dataStore
+      .._marshaller = marshaller;
     manager.dispatcher = CommandInteractionDispatcher(
       manager,
       marshaller: marshaller,
@@ -109,6 +120,154 @@ final class CommandInteractionManager
 
     commands.add(command);
     commandsHandler.addAll(handlers);
+
+    // Collect autocomplete handlers from option trees.
+    _registerAutocompleteHandlers(name, command);
+  }
+
+  /// Walks the command's option tree and registers any [AutocompleteHandler]s.
+  void _registerAutocompleteHandlers(String rootName, CommandBuilder command) {
+    final declaration = switch (command) {
+      final CommandDeclarationBuilder b => b,
+      final CommandDefinitionBuilder d => d.command,
+      _ => null,
+    };
+
+    if (declaration == null) {
+      return;
+    }
+
+    final handlers = _autocompleteHandlers.putIfAbsent(rootName, () => {});
+
+    // Top-level options.
+    for (final option in declaration.options) {
+      _collectFromOption(option, handlers);
+    }
+
+    // Sub-commands.
+    for (final sub in declaration.subCommands) {
+      for (final option in sub.options) {
+        _collectFromOption(option, handlers);
+      }
+    }
+
+    // Groups → sub-commands.
+    for (final group in declaration.groups) {
+      for (final sub in group.commands) {
+        for (final option in sub.options) {
+          _collectFromOption(option, handlers);
+        }
+      }
+    }
+  }
+
+  void _collectFromOption(
+      CommandOption option, Map<String, AutocompleteHandler> handlers) {
+    if (option is Option &&
+        option.autocomplete &&
+        option.onAutocomplete != null) {
+      handlers[option.name] = option.onAutocomplete!;
+    }
+  }
+
+  @override
+  Future<void> handleAutocomplete(Map<String, dynamic> payload) async {
+    final data = payload['data'] as Map<String, dynamic>?;
+    if (data == null) {
+      _marshaller.logger.warn('Autocomplete payload missing "data" field');
+      return;
+    }
+
+    final rootName = data['name'] as String?;
+    if (rootName == null) {
+      _marshaller.logger.warn('Autocomplete payload missing command name');
+      return;
+    }
+
+    final rawOptions = data['options'];
+    if (rawOptions == null) {
+      _marshaller.logger.warn('Autocomplete payload has no options');
+      return;
+    }
+
+    // Find focused option recursively.
+    final focused = _findFocused(rawOptions as Iterable<dynamic>);
+    if (focused == null) {
+      _marshaller.logger.warn('No focused option found in autocomplete payload');
+      return;
+    }
+
+    final optionName = focused['name'] as String;
+    final optionValue = '${focused['value'] ?? ''}';
+
+    // Collect other options (non-focused).
+    final otherOptions = <String, dynamic>{};
+    _collectNonFocused(rawOptions, otherOptions);
+
+    // Look up handler.
+    final commandHandlers = _autocompleteHandlers[rootName];
+    final handler = commandHandlers?[optionName];
+    if (handler == null) {
+      _marshaller.logger.warn(
+          'No autocomplete handler for command "$rootName" option "$optionName"');
+      return;
+    }
+
+    final ctx = AutocompleteContext(
+      name: optionName,
+      value: optionValue,
+      options: otherOptions,
+    );
+
+    final choices = await handler(ctx);
+    // Discord allows max 25 choices.
+    final capped = choices.length > 25 ? choices.take(25).toList() : choices;
+
+    final id = Snowflake.parse(payload['id'] as String);
+    final token = payload['token'] as String;
+
+    await _dataStore.interaction.sendAutocompleteResult(id, token, capped);
+  }
+
+  /// Recurses into options to find the one with `focused == true`.
+  Map<String, dynamic>? _findFocused(Iterable<dynamic> options) {
+    for (final raw in options) {
+      if (raw is! Map<String, dynamic>) {
+        continue;
+      }
+      if (raw['focused'] == true) {
+        return raw;
+      }
+      // Sub-commands nest their own options list.
+      final nested = raw['options'];
+      if (nested != null) {
+        final result = _findFocused(nested as Iterable<dynamic>);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Collects name→value for all non-focused options at any depth.
+  void _collectNonFocused(
+      Iterable<dynamic> options, Map<String, dynamic> out) {
+    for (final raw in options) {
+      if (raw is! Map<String, dynamic>) {
+        continue;
+      }
+      if (raw['focused'] != true) {
+        final name = raw['name'] as String?;
+        if (name != null && raw.containsKey('value')) {
+          out[name] = raw['value'];
+        }
+      }
+      final nested = raw['options'];
+      if (nested != null) {
+        _collectNonFocused(nested as Iterable<dynamic>, out);
+      }
+    }
   }
 
   @override

--- a/packages/core/lib/src/domains/commands/contexts/autocomplete_context.dart
+++ b/packages/core/lib/src/domains/commands/contexts/autocomplete_context.dart
@@ -1,0 +1,26 @@
+/// Context passed to an autocomplete handler when Discord sends an
+/// INTERACTION_CREATE event with type=4 (APPLICATION_COMMAND_AUTOCOMPLETE).
+///
+/// It exposes the focused option (name + partial value typed by the user)
+/// and the other option values that the user has already filled in.
+final class AutocompleteContext {
+  /// The name of the focused option (the one triggering autocomplete).
+  final String name;
+
+  /// The partial string value that the user has typed so far.
+  ///
+  /// For integer/number options Discord still sends the partial input as a
+  /// string, so this is always [String].
+  final String value;
+
+  /// All other options that the user has filled in, keyed by option name.
+  ///
+  /// The focused option itself is NOT included in this map.
+  final Map<String, dynamic> options;
+
+  const AutocompleteContext({
+    required this.name,
+    required this.value,
+    required this.options,
+  });
+}

--- a/packages/core/lib/src/domains/services/datastore/parts.dart
+++ b/packages/core/lib/src/domains/services/datastore/parts.dart
@@ -68,6 +68,9 @@ abstract interface class InteractionPartContract implements DataStorePart {
   Future<void> waitInteraction(Snowflake id, String token);
 
   Future<void> sendModal(Snowflake id, String token, ModalBuilder modal);
+
+  Future<void> sendAutocompleteResult(
+      Snowflake id, String token, List<Choice> choices);
 }
 
 abstract interface class MemberPartContract implements DataStorePart {

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/interaction_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/interaction_part.dart
@@ -146,4 +146,23 @@ final class InteractionPart extends BasePart
 
     await dataStore.requestBucket.post<Map<String, dynamic>>(req);
   }
+
+  @override
+  Future<void> sendAutocompleteResult(
+    Snowflake id,
+    String token,
+    List<Choice> choices,
+  ) async {
+    final req =
+        Request.json(endpoint: '/interactions/$id/$token/callback', body: {
+      'type': InteractionCallbackType.applicationCommandAutocompleteResult.value,
+      'data': {
+        'choices': choices
+            .map((c) => {'name': c.name, 'value': c.value})
+            .toList(),
+      },
+    });
+
+    await dataStore.requestBucket.post<Map<String, dynamic>>(req);
+  }
 }

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/command_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/command_interaction_create_packet.dart
@@ -22,6 +22,8 @@ final class CommandInteractionCreatePacket implements ListenablePacket {
 
     if (type == InteractionType.applicationCommand) {
       await _commandManager.dispatcher.dispatch(message.payload as Map<String, dynamic>);
+    } else if (type == InteractionType.applicationCommandAutocomplete) {
+      await _commandManager.handleAutocomplete(message.payload as Map<String, dynamic>);
     }
   }
 }

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -1,0 +1,437 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
+import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_logger.dart';
+import '../helpers/fake_marshaller.dart';
+import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/ioc_test_helper.dart';
+
+// ── Fake interaction part that captures sendAutocompleteResult calls ──────────
+
+final class _FakeInteractionPart implements InteractionPartContract {
+  final List<({Snowflake id, String token, List<Choice> choices})> autocompleteResults = [];
+
+  @override
+  Future<void> sendAutocompleteResult(
+      Snowflake id, String token, List<Choice> choices) async {
+    autocompleteResults.add((id: id, token: token, choices: choices));
+  }
+
+  // All other methods are not exercised in these tests.
+  @override
+  Future<void> replyInteraction(
+          Snowflake id, String token, MessageBuilder builder, bool ephemeral) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> editInteraction(
+          Snowflake botId, String token, MessageBuilder builder, bool ephemeral) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> deleteInteraction(Snowflake botId, String token) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> noReplyInteraction(
+          Snowflake id, String token, bool ephemeral) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> createFollowup(Snowflake botId, String token,
+          MessageBuilder builder, bool ephemeral) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> editFollowup(Snowflake botId, String token, Snowflake messageId,
+          MessageBuilder builder, bool ephemeral) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> deleteFollowup(
+          Snowflake botId, String token, Snowflake messageId) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> waitInteraction(Snowflake id, String token) async =>
+      throw UnimplementedError();
+  @override
+  Future<void> sendModal(Snowflake id, String token, ModalBuilder modal) async =>
+      throw UnimplementedError();
+}
+
+// ── Minimal DataStore that routes interaction to the fake part ────────────────
+
+final class _FakeDataStore implements DataStoreContract {
+  final _FakeInteractionPart _interaction;
+
+  _FakeDataStore(this._interaction);
+
+  @override
+  InteractionPartContract get interaction => _interaction;
+
+  @override
+  RequestBucket get requestBucket => throw UnimplementedError();
+  @override
+  HttpClientContract get client => throw UnimplementedError();
+  @override
+  ChannelPartContract get channel => throw UnimplementedError();
+  @override
+  ServerPartContract get server => throw UnimplementedError();
+  @override
+  MemberPartContract get member => throw UnimplementedError();
+  @override
+  UserPartContract get user => throw UnimplementedError();
+  @override
+  RolePartContract get role => throw UnimplementedError();
+  @override
+  MessagePartContract get message => throw UnimplementedError();
+  @override
+  StickerPartContract get sticker => throw UnimplementedError();
+  @override
+  EmojiPartContract get emoji => throw UnimplementedError();
+  @override
+  RulesPartContract get rules => throw UnimplementedError();
+  @override
+  ReactionPartContract get reaction => throw UnimplementedError();
+  @override
+  ThreadPart get thread => throw UnimplementedError();
+  @override
+  InvitePartContract get invite => throw UnimplementedError();
+  @override
+  WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+CommandInteractionManager _buildManager({
+  required _FakeDataStore dataStore,
+  required MarshallerContract marshaller,
+}) {
+  return CommandInteractionManager(
+    dataStore: dataStore,
+    marshaller: marshaller,
+    ctx: EntityContext(
+      datastore: dataStore,
+      wss: FakeWebsocketOrchestrator(),
+      logger: marshaller.logger,
+      runtimeState: RuntimeState(),
+    ),
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void main() {
+  group('CommandInteractionManager.handleAutocomplete', () {
+    late _FakeInteractionPart fakePart;
+    late _FakeDataStore fakeDataStore;
+    late FakeLogger logger;
+    late FakeMarshaller marshaller;
+    late CommandInteractionManager manager;
+    late void Function() restoreIoc;
+
+    setUp(() {
+      fakePart = _FakeInteractionPart();
+      fakeDataStore = _FakeDataStore(fakePart);
+      logger = FakeLogger();
+      marshaller = FakeMarshaller(logger: logger);
+
+      final testIoc = createTestIoc(marshaller: marshaller);
+      restoreIoc = testIoc.restore;
+
+      manager = _buildManager(dataStore: fakeDataStore, marshaller: marshaller);
+    });
+
+    tearDown(() {
+      restoreIoc();
+    });
+
+    // ── Registration tests ──────────────────────────────────────────────────
+
+    group('handler registration via addCommand', () {
+      test('registers autocomplete handler for top-level option', () async {
+        String? capturedValue;
+
+        final command = CommandDeclarationBuilder()
+          ..setName('search')
+          ..setDescription('Search something')
+          ..addOption(Option.string(
+            name: 'query',
+            description: 'The search query',
+            autocomplete: true,
+            onAutocomplete: (ctx) {
+              capturedValue = ctx.value;
+              return [Choice('Result', 'result')];
+            },
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '111111111111111111',
+          'token': 'test-token',
+          'data': {
+            'name': 'search',
+            'options': [
+              {'name': 'query', 'type': 3, 'value': 'hello', 'focused': true},
+            ],
+          },
+        });
+
+        expect(capturedValue, 'hello');
+        expect(fakePart.autocompleteResults, hasLength(1));
+      });
+
+      test('sends choices to correct interaction endpoint', () async {
+        final command = CommandDeclarationBuilder()
+          ..setName('pick')
+          ..setDescription('Pick an item')
+          ..addOption(Option.string(
+            name: 'item',
+            description: 'An item',
+            autocomplete: true,
+            onAutocomplete: (ctx) => [
+              Choice('Alpha', 'alpha'),
+              Choice('Beta', 'beta'),
+            ],
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '222222222222222222',
+          'token': 'my-token',
+          'data': {
+            'name': 'pick',
+            'options': [
+              {'name': 'item', 'type': 3, 'value': 'al', 'focused': true},
+            ],
+          },
+        });
+
+        expect(fakePart.autocompleteResults, hasLength(1));
+        final result = fakePart.autocompleteResults.first;
+        expect(result.token, 'my-token');
+        expect(result.id.value, '222222222222222222');
+        expect(result.choices, hasLength(2));
+        expect(result.choices[0].name, 'Alpha');
+        expect(result.choices[1].name, 'Beta');
+      });
+    });
+
+    // ── Context correctness ─────────────────────────────────────────────────
+
+    group('AutocompleteContext values', () {
+      test('focused name and value are passed correctly', () async {
+        AutocompleteContext? capturedCtx;
+
+        final command = CommandDeclarationBuilder()
+          ..setName('greet')
+          ..setDescription('Greet someone')
+          ..addOption(Option.string(
+            name: 'username',
+            description: 'User to greet',
+            autocomplete: true,
+            onAutocomplete: (ctx) {
+              capturedCtx = ctx;
+              return [];
+            },
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '333333333333333333',
+          'token': 'tok',
+          'data': {
+            'name': 'greet',
+            'options': [
+              {
+                'name': 'username',
+                'type': 3,
+                'value': 'ali',
+                'focused': true,
+              },
+            ],
+          },
+        });
+
+        expect(capturedCtx, isNotNull);
+        expect(capturedCtx!.name, 'username');
+        expect(capturedCtx!.value, 'ali');
+      });
+
+      test('non-focused options are collected into context.options', () async {
+        AutocompleteContext? capturedCtx;
+
+        final command = CommandDeclarationBuilder()
+          ..setName('filter')
+          ..setDescription('Filter results')
+          ..addOption(Option.string(
+            name: 'query',
+            description: 'Search query',
+            autocomplete: true,
+            onAutocomplete: (ctx) {
+              capturedCtx = ctx;
+              return [];
+            },
+          ))
+          ..addOption(Option.integer(
+            name: 'limit',
+            description: 'Max results',
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '444444444444444444',
+          'token': 'tok',
+          'data': {
+            'name': 'filter',
+            'options': [
+              {'name': 'query', 'type': 3, 'value': 'foo', 'focused': true},
+              {'name': 'limit', 'type': 4, 'value': 10},
+            ],
+          },
+        });
+
+        expect(capturedCtx, isNotNull);
+        expect(capturedCtx!.options['limit'], 10);
+        // focused option itself should not be in options map
+        expect(capturedCtx!.options.containsKey('query'), isFalse);
+      });
+    });
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    group('edge cases', () {
+      test('logs warning when no handler registered for command', () async {
+        await manager.handleAutocomplete({
+          'id': '111111111111111111',
+          'token': 'tok',
+          'data': {
+            'name': 'unknown',
+            'options': [
+              {'name': 'q', 'type': 3, 'value': 'x', 'focused': true},
+            ],
+          },
+        });
+
+        expect(fakePart.autocompleteResults, isEmpty);
+        expect(
+            logger.warnings,
+            contains(contains(
+                'No autocomplete handler for command "unknown" option "q"')));
+      });
+
+      test('caps choices at 25', () async {
+        final command = CommandDeclarationBuilder()
+          ..setName('big')
+          ..setDescription('Lots of choices')
+          ..addOption(Option.string(
+            name: 'item',
+            description: 'An item',
+            autocomplete: true,
+            onAutocomplete: (ctx) =>
+                List.generate(30, (i) => Choice('Item $i', 'item_$i')),
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '555555555555555555',
+          'token': 'tok',
+          'data': {
+            'name': 'big',
+            'options': [
+              {'name': 'item', 'type': 3, 'value': '', 'focused': true},
+            ],
+          },
+        });
+
+        expect(fakePart.autocompleteResults, hasLength(1));
+        expect(fakePart.autocompleteResults.first.choices, hasLength(25));
+      });
+
+      test('logs warning when no focused option in payload', () async {
+        final command = CommandDeclarationBuilder()
+          ..setName('nofocus')
+          ..setDescription('No focused option')
+          ..addOption(Option.string(
+            name: 'q',
+            description: 'A query',
+            autocomplete: true,
+            onAutocomplete: (ctx) => [],
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '666666666666666666',
+          'token': 'tok',
+          'data': {
+            'name': 'nofocus',
+            'options': [
+              // No focused: true
+              {'name': 'q', 'type': 3, 'value': 'x'},
+            ],
+          },
+        });
+
+        expect(fakePart.autocompleteResults, isEmpty);
+        expect(
+            logger.warnings,
+            contains(contains('No focused option found')));
+      });
+
+      test('does not break when a non-autocomplete option exists alongside autocomplete one',
+          () async {
+        bool handlerCalled = false;
+
+        final command = CommandDeclarationBuilder()
+          ..setName('mixed')
+          ..setDescription('Mixed options')
+          ..addOption(Option.string(
+            name: 'ac',
+            description: 'Autocomplete option',
+            autocomplete: true,
+            onAutocomplete: (ctx) {
+              handlerCalled = true;
+              return [Choice('X', 'x')];
+            },
+          ))
+          ..addOption(Option.boolean(
+            name: 'flag',
+            description: 'A flag',
+          ))
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '777777777777777777',
+          'token': 'tok',
+          'data': {
+            'name': 'mixed',
+            'options': [
+              {'name': 'ac', 'type': 3, 'value': 'x', 'focused': true},
+              {'name': 'flag', 'type': 5, 'value': true},
+            ],
+          },
+        });
+
+        expect(handlerCalled, isTrue);
+        expect(fakePart.autocompleteResults, hasLength(1));
+      });
+    });
+  });
+}

--- a/packages/core/test/commands/command_autocomplete_option_test.dart
+++ b/packages/core/test/commands/command_autocomplete_option_test.dart
@@ -1,0 +1,189 @@
+import 'package:mineral/src/api/common/commands/command_choice_option.dart';
+import 'package:mineral/src/api/common/commands/command_option.dart';
+import 'package:mineral/src/api/common/commands/command_option_type.dart';
+import 'package:mineral/src/domains/commands/contexts/autocomplete_context.dart';
+import 'package:test/test.dart';
+
+List<Choice> _defaultHandler(AutocompleteContext ctx) =>
+    [Choice('Option A', 'a'), Choice('Option B', 'b')];
+
+void main() {
+  group('Option autocomplete', () {
+    final AutocompleteHandler handler = _defaultHandler;
+
+    group('Option.string with autocomplete', () {
+      test('serializes autocomplete: true in toJson', () {
+        final option = Option.string(
+          name: 'query',
+          description: 'Search query',
+          autocomplete: true,
+          onAutocomplete: handler,
+        );
+
+        final json = option.toJson();
+        expect(json['autocomplete'], isTrue);
+      });
+
+      test('does not emit autocomplete key when false', () {
+        final option = Option.string(name: 'query', description: 'Search query');
+        final json = option.toJson();
+        expect(json.containsKey('autocomplete'), isFalse);
+      });
+
+      test('stores the handler', () {
+        final option = Option.string(
+          name: 'query',
+          description: 'Search query',
+          autocomplete: true,
+          onAutocomplete: handler,
+        );
+
+        expect(option.onAutocomplete, isNotNull);
+        expect(option.autocomplete, isTrue);
+      });
+
+      test('type is still CommandOptionType.string', () {
+        final option = Option.string(
+          name: 'query',
+          description: 'Search query',
+          autocomplete: true,
+          onAutocomplete: handler,
+        );
+
+        expect(option.type, CommandOptionType.string);
+      });
+
+      test('throws when autocomplete=true but no handler provided', () {
+        expect(
+          () => Option.string(
+            name: 'query',
+            description: 'Search query',
+            autocomplete: true,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('Option.integer with autocomplete', () {
+      test('serializes autocomplete: true in toJson', () {
+        final option = Option.integer(
+          name: 'level',
+          description: 'A level',
+          autocomplete: true,
+          onAutocomplete: (ctx) => [],
+        );
+
+        final json = option.toJson();
+        expect(json['autocomplete'], isTrue);
+      });
+
+      test('does not emit autocomplete key when false', () {
+        final option = Option.integer(name: 'level', description: 'A level');
+        expect(option.toJson().containsKey('autocomplete'), isFalse);
+      });
+
+      test('throws when autocomplete=true but no handler provided', () {
+        expect(
+          () => Option.integer(
+            name: 'level',
+            description: 'A level',
+            autocomplete: true,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('Option.double with autocomplete', () {
+      test('serializes autocomplete: true in toJson', () {
+        final option = Option.double(
+          name: 'ratio',
+          description: 'A ratio',
+          autocomplete: true,
+          onAutocomplete: (ctx) => [],
+        );
+
+        final json = option.toJson();
+        expect(json['autocomplete'], isTrue);
+      });
+
+      test('does not emit autocomplete key when false', () {
+        final option = Option.double(name: 'ratio', description: 'A ratio');
+        expect(option.toJson().containsKey('autocomplete'), isFalse);
+      });
+
+      test('throws when autocomplete=true but no handler provided', () {
+        expect(
+          () => Option.double(
+            name: 'ratio',
+            description: 'A ratio',
+            autocomplete: true,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('non-autocomplete options', () {
+      test('Option.boolean does not have autocomplete field', () {
+        final option = Option.boolean(name: 'flag', description: 'A flag');
+        expect(option.toJson().containsKey('autocomplete'), isFalse);
+      });
+
+      test('Option without autocomplete has null onAutocomplete', () {
+        final option = Option.string(name: 'name', description: 'A name');
+        expect(option.onAutocomplete, isNull);
+        expect(option.autocomplete, isFalse);
+      });
+    });
+
+    group('AutocompleteHandler invocation', () {
+      test('handler returns choices', () async {
+        final option = Option.string(
+          name: 'fruit',
+          description: 'Pick a fruit',
+          autocomplete: true,
+          onAutocomplete: (ctx) => [
+            Choice('Apple', 'apple'),
+            Choice('Banana', 'banana'),
+          ],
+        );
+
+        final ctx = AutocompleteContext(
+          name: 'fruit',
+          value: 'app',
+          options: {},
+        );
+
+        final choices = await option.onAutocomplete!(ctx);
+        expect(choices, hasLength(2));
+        expect(choices[0].name, 'Apple');
+        expect(choices[0].value, 'apple');
+      });
+
+      test('handler receives partial value', () async {
+        String? capturedValue;
+
+        final option = Option.string(
+          name: 'query',
+          description: 'Search',
+          autocomplete: true,
+          onAutocomplete: (ctx) {
+            capturedValue = ctx.value;
+            return [];
+          },
+        );
+
+        final ctx = AutocompleteContext(
+          name: 'query',
+          value: 'hell',
+          options: {},
+        );
+
+        await option.onAutocomplete!(ctx);
+        expect(capturedValue, 'hell');
+      });
+    });
+  });
+}

--- a/packages/core/test/helpers/mocks.dart
+++ b/packages/core/test/helpers/mocks.dart
@@ -59,6 +59,9 @@ final class FakeCommandInteractionManager
 
   @override
   void addCommand(CommandBuilder command) {}
+
+  @override
+  Future<void> handleAutocomplete(Map<String, dynamic> payload) async {}
 }
 
 /// A no-op [RunningStrategy] that immediately returns from every hook.


### PR DESCRIPTION
## Summary
Implements slash-command option autocomplete end-to-end.

- `Option.string/integer/double` accept `autocomplete: true` + `onAutocomplete` handler; `toJson` emits `autocomplete: true` (no static choices); declaring autocomplete without a handler throws
- `AutocompleteHandler = FutureOr<List<Choice>> Function(AutocompleteContext ctx)`; new read-only `AutocompleteContext` (focused option `name`, partial `value`, other `options`)
- `command_interaction_create_packet` routes `applicationCommandAutocomplete` → `CommandInteractionManager.handleAutocomplete(...)`, which finds the focused option, invokes the handler (caps at 25 choices) and responds
- New `InteractionPart.sendAutocompleteResult(...)` (callback type 8) on the contract + impl

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New tests pass (23/23): option declaration/serialization/validation + handleAutocomplete routing & response
- [x] No regression: full `test/commands/` suite passes (184/184)

Note: handler registry is keyed by command→option name (last-writer-wins if two subcommands share an option name); documented as a known simplification.

Closes #384