### PR TITLE
fix: drop malformed gateway frames instead of crashing (H2)

### DIFF
--- a/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
+++ b/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:io' as io;
 
 import 'package:mineral/contracts.dart';
+import 'package:mineral/src/infrastructure/io/exceptions/serialization_exception.dart';
 import 'package:mineral/src/infrastructure/services/wss/interceptor.dart';
 import 'package:mineral/src/infrastructure/services/wss/websocket_message.dart';
 import 'package:mineral/src/infrastructure/services/wss/websocket_requested_message.dart';
@@ -122,11 +123,14 @@ final class WebsocketClientImpl implements WebsocketClient {
   }
 
   Future<void> _handleMessage(dynamic callback, dynamic message) async {
-    final interceptedMessage = await _handleMessageInterceptors(
-        WebsocketMessageImpl(
-            channelName: name, originalContent: message, content: message));
-
-    callback(interceptedMessage);
+    try {
+      final interceptedMessage = await _handleMessageInterceptors(
+          WebsocketMessageImpl(
+              channelName: name, originalContent: message, content: message));
+      callback(interceptedMessage);
+    } on SerializationException catch (e) {
+      _logger.warn('Dropping malformed gateway frame: $e');
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
Fixes H2: `_handleMessage` ran the JSON/ETF decode pipeline as a dropped (fire-and-forget) `Future`, so a `SerializationException` from a malformed frame became an unhandled async error and crashed the bot.

`_handleMessage` now wraps the decode + dispatch in `try/catch on SerializationException`, logging and dropping the bad frame. Both decoders normalize decode failures to `SerializationException`, so this is the precise boundary.

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] `dart test packages/core` — 1309/1309 (no regression)

Note: `_handleMessage` is private and both call sites need a live `io.WebSocket`; a focused test would require a disproportionate refactor, so we rely on the analyzer + full suite (existing encoder tests already cover `SerializationException`).

Closes #417