### PR TITLE
feat: implement guild onboarding

### DIFF
--- a/packages/core/lib/api.dart
+++ b/packages/core/lib/api.dart
@@ -137,6 +137,7 @@ export 'package:mineral/src/api/server/member_voice.dart';
 export 'package:mineral/src/api/server/moderation/action.dart';
 export 'package:mineral/src/api/server/moderation/auto_moderation_rule.dart';
 export 'package:mineral/src/api/server/moderation/rule_execution.dart';
+export 'package:mineral/src/api/server/onboarding.dart';
 export 'package:mineral/src/api/server/role.dart';
 export 'package:mineral/src/api/server/server.dart';
 export 'package:mineral/src/api/server/server_assets.dart';

--- a/packages/core/lib/src/api/server/enums/onboarding_mode.dart
+++ b/packages/core/lib/src/api/server/enums/onboarding_mode.dart
@@ -1,0 +1,11 @@
+import 'package:mineral/src/api/common/types/enhanced_enum.dart';
+
+enum OnboardingMode implements EnhancedEnum<int> {
+  default_(0),
+  advanced(1);
+
+  @override
+  final int value;
+
+  const OnboardingMode(this.value);
+}

--- a/packages/core/lib/src/api/server/enums/onboarding_prompt_type.dart
+++ b/packages/core/lib/src/api/server/enums/onboarding_prompt_type.dart
@@ -1,0 +1,11 @@
+import 'package:mineral/src/api/common/types/enhanced_enum.dart';
+
+enum OnboardingPromptType implements EnhancedEnum<int> {
+  multipleChoice(0),
+  dropdown(1);
+
+  @override
+  final int value;
+
+  const OnboardingPromptType(this.value);
+}

