### PR TITLE
fix: supervise reconnection/resume/heartbeat futures (H4)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 5.1.1
+
+### WebSocket resilience fixes
+
+- **H1** — WebSocket error handler is now always attached before the stream is
+  listened to, preventing unhandled-stream-error crashes on connection failure.
+- **H2** — Malformed or unexpected frame payloads are logged and dropped
+  instead of crashing the shard message loop.
+- **H3** — A `connect()` failure (e.g. `WebSocketException`, `SocketException`)
+  now triggers the exponential-backoff reconnect strategy rather than silently
+  hanging.
+- **H4** — `resume()` and `reconnect()` are no longer fire-and-forget. A
+  `FatalGatewayException` thrown when `maxReconnectAttempts` is exceeded is now
+  caught by a supervised `catchError` handler and routed to a private
+  `_handleFatal` helper (cancel heartbeat → disconnect client → invoke
+  `onFatalDisconnect`). The `DisconnectAction.fatal` path likewise calls
+  `_handleFatal` instead of throwing synchronously from a stream callback.
+  Heartbeat Timer callbacks in `ShardAuthentication` are supervised by the same
+  pattern via `_onHeartbeatError`. `onFatalDisconnect` is promoted to the
+  `WebsocketOrchestratorContract` interface so any implementation (including
+  test doubles) can register the callback.
+
 # 5.1.0
 
 ## Breaking changes — `Server` → `Guild` rename

