### PR TITLE
feat: implement application emojis

### DIFF
--- a/packages/core/lib/api.dart
+++ b/packages/core/lib/api.dart
@@ -62,6 +62,7 @@ export 'package:mineral/src/api/common/emoji.dart';
 export 'package:mineral/src/api/common/image_asset.dart';
 export 'package:mineral/src/api/common/intent.dart';
 export 'package:mineral/src/api/common/lang.dart';
+export 'package:mineral/src/api/common/managers/application_emoji_manager.dart';
 export 'package:mineral/src/api/common/message.dart';
 export 'package:mineral/src/api/common/message_properties.dart';
 export 'package:mineral/src/api/common/message_reaction.dart';

--- a/packages/core/lib/src/api/common/bot/bot.dart
+++ b/packages/core/lib/src/api/common/bot/bot.dart
@@ -1,8 +1,10 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
 
 final class Bot {
   final WebsocketOrchestratorContract _wss;
+  final EntityContext? _ctx;
 
   final Snowflake id;
   final String? discriminator;
@@ -33,7 +35,23 @@ final class Bot {
     required this.presences,
     required this.guildIds,
     required this.application,
-  }) : _wss = wss;
+    EntityContext? ctx,
+  })  : _wss = wss,
+        _ctx = ctx;
+
+  /// Manager for application-owned emojis (usable across all servers).
+  /// ```dart
+  /// final emojis = await bot.emojis.fetch();
+  /// ```
+  ApplicationEmojiManager get emojis {
+    final ctx = _ctx;
+    if (ctx == null) {
+      throw StateError(
+          'Bot.emojis requires an EntityContext. '
+          'Pass entityContext: to Bot.fromJson().');
+    }
+    return ApplicationEmojiManager(application.id, ctx: ctx);
+  }
 
   /// Updates presence of this
   void setPresence(
@@ -46,11 +64,13 @@ final class Bot {
   factory Bot.fromJson(
     Map<String, dynamic> json, {
     required WebsocketOrchestratorContract wss,
+    EntityContext? entityContext,
   }) {
     final user = json['user'] as Map<String, dynamic>;
     final application = json['application'] as Map<String, dynamic>;
     return Bot._(
         wss: wss,
+        ctx: entityContext,
         id: Snowflake.parse(user['id']),
         discriminator: user['discriminator'] as String?,
         version: json['v'] as int,

--- a/packages/core/lib/src/api/common/managers/application_emoji_manager.dart
+++ b/packages/core/lib/src/api/common/managers/application_emoji_manager.dart
@@ -1,0 +1,48 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
+
+final class ApplicationEmojiManager {
+  final EntityContext _ctx;
+  DataStoreContract get _datastore => _ctx.datastore;
+
+  final Snowflake _applicationId;
+
+  ApplicationEmojiManager(this._applicationId, {required EntityContext ctx})
+      : _ctx = ctx;
+
+  /// Fetch all application-owned emojis.
+  /// ```dart
+  /// final emojis = await bot.emojis.fetch();
+  /// ```
+  Future<Map<Snowflake, Emoji>> fetch() =>
+      _datastore.applicationEmoji.fetch(_applicationId.value);
+
+  /// Get a single application emoji by its id.
+  /// ```dart
+  /// final emoji = await bot.emojis.get('1234567890');
+  /// ```
+  Future<Emoji?> get(String id) =>
+      _datastore.applicationEmoji.get(_applicationId.value, id);
+
+  /// Create a new application emoji.
+  /// ```dart
+  /// final emoji = await bot.emojis.create(name: 'my_emoji', image: Image.fromFile('path/to/file.png'));
+  /// ```
+  Future<Emoji> create({required String name, required Image image}) =>
+      _datastore.applicationEmoji.create(_applicationId.value, name, image);
+
+  /// Update the name of an application emoji.
+  /// ```dart
+  /// await bot.emojis.update('1234567890', name: 'new_name');
+  /// ```
+  Future<Emoji?> update(String id, {required String name}) =>
+      _datastore.applicationEmoji.update(_applicationId.value, id, name);
+
+  /// Delete an application emoji.
+  /// ```dart
+  /// await bot.emojis.delete('1234567890');
+  /// ```
+  Future<void> delete(String id) =>
+      _datastore.applicationEmoji.delete(_applicationId.value, id);
+}

--- a/packages/core/lib/src/domains/services/datastore/datastore.dart
+++ b/packages/core/lib/src/domains/services/datastore/datastore.dart
@@ -37,4 +37,6 @@ abstract class DataStoreContract {
   WebhookPartContract get webhook;
 
   GuildScheduledEventPartContract get scheduledEvent;
+
+  ApplicationEmojiPartContract get applicationEmoji;
 }

--- a/packages/core/lib/src/domains/services/datastore/parts.dart
+++ b/packages/core/lib/src/domains/services/datastore/parts.dart
@@ -406,3 +406,15 @@ abstract interface class InvitePartContract implements DataStorePart {
 
   Future<void> delete(String code, String? reason);
 }
+
+abstract interface class ApplicationEmojiPartContract implements DataStorePart {
+  Future<Map<Snowflake, Emoji>> fetch(Object applicationId);
+
+  Future<Emoji?> get(Object applicationId, Object emojiId);
+
+  Future<Emoji> create(Object applicationId, String name, Image image);
+
+  Future<Emoji?> update(Object applicationId, Object emojiId, String name);
+
+  Future<void> delete(Object applicationId, Object emojiId);
+}

--- a/packages/core/lib/src/infrastructure/internals/datastore/datastore.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/datastore.dart
@@ -1,5 +1,6 @@
 import 'package:mineral/contracts.dart';
 import 'package:mineral/src/domains/services/http/http.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/application_emoji_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/channel_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/emoji_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/guild_scheduled_event_part.dart';
@@ -69,6 +70,9 @@ final class DataStore implements DataStoreContract {
   @override
   late final GuildScheduledEventPart scheduledEvent;
 
+  @override
+  late final ApplicationEmojiPart applicationEmoji;
+
   DataStore({
     required this.client,
     required MarshallerContract marshaller,
@@ -91,5 +95,6 @@ final class DataStore implements DataStoreContract {
     invite = InvitePart(marshaller, this);
     webhook = WebhookPart(marshaller, this);
     scheduledEvent = GuildScheduledEventPart(marshaller, this);
+    applicationEmoji = ApplicationEmojiPart(marshaller, this);
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/application_emoji_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/application_emoji_part.dart
@@ -1,0 +1,103 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/base_part.dart';
+
+final class ApplicationEmojiPart extends BasePart
+    implements ApplicationEmojiPartContract {
+  ApplicationEmojiPart(super.marshaller, super.dataStore);
+
+  /// Builds a normalized payload suitable for [EmojiSerializer.serialize]
+  /// from a raw Discord application-emoji payload (which has no [guild_id]).
+  ///
+  /// We use [applicationId] as the [server_id] so the resulting [Emoji] has a
+  /// non-null [serverId] field, and we skip the cache-write path that
+  /// [EmojiSerializer.normalize] would do (no caching for app emojis).
+  Map<String, dynamic> _normalizePayload(
+      Map<String, dynamic> raw, String applicationId) {
+    return {
+      'id': raw['id'],
+      'name': raw['name'],
+      'managed': raw['managed'] ?? false,
+      'available': raw['available'] ?? true,
+      'animated': raw['animated'] ?? false,
+      'roles': <String>[],
+      'server_id': applicationId,
+    };
+  }
+
+  Future<Emoji> _buildEmoji(
+      Map<String, dynamic> raw, String applicationId) async {
+    final normalized = _normalizePayload(raw, applicationId);
+    return marshaller.serializers.emojis.serialize(normalized);
+  }
+
+  @override
+  Future<Map<Snowflake, Emoji>> fetch(Object applicationId) async {
+    final appId = Snowflake.parse(applicationId);
+    final req =
+        Request.json(endpoint: '/applications/$appId/emojis');
+    final result =
+        await dataStore.requestBucket.get<Map<String, dynamic>>(req);
+
+    // Discord wraps application emojis in { "items": [...] }
+    final items =
+        (result['items'] as List<dynamic>).cast<Map<String, dynamic>>();
+
+    final emojis = await items.map((element) async {
+      return _buildEmoji(element, appId.value);
+    }).wait;
+
+    return emojis.asMap().map((_, value) => MapEntry(value.id!, value));
+  }
+
+  @override
+  Future<Emoji?> get(Object applicationId, Object emojiId) async {
+    final appId = Snowflake.parse(applicationId);
+    final req =
+        Request.json(endpoint: '/applications/$appId/emojis/$emojiId');
+    final result =
+        await dataStore.requestBucket.get<Map<String, dynamic>>(req);
+
+    return _buildEmoji(result, appId.value);
+  }
+
+  @override
+  Future<Emoji> create(
+      Object applicationId, String name, Image image) async {
+    final appId = Snowflake.parse(applicationId);
+    final req = Request.json(
+      endpoint: '/applications/$appId/emojis',
+      body: {
+        'name': name.replaceAll(' ', '_'),
+        'image': image.base64,
+      },
+    );
+    final result =
+        await dataStore.requestBucket.post<Map<String, dynamic>>(req);
+
+    return _buildEmoji(result, appId.value);
+  }
+
+  @override
+  Future<Emoji?> update(
+      Object applicationId, Object emojiId, String name) async {
+    final appId = Snowflake.parse(applicationId);
+    final req = Request.json(
+      endpoint: '/applications/$appId/emojis/$emojiId',
+      body: {'name': name.replaceAll(' ', '_')},
+    );
+    final result =
+        await dataStore.requestBucket.patch<Map<String, dynamic>>(req);
+
+    return _buildEmoji(result, appId.value);
+  }
+
+  @override
+  Future<void> delete(Object applicationId, Object emojiId) async {
+    final appId = Snowflake.parse(applicationId);
+    final req = Request.json(
+        endpoint: '/applications/$appId/emojis/$emojiId');
+    await dataStore.requestBucket.delete<Map<String, dynamic>>(req);
+  }
+}

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/ready_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/ready_packet.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
 import 'package:mineral/src/api/common/bot/bot.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
@@ -19,17 +20,20 @@ final class ReadyPacket implements ListenablePacket {
   final WebsocketOrchestratorContract _wss;
   final RuntimeState _runtimeState;
   final CacheConfig? _cacheConfig;
+  final EntityContext _entityContext;
 
   ReadyPacket({
     required MarshallerContract marshaller,
     required CommandInteractionManagerContract commandManager,
     required WebsocketOrchestratorContract wss,
     required RuntimeState runtimeState,
+    required EntityContext entityContext,
     CacheConfig? cacheConfig,
   })  : _marshaller = marshaller,
         _commandManager = commandManager,
         _wss = wss,
         _runtimeState = runtimeState,
+        _entityContext = entityContext,
         _cacheConfig = cacheConfig;
 
   @override
@@ -38,7 +42,8 @@ final class ReadyPacket implements ListenablePacket {
     // in the shared [RuntimeState] for downstream consumers (GuildCreatePacket,
     // Interaction).
     final bot = _runtimeState.bot ??=
-        Bot.fromJson(message.payload as Map<String, dynamic>, wss: _wss);
+        Bot.fromJson(message.payload as Map<String, dynamic>,
+            wss: _wss, entityContext: _entityContext);
 
     if (!isAlreadyUsed) {
       await _commandManager.registerGlobal(bot);

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -101,6 +101,7 @@ final class PacketListener implements PacketListenerContract {
         commandManager: cm,
         wss: wss,
         runtimeState: runtimeState,
+        entityContext: entityContext,
         cacheConfig: cacheConfig));
     subscribe(MessageCreatePacket(marshaller: m));
     subscribe(MessageUpdatePacket(marshaller: m));

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -102,6 +102,9 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError();
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/packages/core/test/commands/command_interaction_dispatcher_test.dart
+++ b/packages/core/test/commands/command_interaction_dispatcher_test.dart
@@ -103,6 +103,10 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();
+
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError();
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/packages/core/test/datastore/parts/application_emoji_part_test.dart
+++ b/packages/core/test/datastore/parts/application_emoji_part_test.dart
@@ -1,0 +1,220 @@
+import 'dart:io';
+
+import 'package:mineral/api.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/application_emoji_part.dart';
+import 'package:test/test.dart';
+
+import '../../helpers/fake_datastore.dart';
+import '../../helpers/fake_http_client.dart';
+import '../../helpers/fake_marshaller.dart';
+import '../../helpers/fake_response.dart';
+import '../../helpers/ioc_test_helper.dart';
+
+/// A raw Discord application-emoji payload (no guild_id field).
+Map<String, dynamic> _emojiPayload({
+  String id = '111222333444555666',
+  String name = 'thumbsup',
+}) =>
+    {
+      'id': id,
+      'name': name,
+      'managed': false,
+      'available': true,
+      'animated': false,
+      'roles': null,
+    };
+
+/// Creates a minimal [Image] from a 1x1 transparent PNG for tests.
+Image _fakeImage() {
+  // 1x1 transparent PNG bytes (smallest valid PNG)
+  final pngBytes = [
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+    0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+    0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC,
+    0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, // IEND chunk
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+  ];
+  final path =
+      '${Directory.systemTemp.path}/test_emoji_${DateTime.now().microsecondsSinceEpoch}.png';
+  final tmpFile = File(path)..writeAsBytesSync(pngBytes);
+  final image = Image.file(tmpFile);
+  tmpFile.deleteSync();
+  return image;
+}
+
+void main() {
+  const applicationId = '999888777666555444';
+
+  group('ApplicationEmojiPart', () {
+    late FakeHttpClient http;
+    late FakeDataStore dataStore;
+    late ApplicationEmojiPart part;
+    late void Function() restoreIoc;
+
+    /// Creates a fresh [ApplicationEmojiPart] with a given HTTP client,
+    /// registers a new IoC scope, and returns the restore callback.
+    (ApplicationEmojiPart, void Function() restore) buildPart(
+        FakeHttpClient client) {
+      final ds = FakeDataStore(client);
+      final ioc = createTestIoc(dataStore: ds);
+      return (ApplicationEmojiPart(FakeMarshaller(), ds), ioc.restore);
+    }
+
+    setUp(() {
+      http = FakeHttpClient();
+      dataStore = FakeDataStore(http);
+      final iocResult = createTestIoc(dataStore: dataStore);
+      restoreIoc = iocResult.restore;
+      part = ApplicationEmojiPart(FakeMarshaller(), dataStore);
+    });
+
+    tearDown(() => restoreIoc());
+
+    // ── fetch ────────────────────────────────────────────────────────────────
+
+    group('fetch()', () {
+      test('sends GET to /applications/:id/emojis', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, {
+            'items': [_emojiPayload()],
+          }),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        await p.fetch(applicationId);
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('GET'));
+        expect(client.calls.single.path,
+            equals('/applications/$applicationId/emojis'));
+      });
+
+      test('unwraps the items wrapper and returns Emojis', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, {
+            'items': [
+              _emojiPayload(id: '111000111000111000', name: 'wave'),
+              _emojiPayload(id: '222000222000222000', name: 'fire'),
+            ],
+          }),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        final result = await p.fetch(applicationId);
+        restore();
+
+        expect(result, hasLength(2));
+        expect(result.values.map((e) => e.name), containsAll(['wave', 'fire']));
+      });
+
+      test('returns empty map when items is empty', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, {'items': []}),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        final result = await p.fetch(applicationId);
+        restore();
+
+        expect(result, isEmpty);
+      });
+    });
+
+    // ── get ──────────────────────────────────────────────────────────────────
+
+    group('get()', () {
+      test('sends GET to /applications/:id/emojis/:emojiId', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _emojiPayload()),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        await p.get(applicationId, '111222333444555666');
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('GET'));
+        expect(client.calls.single.path,
+            equals('/applications/$applicationId/emojis/111222333444555666'));
+      });
+
+      test('deserializes app-emoji payload WITHOUT guild_id into an Emoji', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200,
+              _emojiPayload(id: '555666777888999000', name: 'cool')),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        final emoji = await p.get(applicationId, '555666777888999000');
+        restore();
+
+        expect(emoji, isA<Emoji>());
+        expect(emoji!.name, equals('cool'));
+        expect(emoji.id, equals(Snowflake.parse('555666777888999000')));
+        // serverId is set to applicationId since app emojis have no guild_id
+        expect(emoji.serverId, equals(Snowflake.parse(applicationId)));
+        expect(emoji.managed, isFalse);
+        expect(emoji.available, isTrue);
+        expect(emoji.animated, isFalse);
+        expect(emoji.roles, isEmpty);
+      });
+    });
+
+    // ── create ───────────────────────────────────────────────────────────────
+
+    group('create()', () {
+      test('sends POST to /applications/:id/emojis', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _emojiPayload()),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        await p.create(applicationId, 'test', _fakeImage());
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('POST'));
+        expect(client.calls.single.path,
+            equals('/applications/$applicationId/emojis'));
+      });
+    });
+
+    // ── update ───────────────────────────────────────────────────────────────
+
+    group('update()', () {
+      test('sends PATCH to /applications/:id/emojis/:emojiId', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200,
+              _emojiPayload(id: '111222333444555666', name: 'new_name')),
+        ]);
+        final (p, restore) = buildPart(client);
+
+        await p.update(applicationId, '111222333444555666', 'new_name');
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('PATCH'));
+        expect(client.calls.single.path,
+            equals('/applications/$applicationId/emojis/111222333444555666'));
+      });
+    });
+
+    // ── delete ───────────────────────────────────────────────────────────────
+
+    group('delete()', () {
+      test('sends DELETE to /applications/:id/emojis/:emojiId', () async {
+        await part.delete(applicationId, '111222333444555666');
+
+        expect(http.calls, hasLength(1));
+        expect(http.calls.single.method, equals('DELETE'));
+        expect(http.calls.single.path,
+            equals('/applications/$applicationId/emojis/111222333444555666'));
+      });
+    });
+  });
+}