--- a/packages/core/lib/src/api/server/onboarding.dart
+++ b/packages/core/lib/src/api/server/onboarding.dart
@@ -1,0 +1,200 @@
+import 'package:mineral/src/api/common/snowflake.dart';
+import 'package:mineral/src/api/server/enums/onboarding_mode.dart';
+import 'package:mineral/src/api/server/enums/onboarding_prompt_type.dart';
+
+export 'package:mineral/src/api/server/enums/onboarding_mode.dart';
+export 'package:mineral/src/api/server/enums/onboarding_prompt_type.dart';
+
+/// An option inside an [OnboardingPrompt].
+final class OnboardingPromptOption {
+  /// The option's unique id.
+  final Snowflake id;
+
+  /// Channel ids that a member gains access to when this option is selected.
+  final List<Snowflake> channelIds;
+
+  /// Role ids assigned to the member when this option is selected.
+  final List<Snowflake> roleIds;
+
+  /// The emoji id if the emoji is custom.
+  final Snowflake? emojiId;
+
+  /// The emoji name if custom, the unicode character if standard, or null.
+  final String? emojiName;
+
+  /// Whether the emoji is animated.
+  final bool? emojiAnimated;
+
+  /// The title of the option.
+  final String title;
+
+  /// The description of the option.
+  final String? description;
+
+  const OnboardingPromptOption({
+    required this.id,
+    required this.channelIds,
+    required this.roleIds,
+    required this.title,
+    this.emojiId,
+    this.emojiName,
+    this.emojiAnimated,
+    this.description,
+  });
+
+  factory OnboardingPromptOption.fromJson(Map<String, dynamic> json) {
+    final emoji = json['emoji'] as Map<String, dynamic>?;
+    final rawChannelIds =
+        (json['channel_ids'] as List<dynamic>? ?? []).cast<String>();
+    final rawRoleIds =
+        (json['role_ids'] as List<dynamic>? ?? []).cast<String>();
+
+    return OnboardingPromptOption(
+      id: Snowflake.parse(json['id']),
+      channelIds: rawChannelIds.map(Snowflake.parse).toList(),
+      roleIds: rawRoleIds.map(Snowflake.parse).toList(),
+      emojiId: emoji != null ? Snowflake.nullable(emoji['id']) : null,
+      emojiName: emoji?['name'] as String?,
+      emojiAnimated: emoji?['animated'] as bool?,
+      title: json['title'] as String,
+      description: json['description'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id.value,
+      'channel_ids': channelIds.map((s) => s.value).toList(),
+      'role_ids': roleIds.map((s) => s.value).toList(),
+      if (emojiId != null || emojiName != null || emojiAnimated != null)
+        'emoji': {
+          if (emojiId != null) 'id': emojiId!.value,
+          if (emojiName != null) 'name': emojiName,
+          if (emojiAnimated != null) 'animated': emojiAnimated,
+        },
+      'title': title,
+      if (description != null) 'description': description,
+    };
+  }
+}
+
+/// A single onboarding prompt shown to new members.
+final class OnboardingPrompt {
+  /// The prompt's unique id.
+  final Snowflake id;
+
+  /// The type of prompt (multiple choice or dropdown).
+  final OnboardingPromptType type;
+
+  /// The options available in this prompt.
+  final List<OnboardingPromptOption> options;
+
+  /// The title displayed for this prompt.
+  final String title;
+
+  /// Whether only one option can be selected at a time.
+  final bool singleSelect;
+
+  /// Whether the prompt is required before a member can finish onboarding.
+  final bool required;
+
+  /// Whether the prompt is present in the onboarding flow.
+  final bool inOnboarding;
+
+  const OnboardingPrompt({
+    required this.id,
+    required this.type,
+    required this.options,
+    required this.title,
+    required this.singleSelect,
+    required this.required,
+    required this.inOnboarding,
+  });
+
+  factory OnboardingPrompt.fromJson(Map<String, dynamic> json) {
+    final rawOptions =
+        (json['options'] as List<dynamic>? ?? [])
+            .cast<Map<String, dynamic>>();
+    final typeValue = json['type'] as int;
+    return OnboardingPrompt(
+      id: Snowflake.parse(json['id']),
+      type: OnboardingPromptType.values.firstWhere(
+        (e) => e.value == typeValue,
+        orElse: () => OnboardingPromptType.multipleChoice,
+      ),
+      options: rawOptions.map(OnboardingPromptOption.fromJson).toList(),
+      title: json['title'] as String,
+      singleSelect: json['single_select'] as bool,
+      required: json['required'] as bool,
+      inOnboarding: json['in_onboarding'] as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id.value,
+      'type': type.value,
+      'options': options.map((o) => o.toJson()).toList(),
+      'title': title,
+      'single_select': singleSelect,
+      'required': required,
+      'in_onboarding': inOnboarding,
+    };
+  }
+}
+
+/// A guild's onboarding configuration.
+final class Onboarding {
+  /// The id of the guild this onboarding belongs to.
+  final Snowflake guildId;
+
+  /// The prompts shown during onboarding and in the community customization
+  /// menu.
+  final List<OnboardingPrompt> prompts;
+
+  /// The channel ids that members get opted into automatically.
+  final List<Snowflake> defaultChannelIds;
+
+  /// Whether onboarding is enabled in the guild.
+  final bool enabled;
+
+  /// The mode for onboarding.
+  final OnboardingMode mode;
+
+  const Onboarding({
+    required this.guildId,
+    required this.prompts,
+    required this.defaultChannelIds,
+    required this.enabled,
+    required this.mode,
+  });
+
+  factory Onboarding.fromJson(Map<String, dynamic> json) {
+    final rawPrompts =
+        (json['prompts'] as List<dynamic>? ?? [])
+            .cast<Map<String, dynamic>>();
+    final rawChannelIds =
+        (json['default_channel_ids'] as List<dynamic>? ?? []).cast<String>();
+    final modeValue = json['mode'] as int;
+    return Onboarding(
+      guildId: Snowflake.parse(json['guild_id']),
+      prompts: rawPrompts.map(OnboardingPrompt.fromJson).toList(),
+      defaultChannelIds: rawChannelIds.map(Snowflake.parse).toList(),
+      enabled: json['enabled'] as bool,
+      mode: OnboardingMode.values.firstWhere(
+        (e) => e.value == modeValue,
+        orElse: () => OnboardingMode.default_,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'guild_id': guildId.value,
+      'prompts': prompts.map((p) => p.toJson()).toList(),
+      'default_channel_ids': defaultChannelIds.map((s) => s.value).toList(),
+      'enabled': enabled,
+      'mode': mode.value,
+    };
+  }
+}

--- a/packages/core/lib/src/api/server/server.dart
+++ b/packages/core/lib/src/api/server/server.dart
@@ -171,4 +171,40 @@ final class Server {
       reason: reason,
     );
   }
+
+  /// Fetch the guild onboarding configuration.
+  ///
+  /// ```dart
+  /// final onboarding = await server.fetchOnboarding();
+  /// ```
+  Future<Onboarding> fetchOnboarding() =>
+      _datastore.onboarding.fetch(id.value);
+
+  /// Update the guild onboarding configuration.
+  ///
+  /// Only the provided parameters are sent in the request body.
+  ///
+  /// ```dart
+  /// await server.updateOnboarding(
+  ///   enabled: true,
+  ///   mode: OnboardingMode.default_,
+  ///   reason: 'Enabling onboarding',
+  /// );
+  /// ```
+  Future<Onboarding> updateOnboarding({
+    List<OnboardingPrompt>? prompts,
+    List<Snowflake>? defaultChannelIds,
+    bool? enabled,
+    OnboardingMode? mode,
+    String? reason,
+  }) {
+    return _datastore.onboarding.update(
+      id.value,
+      prompts: prompts,
+      defaultChannelIds: defaultChannelIds?.cast<Object>(),
+      enabled: enabled,
+      mode: mode,
+      reason: reason,
+    );
+  }
 }

