### PR TITLE
fix: surface initial connection failure to the backoff strategy (H3)

### DIFF
--- a/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
+++ b/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
@@ -101,11 +101,10 @@ final class WebsocketClientImpl implements WebsocketClient {
       }
     } on io.WebSocketException catch (err) {
       _logger.error('WebSocket connection failed: $err');
-      _onError?.call({
-        'error': err,
-        'code': _channel?.closeCode,
-        'reason': _channel?.closeReason
-      });
+      _onClose?.call(1006);
+    } on io.SocketException catch (err) {
+      _logger.error('Socket connection failed: $err');
+      _onClose?.call(1006);
     }
   }
 

--- a/packages/core/test/wss/shard_network_error_test.dart
+++ b/packages/core/test/wss/shard_network_error_test.dart
@@ -210,6 +210,52 @@ void main() {
       });
     });
 
+    group('connect failure synthetic code (H3 fix)', () {
+      // When WebsocketClientImpl.connect() catches a WebSocketException or
+      // SocketException it calls _onClose(1006) — the same code that onDone
+      // uses for an abnormal closure. This group asserts that code 1006
+      // arriving through dispatch() triggers the reconnect path, not a no-op.
+
+      test('code 1006 is not a no-op (does not leave warnings empty)', () {
+        final shard = _createShard(logger: logger)
+          ..client = FakeWebsocketClient();
+        final networkError = ShardNetworkError(shard);
+
+        _dispatchSilently(() => networkError.dispatch(1006));
+
+        expect(logger.warnings, isNotEmpty,
+            reason: 'A connect failure must not silently hang');
+      });
+
+      test('code 1006 invalidates session and triggers reconnect', () {
+        final shard = _createShard(logger: logger)
+          ..client = FakeWebsocketClient();
+        shard.authentication.setupRequirements({
+          'session_id': 'stale-session',
+          'resume_gateway_url': 'wss://old-url',
+        });
+        final networkError = ShardNetworkError(shard);
+
+        _dispatchSilently(() => networkError.dispatch(1006));
+
+        expect(shard.authentication.sessionId, isNull,
+            reason: 'Session must be invalidated on connect failure');
+        expect(shard.authentication.resumeUrl, isNull,
+            reason: 'Resume URL must be cleared on connect failure');
+      });
+
+      test('code 1006 disconnects the client before reconnecting', () {
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(logger: logger)..client = fakeClient;
+        final networkError = ShardNetworkError(shard);
+
+        _dispatchSilently(() => networkError.dispatch(1006));
+
+        expect(fakeClient.disconnected, isTrue,
+            reason: 'Client must be disconnected before reconnect attempt');
+      });
+    });
+
     group('unknown codes', () {
       test('logs warning about unknown code', () {
         final shard = _createShard(logger: logger)


### PR DESCRIPTION
## Summary
Fixes H3: a failed initial connection forwarded `code: null`, which the shard's `dispatch(null)` treats as a no-op → the bot hung silently with no backoff; and `SocketException` (DNS/network down) was uncaught and propagated unhandled.

- The `connect()` failure path now calls `_onClose(1006)` (abnormal closure). `_onClose` is wired directly to `ShardNetworkError.dispatch`, and code 1006 maps to `DisconnectAction.reconnect` → `invalidateSession()` + `reconnect()` (the existing backoff). `_onError` was avoided because its wiring drops non-int codes to `null` (the original bug).
- Added a `catch (io.SocketException)` clause so DNS/network failures also route to backoff instead of escaping.

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] `dart test packages/core` — 1312/1312
- [x] New tests in `shard_network_error_test.dart`: code 1006 is not a no-op, invalidates session + reconnects, disconnects the client first

Closes #418