--- a/packages/core/test/helpers/fake_datastore.dart
+++ b/packages/core/test/helpers/fake_datastore.dart
@@ -66,4 +66,8 @@ final class FakeDataStore implements DataStoreContract {
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError('scheduledEvent');
+
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError('applicationEmoji');
 }

--- a/packages/core/test/packets/application_command_permissions_update_packet_test.dart
+++ b/packages/core/test/packets/application_command_permissions_update_packet_test.dart
@@ -65,6 +65,9 @@ final class _NoopDs implements DataStoreContract {
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();
   @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError();
+  @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
@@ -107,6 +110,9 @@ final class _DeferredDataStore implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
@@ -157,6 +163,9 @@ final class _FakeDataStore implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();

--- a/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
+++ b/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
@@ -65,6 +65,9 @@ final class _DeferredDataStore implements DataStoreContract {
   GuildScheduledEventPartContract get scheduledEvent =>
       _resolve().scheduledEvent;
   @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      _resolve().applicationEmoji;
+  @override
   RequestBucket get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
@@ -119,6 +122,9 @@ final class _FakeDataStore implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
 }
 
@@ -734,6 +740,9 @@ final class _NoopDs implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();

--- a/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
+++ b/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
@@ -65,6 +65,9 @@ final class _NoopDs implements DataStoreContract {
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();
   @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError();
+  @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
@@ -110,6 +113,9 @@ final class _DeferredDataStore implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
@@ -163,6 +169,9 @@ final class _FakeDataStore implements DataStoreContract {
   InvitePartContract get invite => throw UnimplementedError();
   @override
   WebhookPartContract get webhook => throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();

--- a/packages/core/test/packets/webhooks_update_packet_test.dart
+++ b/packages/core/test/packets/webhooks_update_packet_test.dart
@@ -62,6 +62,9 @@ final class _DeferredDataStore implements DataStoreContract {
   GuildScheduledEventPartContract get scheduledEvent =>
       _resolve().scheduledEvent;
   @override
+  ApplicationEmojiPartContract get applicationEmoji =>
+      _resolve().applicationEmoji;
+  @override
   RequestBucket get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
@@ -113,6 +116,9 @@ final class _FakeDataStore implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
 }
 
@@ -213,6 +219,9 @@ final class _NoopDs implements DataStoreContract {
   WebhookPartContract get webhook => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
+      throw UnimplementedError();
+  @override
+  ApplicationEmojiPartContract get applicationEmoji =>
       throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();


### PR DESCRIPTION
## Summary
Adds application-owned emojis (usable across all servers), exposed as `bot.emojis`.

- New `ApplicationEmojiPart` datastore part hitting `/applications/{app.id}/emojis` (handles the `items` wrapper; fetch/get/create/update/delete)
- New `ApplicationEmojiManager` (`fetch`/`get`/`create`/`update`/`delete`), exported from `api.dart`
- `Bot` now carries an optional `EntityContext` and exposes `emojis`; `ReadyPacket` passes the context through
- Reuses the existing `Emoji` entity; application emojis (no `guild_id`) are built without the guild-scoped serializer path

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New part tests pass (8/8): endpoints/methods, `items` unwrapping, empty list, no-guild_id deserialization
- [x] No regression: full suite passes (1123/1123)

Closes #388