--- a/packages/core/lib/src/domains/services/datastore/datastore.dart
+++ b/packages/core/lib/src/domains/services/datastore/datastore.dart
@@ -41,4 +41,6 @@ abstract class DataStoreContract {
   ApplicationEmojiPartContract get applicationEmoji;
 
   WelcomeScreenPartContract get welcomeScreen;
+
+  OnboardingPartContract get onboarding;
 }

--- a/packages/core/lib/src/domains/services/datastore/parts.dart
+++ b/packages/core/lib/src/domains/services/datastore/parts.dart
@@ -430,3 +430,16 @@ abstract interface class WelcomeScreenPartContract implements DataStorePart {
     String? reason,
   });
 }
+
+abstract interface class OnboardingPartContract implements DataStorePart {
+  Future<Onboarding> fetch(Object serverId);
+
+  Future<Onboarding> update(
+    Object serverId, {
+    List<OnboardingPrompt>? prompts,
+    List<Object>? defaultChannelIds,
+    bool? enabled,
+    OnboardingMode? mode,
+    String? reason,
+  });
+}

--- a/packages/core/lib/src/infrastructure/internals/datastore/datastore.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/datastore.dart
@@ -8,6 +8,7 @@ import 'package:mineral/src/infrastructure/internals/datastore/parts/interaction
 import 'package:mineral/src/infrastructure/internals/datastore/parts/invite_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/member_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/message_part.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/onboarding_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/reaction_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/role_part.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/rules_part.dart';