--- a/packages/core/lib/src/domains/services/wss/websocket_orchestrator.dart
+++ b/packages/core/lib/src/domains/services/wss/websocket_orchestrator.dart
@@ -24,6 +24,11 @@ abstract class WebsocketOrchestratorContract {
 
   Map<int, ShardContract> get shards;
 
+  /// Optional callback invoked when a shard encounters a fatal, non-recoverable
+  /// gateway error. Set by the application layer (e.g. [Kernel]) after
+  /// construction to handle teardown (dispose, exit, etc.).
+  Future<void> Function()? get onFatalDisconnect;
+
   void send(WebsocketIsolateMessageTransfert message);
 
   void setBotPresence(

--- a/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
@@ -68,15 +68,39 @@ final class ShardAuthentication implements ShardAuthenticationContract {
     shard.client.send(message.build());
   }
 
+  /// Handles errors from fire-and-forget heartbeat futures.
+  ///
+  /// [FatalGatewayException] → cancel heartbeat, disconnect the client, and
+  /// invoke [WebsocketOrchestrator.onFatalDisconnect] if available.
+  ///
+  /// Any other error is logged and rethrown so unexpected programming errors
+  /// are not silently discarded.
+  void _onHeartbeatError(Object error, StackTrace stack) {
+    if (error is FatalGatewayException) {
+      shard.logger.error(
+          'Fatal gateway error during heartbeat: ${error.message} (${error.code}). Cannot reconnect.');
+      cancelHeartbeat();
+      unawaited(shard.client.disconnect());
+      unawaited(shard.wss.onFatalDisconnect?.call() ?? Future<void>.value());
+      return; // handled — do not propagate
+    }
+    shard.logger.error('Unexpected heartbeat error: $error\n$stack');
+    throw error;
+  }
+
   void createHeartbeatTimer(int interval) {
     _heartbeatTimer?.cancel();
     final jitterDelay =
         Duration(milliseconds: (_random.nextDouble() * interval).toInt());
     _heartbeatTimer = Timer(jitterDelay, () {
-      heartbeat();
+      unawaited(
+        Future.sync(heartbeat).catchError(_onHeartbeatError),
+      );
       _heartbeatTimer =
           Timer.periodic(Duration(milliseconds: interval), (timer) {
-        heartbeat();
+        unawaited(
+          Future.sync(heartbeat).catchError(_onHeartbeatError),
+        );
       });
     });
   }

--- a/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart
@@ -3,13 +3,43 @@ import 'dart:async';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/src/domains/services/wss/constants/shard_disconnect_error.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard.dart';
-import 'package:mineral/src/infrastructure/internals/wss/websocket_orchestrator.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/fatal_gateway_exception.dart';
 
 final class ShardNetworkError implements ShardNetworkErrorContract {
   final Shard shard;
 
   ShardNetworkError(this.shard);
+
+  // ── Fatal-path helpers ─────────────────────────────────────────────────────
+
+  /// Performs the fatal shutdown sequence: cancel heartbeat, disconnect the
+  /// client, and invoke [WebsocketOrchestrator.onFatalDisconnect] if set.
+  /// Nothing is thrown — the error is fully handled here.
+  void _handleFatal(FatalGatewayException e) {
+    shard.logger.error(
+        'Fatal gateway error: ${e.message} (${e.code}). Cannot reconnect.');
+    shard.authentication.cancelHeartbeat();
+    unawaited(shard.client.disconnect());
+    unawaited(shard.wss.onFatalDisconnect?.call() ?? Future<void>.value());
+  }
+
+  /// Handles errors from fire-and-forget reconnection futures.
+  ///
+  /// [FatalGatewayException] → routes to [_handleFatal] (swallowed after
+  /// the shutdown sequence so the error does not escape the zone).
+  ///
+  /// Any other error is logged and rethrown so that unexpected programming
+  /// errors are not silently discarded.
+  void _onReconnectError(Object error, StackTrace stack) {
+    if (error is FatalGatewayException) {
+      _handleFatal(error);
+      return; // handled — do not propagate
+    }
+    shard.logger.error('Unexpected reconnect error: $error\n$stack');
+    throw error;
+  }
+
+  // ── Public dispatch ────────────────────────────────────────────────────────
 
   @override
   void dispatch(dynamic payload) {
@@ -33,21 +63,19 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
       switch (error.action) {
         case DisconnectAction.resume:
           logger.trace('Attempting to resume session');
-          shard.authentication.resume();
+          unawaited(
+            Future.sync(() => shard.authentication.resume())
+                .catchError(_onReconnectError),
+          );
         case DisconnectAction.reconnect:
           logger.trace('Attempting full reconnect');
           shard.authentication.invalidateSession();
-          shard.authentication.reconnect();
+          unawaited(
+            Future.sync(() => shard.authentication.reconnect())
+                .catchError(_onReconnectError),
+          );
         case DisconnectAction.fatal:
-          logger.error(
-              'Fatal gateway error: ${error.message} (${error.code}). Cannot reconnect.');
-          shard.authentication.cancelHeartbeat();
-          unawaited(shard.client.disconnect());
-          final wss = shard.wss;
-          if (wss is WebsocketOrchestrator) {
-            unawaited(wss.onFatalDisconnect?.call() ?? Future<void>.value());
-          }
-          throw FatalGatewayException(error.message, error.code);
+          _handleFatal(FatalGatewayException(error.message, error.code));
       }
       return;
     }
@@ -55,6 +83,9 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
     logger.warn(
         'WebSocket closed with unknown code: $payload. Attempting reconnect.');
     shard.authentication.invalidateSession();
-    shard.authentication.reconnect();
+    unawaited(
+      Future.sync(() => shard.authentication.reconnect())
+          .catchError(_onReconnectError),
+    );
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
@@ -69,6 +69,7 @@ final class WebsocketOrchestrator implements WebsocketOrchestratorContract {
   /// Set by [Kernel] after construction to break the otherwise-circular
   /// dependency between the orchestrator (built first) and the kernel
   /// (built later, owns dispose).
+  @override
   Future<void> Function()? onFatalDisconnect;
 
   WebsocketOrchestrator(

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mineral
 description: Mineral is a Discord framework for designing discord bots in Dart.
-version: 5.1.0
+version: 5.1.1
 
 repository: https://github.com/mineral-dart/core
 # homepage: https://www.example.com

--- a/packages/core/test/helpers/fake_websocket_orchestrator.dart
+++ b/packages/core/test/helpers/fake_websocket_orchestrator.dart
@@ -35,6 +35,10 @@ final class FakeWebsocketOrchestrator extends WebsocketOrchestratorContract {
   ShardingConfigContract get config => _config;
   @override
   Map<int, ShardContract> get shards => {};
+
+  @override
+  Future<void> Function()? onFatalDisconnect;
+
   @override
   void send(WebsocketIsolateMessageTransfert message) {}
   @override

--- a/packages/core/test/wss/shard_network_error_test.dart
+++ b/packages/core/test/wss/shard_network_error_test.dart
@@ -16,13 +16,22 @@ import '../helpers/mocks.dart';
 
 /// Creates a shard with configurable maxReconnectAttempts so that
 /// resume/reconnect throw FatalGatewayException when set to 0.
-Shard _createShard({required FakeLogger logger, int maxReconnect = 0}) {
+///
+/// Pass [onFatalDisconnect] to install a fatal-disconnect callback on the
+/// orchestrator (used in H4 supervision tests).
+Shard _createShard({
+  required FakeLogger logger,
+  int maxReconnect = 0,
+  Future<void> Function()? onFatalDisconnect,
+}) {
+  final wss = FakeWebsocketOrchestrator(maxReconnectAttempts: maxReconnect)
+    ..onFatalDisconnect = onFatalDisconnect;
   return Shard(
     shardName: 'test-shard-0',
     shardIndex: 0,
     shardCount: 1,
     url: 'wss://fake',
-    wss: FakeWebsocketOrchestrator(maxReconnectAttempts: maxReconnect),
+    wss: wss,
     logger: logger,
     strategy: FakeRunningStrategy(),
   );
@@ -172,14 +181,24 @@ void main() {
     });
 
     group('fatal codes', () {
-      test('logs fatal error and disconnects for code 4004', () {
+      // H4 fix: dispatch() must NOT throw for fatal codes — _handleFatal
+      // absorbs the error and routes to onFatalDisconnect.
+
+      test('does NOT throw for code 4004 (H4 fix)', () {
         final fakeClient = FakeWebsocketClient();
         final shard = _createShard(logger: logger)..client = fakeClient;
         final networkError = ShardNetworkError(shard);
 
-        final error = _dispatchSilently(() => networkError.dispatch(4004));
+        // dispatch() must complete without throwing
+        expect(() => networkError.dispatch(4004), returnsNormally);
+      });
 
-        expect(error, isNotNull);
+      test('logs fatal error and disconnects for code 4004', () {
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(logger: logger)..client = fakeClient;
+
+        ShardNetworkError(shard).dispatch(4004);
+
         expect(logger.errors, contains(contains('Fatal gateway error')));
         expect(logger.errors.first, contains('4004'));
         expect(fakeClient.disconnected, isTrue);
@@ -188,11 +207,9 @@ void main() {
       test('logs fatal error and disconnects for code 4014', () {
         final fakeClient = FakeWebsocketClient();
         final shard = _createShard(logger: logger)..client = fakeClient;
-        final networkError = ShardNetworkError(shard);
 
-        final error = _dispatchSilently(() => networkError.dispatch(4014));
+        ShardNetworkError(shard).dispatch(4014);
 
-        expect(error, isNotNull);
         expect(logger.errors, contains(contains('Fatal gateway error')));
         expect(fakeClient.disconnected, isTrue);
       });
@@ -200,11 +217,9 @@ void main() {
       test('logs fatal error and disconnects for code 4010 (invalidShard)', () {
         final fakeClient = FakeWebsocketClient();
         final shard = _createShard(logger: logger)..client = fakeClient;
-        final networkError = ShardNetworkError(shard);
 
-        final error = _dispatchSilently(() => networkError.dispatch(4010));
+        ShardNetworkError(shard).dispatch(4010);
 
-        expect(error, isNotNull);
         expect(logger.errors, contains(contains('Fatal gateway error')));
         expect(fakeClient.disconnected, isTrue);
       });
@@ -275,6 +290,151 @@ void main() {
         _dispatchSilently(() => networkError.dispatch(1234));
 
         expect(fakeClient.disconnected, isTrue);
+      });
+    });
+
+    // ── H4 — supervised reconnection / fatal routed to hook ─────────────────
+
+    group('H4 — reconnect/resume supervision', () {
+      test(
+          'resume() throwing FatalGatewayException calls onFatalDisconnect '
+          'and no uncaught error escapes', () async {
+        bool fatalCalled = false;
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(
+          logger: logger,
+          maxReconnect: 0, // ensures resume() throws FatalGatewayException
+          onFatalDisconnect: () async {
+            fatalCalled = true;
+          },
+        )..client = fakeClient;
+
+        final uncaughtErrors = <Object>[];
+        await runZonedGuarded(
+          () async {
+            ShardNetworkError(shard).dispatch(4000); // resume code
+            // Give the fire-and-forget future time to complete.
+            await Future<void>.delayed(Duration.zero);
+          },
+          (e, _) => uncaughtErrors.add(e),
+        );
+
+        expect(uncaughtErrors, isEmpty,
+            reason: 'No error must escape the zone');
+        expect(fatalCalled, isTrue,
+            reason: 'onFatalDisconnect must be invoked');
+        expect(fakeClient.disconnected, isTrue,
+            reason: 'Client must be disconnected on fatal');
+        expect(logger.errors, contains(contains('Fatal gateway error')));
+      });
+
+      test(
+          'reconnect() throwing FatalGatewayException calls onFatalDisconnect '
+          'and no uncaught error escapes', () async {
+        bool fatalCalled = false;
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(
+          logger: logger,
+          maxReconnect: 0, // ensures reconnect() throws FatalGatewayException
+          onFatalDisconnect: () async {
+            fatalCalled = true;
+          },
+        )..client = fakeClient;
+
+        final uncaughtErrors = <Object>[];
+        await runZonedGuarded(
+          () async {
+            ShardNetworkError(shard).dispatch(1000); // reconnect code
+            await Future<void>.delayed(Duration.zero);
+          },
+          (e, _) => uncaughtErrors.add(e),
+        );
+
+        expect(uncaughtErrors, isEmpty,
+            reason: 'No error must escape the zone');
+        expect(fatalCalled, isTrue,
+            reason: 'onFatalDisconnect must be invoked');
+        expect(fakeClient.disconnected, isTrue,
+            reason: 'Client must be disconnected on fatal');
+        expect(logger.errors, contains(contains('Fatal gateway error')));
+      });
+
+      test(
+          'unknown-code reconnect() throwing FatalGatewayException calls '
+          'onFatalDisconnect and no uncaught error escapes', () async {
+        bool fatalCalled = false;
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(
+          logger: logger,
+          maxReconnect: 0,
+          onFatalDisconnect: () async {
+            fatalCalled = true;
+          },
+        )..client = fakeClient;
+
+        final uncaughtErrors = <Object>[];
+        await runZonedGuarded(
+          () async {
+            ShardNetworkError(shard).dispatch(9999); // unknown code
+            await Future<void>.delayed(Duration.zero);
+          },
+          (e, _) => uncaughtErrors.add(e),
+        );
+
+        expect(uncaughtErrors, isEmpty,
+            reason: 'No error must escape the zone');
+        expect(fatalCalled, isTrue,
+            reason: 'onFatalDisconnect must be invoked for unknown code');
+        expect(fakeClient.disconnected, isTrue);
+      });
+
+      test(
+          'DisconnectAction.fatal path calls onFatalDisconnect, disconnects '
+          'client, cancels heartbeat, and does NOT throw', () async {
+        bool fatalCalled = false;
+        final fakeClient = FakeWebsocketClient();
+        final shard = _createShard(
+          logger: logger,
+          onFatalDisconnect: () async {
+            fatalCalled = true;
+          },
+        )..client = fakeClient;
+
+        final uncaughtErrors = <Object>[];
+        await runZonedGuarded(
+          () async {
+            // dispatch() must complete without throwing
+            expect(
+              () => ShardNetworkError(shard).dispatch(4004),
+              returnsNormally,
+            );
+            await Future<void>.delayed(Duration.zero);
+          },
+          (e, _) => uncaughtErrors.add(e),
+        );
+
+        expect(uncaughtErrors, isEmpty,
+            reason: 'Fatal path must not throw from a callback');
+        expect(fatalCalled, isTrue,
+            reason: 'onFatalDisconnect must be called on fatal code');
+        expect(fakeClient.disconnected, isTrue,
+            reason: 'Client must be disconnected');
+        expect(logger.errors, contains(contains('Fatal gateway error')));
+      });
+
+      test(
+          'DisconnectAction.fatal path invokes onFatalDisconnect '
+          'even when it is null (no-op)', () {
+        final fakeClient = FakeWebsocketClient();
+        // onFatalDisconnect intentionally left null
+        final shard = _createShard(logger: logger)..client = fakeClient;
+
+        expect(
+          () => ShardNetworkError(shard).dispatch(4004),
+          returnsNormally,
+        );
+        expect(fakeClient.disconnected, isTrue);
+        expect(logger.errors, contains(contains('Fatal gateway error')));
       });
     });
   });


### PR DESCRIPTION
## Summary
Fixes H4: `resume()`/`reconnect()` (and `heartbeat()` Timer callbacks) were fire-and-forget while their strategy throws `FatalGatewayException` past `maxReconnectAttempts`; and the `fatal` case `throw`ed from a synchronous callback → uncontrolled zone crash / silent shard death.

- New `_handleFatal(...)` performs the fatal shutdown once (cancel heartbeat, disconnect, invoke `onFatalDisconnect`) without throwing.
- All fire-and-forget reconnection calls wrapped with `unawaited(Future.sync(...).catchError(_onReconnectError))`, routing `FatalGatewayException` to `_handleFatal` and logging+rethrowing unexpected errors.
- `DisconnectAction.fatal` now calls `_handleFatal(...)` instead of `throw`.
- Heartbeat Timer callbacks supervised the same way.
- `onFatalDisconnect` promoted to `WebsocketOrchestratorContract` (removes the `is WebsocketOrchestrator` downcast and makes the hook testable).

Bumps to **5.1.1** with a CHANGELOG entry covering the H1–H4 websocket resilience lot.

## Test plan
- [x] `dart analyze packages/core packages/cache packages/test` — no issues
- [x] `dart test packages/core` — 1318/1318
- [x] New tests: resume/reconnect/unknown-code throwing `FatalGatewayException` → `onFatalDisconnect` called, nothing escapes; fatal path → hook called, client disconnected, no throw

Closes #419