### PR TITLE
fix: attach the websocket error handler (H1)

### DIFF
--- a/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
+++ b/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
@@ -80,18 +80,15 @@ final class WebsocketClientImpl implements WebsocketClient {
         }
       });
 
-      if (_onError != null) {
-        stream!.handleError((err) {
-          _onError({
-            'error': err,
-            'code': _channel?.closeCode,
-            'reason': _channel?.closeReason
-          });
-        });
-      }
-
       _channelListener = stream!.listen(
         (dynamic message) => _handleMessage(_onMessage, message),
+        onError: (Object err) {
+          _onError?.call({
+            'error': err,
+            'code': _channel?.closeCode,
+            'reason': _channel?.closeReason,
+          });
+        },
         onDone: () {
           _onClose?.call(_channel?.closeCode);
         },


### PR DESCRIPTION
## Summary
Fixes H1: the WebSocket error handler was attached to a discarded stream (`stream.handleError(...)` whose returned stream was never listened) and the real `listen(...)` had no `onError:`. Socket errors became unhandled async errors that could terminate the isolate (silent shard death).

Now the error handler is passed as `onError:` of the active `listen(...)` subscription, so socket errors reach `_onError` and the reconnection path.

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] `dart test packages/core` — 1309/1309 (no regression)

Note: `WebsocketClientImpl` connects via `io.WebSocket.connect` with no injectable stream seam, so a focused unit test would require a disproportionate refactor; the analyzer validates the `onError:` wiring and the full suite guards regressions.

Closes #416