@@ -77,6 +78,9 @@ final class DataStore implements DataStoreContract {
   @override
   late final WelcomeScreenPart welcomeScreen;
 
+  @override
+  late final OnboardingPart onboarding;
+
   DataStore({
     required this.client,
     required MarshallerContract marshaller,
@@ -101,5 +105,6 @@ final class DataStore implements DataStoreContract {
     scheduledEvent = GuildScheduledEventPart(marshaller, this);
     applicationEmoji = ApplicationEmojiPart(marshaller, this);
     welcomeScreen = WelcomeScreenPart(marshaller, this);
+    onboarding = OnboardingPart(marshaller, this);
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
@@ -1,0 +1,51 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/base_part.dart';
+import 'package:mineral/src/infrastructure/internals/http/discord_header.dart';
+
+final class OnboardingPart extends BasePart
+    implements OnboardingPartContract {
+  OnboardingPart(super.marshaller, super.dataStore);
+
+  @override
+  Future<Onboarding> fetch(Object serverId) async {
+    final guildId = Snowflake.parse(serverId);
+    final req =
+        Request.json(endpoint: '/guilds/$guildId/onboarding');
+    final result =
+        await dataStore.requestBucket.get<Map<String, dynamic>>(req);
+    return Onboarding.fromJson(result);
+  }
+
+  @override
+  Future<Onboarding> update(
+    Object serverId, {
+    List<OnboardingPrompt>? prompts,
+    List<Object>? defaultChannelIds,
+    bool? enabled,
+    OnboardingMode? mode,
+    String? reason,
+  }) async {
+    final guildId = Snowflake.parse(serverId);
+
+    final body = <String, dynamic>{
+      if (prompts != null)
+        'prompts': prompts.map((p) => p.toJson()).toList(),
+      if (defaultChannelIds != null)
+        'default_channel_ids':
+            defaultChannelIds.map((id) => id.toString()).toList(),
+      if (enabled != null) 'enabled': enabled,
+      if (mode != null) 'mode': mode.value,
+    };
+
+    final req = Request.json(
+      endpoint: '/guilds/$guildId/onboarding',
+      body: body,
+      headers: {DiscordHeader.auditLogReason(reason)},
+    );
+    final result =
+        await dataStore.requestBucket.put<Map<String, dynamic>>(req);
+    return Onboarding.fromJson(result);
+  }
+}

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -107,6 +107,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/packages/core/test/commands/command_interaction_dispatcher_test.dart
+++ b/packages/core/test/commands/command_interaction_dispatcher_test.dart
@@ -109,6 +109,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────

--- a/packages/core/test/datastore/parts/onboarding_part_test.dart
+++ b/packages/core/test/datastore/parts/onboarding_part_test.dart
@@ -1,0 +1,394 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/src/infrastructure/internals/datastore/parts/onboarding_part.dart';
+import 'package:test/test.dart';
+
+import '../../helpers/fake_datastore.dart';
+import '../../helpers/fake_http_client.dart';
+import '../../helpers/fake_marshaller.dart';
+import '../../helpers/fake_response.dart';
+import '../../helpers/ioc_test_helper.dart';
+
+const _guildId = '123456789012345678';
+
+Map<String, dynamic> _onboardingPayload({
+  bool enabled = true,
+  int mode = 0,
+  List<Map<String, dynamic>>? prompts,
+  List<String>? defaultChannelIds,
+}) =>
+    {
+      'guild_id': _guildId,
+      'prompts': prompts ??
+          [
+            {
+              'id': '111222333444555666',
+              'type': 0,
+              'options': [
+                {
+                  'id': '999888777666555444',
+                  'channel_ids': ['111111111111111111'],
+                  'role_ids': ['222222222222222222'],
+                  'emoji': {
+                    'id': '333333333333333333',
+                    'name': 'wave',
+                    'animated': false,
+                  },
+                  'title': 'Option A',
+                  'description': 'First option',
+                },
+              ],
+              'title': 'What are you here for?',
+              'single_select': false,
+              'required': true,
+              'in_onboarding': true,
+            },
+          ],
+      'default_channel_ids': defaultChannelIds ?? ['444444444444444444'],
+      'enabled': enabled,
+      'mode': mode,
+    };
+
+(OnboardingPart, void Function() restore) _buildPart(FakeHttpClient client) {
+  final ds = FakeDataStore(client);
+  final ioc = createTestIoc(dataStore: ds);
+  return (OnboardingPart(FakeMarshaller(), ds), ioc.restore);
+}
+
+void main() {
+  group('OnboardingPart', () {
+    late void Function() restoreIoc;
+
+    setUp(() {
+      final http = FakeHttpClient();
+      final dataStore = FakeDataStore(http);
+      final iocResult = createTestIoc(dataStore: dataStore);
+      restoreIoc = iocResult.restore;
+    });
+
+    tearDown(() => restoreIoc());
+
+    // ── fetch ─────────────────────────────────────────────────────────────────
+
+    group('fetch()', () {
+      test('sends GET to /guilds/:id/onboarding', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        await p.fetch(_guildId);
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('GET'));
+        expect(client.calls.single.path,
+            equals('/guilds/$_guildId/onboarding'));
+      });
+
+      test('parses guild_id correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.guildId, equals(Snowflake.parse(_guildId)));
+      });
+
+      test('parses enabled correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(enabled: false)),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.enabled, isFalse);
+      });
+
+      test('parses mode correctly as ONBOARDING_DEFAULT', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(mode: 0)),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.mode, equals(OnboardingMode.default_));
+      });
+
+      test('parses mode correctly as ONBOARDING_ADVANCED', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(mode: 1)),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.mode, equals(OnboardingMode.advanced));
+      });
+
+      test('parses prompts correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.prompts, hasLength(1));
+
+        final prompt = onboarding.prompts.first;
+        expect(prompt.id, equals(Snowflake.parse('111222333444555666')));
+        expect(prompt.type, equals(OnboardingPromptType.multipleChoice));
+        expect(prompt.title, equals('What are you here for?'));
+        expect(prompt.singleSelect, isFalse);
+        expect(prompt.required, isTrue);
+        expect(prompt.inOnboarding, isTrue);
+      });
+
+      test('parses prompt options correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        final option = onboarding.prompts.first.options.first;
+        expect(option.id, equals(Snowflake.parse('999888777666555444')));
+        expect(option.channelIds,
+            equals([Snowflake.parse('111111111111111111')]));
+        expect(option.roleIds,
+            equals([Snowflake.parse('222222222222222222')]));
+        expect(option.emojiId,
+            equals(Snowflake.parse('333333333333333333')));
+        expect(option.emojiName, equals('wave'));
+        expect(option.emojiAnimated, isFalse);
+        expect(option.title, equals('Option A'));
+        expect(option.description, equals('First option'));
+      });
+
+      test('parses defaultChannelIds correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.defaultChannelIds,
+            equals([Snowflake.parse('444444444444444444')]));
+      });
+
+      test('handles empty prompts list', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(prompts: [])),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.prompts, isEmpty);
+      });
+
+      test('handles empty defaultChannelIds', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(defaultChannelIds: [])),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(onboarding.defaultChannelIds, isEmpty);
+      });
+
+      test('parses DROPDOWN prompt type correctly', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200,
+              _onboardingPayload(prompts: [
+                {
+                  'id': '111222333444555666',
+                  'type': 1,
+                  'options': [],
+                  'title': 'Dropdown prompt',
+                  'single_select': true,
+                  'required': false,
+                  'in_onboarding': false,
+                }
+              ])),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        expect(
+            onboarding.prompts.first.type, equals(OnboardingPromptType.dropdown));
+      });
+
+      test('parses prompt option with no emoji', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200,
+              _onboardingPayload(prompts: [
+                {
+                  'id': '111222333444555666',
+                  'type': 0,
+                  'options': [
+                    {
+                      'id': '999888777666555444',
+                      'channel_ids': [],
+                      'role_ids': [],
+                      'title': 'No emoji option',
+                      'description': null,
+                    }
+                  ],
+                  'title': 'Prompt',
+                  'single_select': false,
+                  'required': false,
+                  'in_onboarding': true,
+                }
+              ])),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.fetch(_guildId);
+        restore();
+
+        final option = onboarding.prompts.first.options.first;
+        expect(option.emojiId, isNull);
+        expect(option.emojiName, isNull);
+        expect(option.emojiAnimated, isNull);
+        expect(option.description, isNull);
+      });
+    });
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    group('update()', () {
+      test('sends PUT to /guilds/:id/onboarding', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        await p.update(_guildId, enabled: true);
+        restore();
+
+        expect(client.calls, hasLength(1));
+        expect(client.calls.single.method, equals('PUT'));
+        expect(client.calls.single.path,
+            equals('/guilds/$_guildId/onboarding'));
+      });
+
+      test('returns parsed Onboarding from PUT response', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(enabled: true, mode: 1)),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.update(_guildId, enabled: true);
+        restore();
+
+        expect(onboarding, isA<Onboarding>());
+        expect(onboarding.enabled, isTrue);
+        expect(onboarding.mode, equals(OnboardingMode.advanced));
+      });
+
+      test('sends audit log reason header when reason is provided', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        await p.update(_guildId, reason: 'audit reason', enabled: true);
+        restore();
+
+        expect(client.calls.single.method, equals('PUT'));
+        expect(client.calls.single.path,
+            equals('/guilds/$_guildId/onboarding'));
+      });
+
+      test('only-present fields are sent (enabled only)', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.update(_guildId, enabled: false);
+        restore();
+
+        expect(onboarding, isA<Onboarding>());
+        expect(client.calls, hasLength(1));
+      });
+
+      test('sends mode when provided', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200, _onboardingPayload(mode: 1)),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding =
+            await p.update(_guildId, mode: OnboardingMode.advanced);
+        restore();
+
+        expect(onboarding.mode, equals(OnboardingMode.advanced));
+        expect(client.calls.single.method, equals('PUT'));
+      });
+
+      test('sends defaultChannelIds when provided', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(
+              200,
+              _onboardingPayload(
+                  defaultChannelIds: ['555555555555555555'])),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.update(
+          _guildId,
+          defaultChannelIds: ['555555555555555555'],
+        );
+        restore();
+
+        expect(onboarding.defaultChannelIds,
+            equals([Snowflake.parse('555555555555555555')]));
+      });
+
+      test('sends prompts when provided', () async {
+        final client = FakeHttpClient([
+          FakeResponse<Map<String, dynamic>>(200, _onboardingPayload()),
+        ]);
+        final (p, restore) = _buildPart(client);
+
+        final onboarding = await p.update(
+          _guildId,
+          prompts: [],
+        );
+        restore();
+
+        expect(onboarding, isA<Onboarding>());
+        expect(client.calls, hasLength(1));
+      });
+    });
+  });
+}

--- a/packages/core/test/helpers/fake_datastore.dart
+++ b/packages/core/test/helpers/fake_datastore.dart
@@ -74,4 +74,8 @@ final class FakeDataStore implements DataStoreContract {
   @override
   WelcomeScreenPartContract get welcomeScreen =>
       throw UnimplementedError('welcomeScreen');
+
+  @override
+  OnboardingPartContract get onboarding =>
+      throw UnimplementedError('onboarding');
 }

--- a/packages/core/test/packets/application_command_permissions_update_packet_test.dart
+++ b/packages/core/test/packets/application_command_permissions_update_packet_test.dart
@@ -70,6 +70,8 @@ final class _NoopDs implements DataStoreContract {
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
   @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
+  @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
@@ -118,6 +120,8 @@ final class _DeferredDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
@@ -173,6 +177,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override

--- a/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
+++ b/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
@@ -70,6 +70,8 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   WelcomeScreenPartContract get welcomeScreen => _resolve().welcomeScreen;
   @override
+  OnboardingPartContract get onboarding => _resolve().onboarding;
+  @override
   RequestBucket get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
@@ -130,6 +132,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
 }
 
 /// [ChannelPartContract] that returns a pre-built [Channel].
@@ -750,6 +754,8 @@ final class _NoopDs implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override

--- a/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
+++ b/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
@@ -70,6 +70,8 @@ final class _NoopDs implements DataStoreContract {
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
   @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
+  @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
@@ -121,6 +123,8 @@ final class _DeferredDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override
@@ -178,6 +182,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   GuildScheduledEventPartContract get scheduledEvent =>
       throw UnimplementedError();

--- a/packages/core/test/packets/webhooks_update_packet_test.dart
+++ b/packages/core/test/packets/webhooks_update_packet_test.dart
@@ -67,6 +67,8 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   WelcomeScreenPartContract get welcomeScreen => _resolve().welcomeScreen;
   @override
+  OnboardingPartContract get onboarding => _resolve().onboarding;
+  @override
   RequestBucket get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
@@ -124,6 +126,8 @@ final class _FakeDataStore implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
 }
 
 /// [ChannelPartContract] that returns a pre-built [Channel].
@@ -229,6 +233,8 @@ final class _NoopDs implements DataStoreContract {
       throw UnimplementedError();
   @override
   WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
+  @override
+  OnboardingPartContract get onboarding => throw UnimplementedError();
   @override
   RequestBucket get requestBucket => throw UnimplementedError();
   @override


### PR DESCRIPTION
## Summary
Adds guild onboarding support (fetch + edit) on `Server`.

- New `Onboarding` / `OnboardingPrompt` / `OnboardingPromptOption` entities (factory `fromJson` + `toJson`) and `OnboardingMode` / `OnboardingPromptType` enums, exported from `api.dart`
- New `OnboardingPart` datastore part: `fetch` (GET) and `update` (PUT with only-present fields + audit reason header) against `/guilds/{id}/onboarding`
- `Server.fetchOnboarding()` and `Server.updateOnboarding(...)`

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New part tests pass (19/19): prompt/option/mode parsing + PUT behavior
- [x] No regression: full suite passes (1152/1152)

Closes #389