### PR TITLE
fix: redact webhook/interaction tokens in rate-limit logs (M1)

### DIFF
--- a/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
@@ -88,7 +88,7 @@ final class QueueableRequest<T> {
         }
 
         _logger.warn(
-          'Rate limit reached on $route '
+          'Rate limit reached on ${route.redactedString} '
           '(attempt ${attempt + 1}/$_maxRateLimitRetries, '
           '${isGlobal ? 'global' : 'bucket'}). '
           'Retrying in ${retryDelay.inMilliseconds}ms',

--- a/packages/core/lib/src/infrastructure/internals/datastore/route_key.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/route_key.dart
@@ -80,6 +80,43 @@ final class RouteKey {
     return true;
   }
 
+  /// Returns a human-readable representation of this route with sensitive
+  /// credential segments redacted.
+  ///
+  /// The raw token that follows the webhook/interaction id is masked with
+  /// `***` so that it is never exposed in log output (CWE-532).
+  /// Bucketing identity ([normalizedPath], [==], [hashCode]) is unaffected.
+  String get redactedString {
+    final redacted = _redactTokenSegments(normalizedPath);
+    return '$method $redacted';
+  }
+
+  /// Replaces the token segment that immediately follows a webhook or
+  /// interaction id with `***`.
+  ///
+  /// Patterns handled:
+  ///   `/webhooks/<id>/<token>[/...]`   — id kept as raw snowflake (major param)
+  ///   `/interactions/{id}/<token>[/...]` — id normalised to `{id}` placeholder
+  static String _redactTokenSegments(String path) {
+    final segments = path.split('/');
+    // segments[0] is always '' because path starts with '/'
+    final out = <String>[];
+    for (var i = 0; i < segments.length; i++) {
+      final segment = segments[i];
+      if (i >= 3) {
+        final routeClass = segments[i - 2]; // e.g. 'webhooks' or 'interactions'
+        // For webhooks the id is raw (major param); for interactions it is
+        // normalised to '{id}'.  Either way, position i is the token segment.
+        if (routeClass == 'webhooks' || routeClass == 'interactions') {
+          out.add('***');
+          continue;
+        }
+      }
+      out.add(segment);
+    }
+    return out.join('/');
+  }
+
   @override
   String toString() => '$method $normalizedPath';
 

--- a/packages/core/test/datastore/request_bucket_test.dart
+++ b/packages/core/test/datastore/request_bucket_test.dart
@@ -89,5 +89,77 @@ void main() {
       // Bucket state recorded; remaining=4 means not exhausted.
       expect(bucket.registry.globalLockedUntil, isNull);
     });
+
+    test('429 on webhook route logs redacted token, not the raw credential',
+        () async {
+      const webhookToken = 'supersecretwebhooktoken';
+      const webhookId = '111111111111111111';
+      final http = FakeHttpClient([
+        FakeResponse<Map<String, dynamic>>(
+          429,
+          const {'global': false, 'retry_after': 0.0},
+          bodyString: '{"global":false,"retry_after":0.0}',
+        ),
+        FakeResponse.ok(),
+      ]);
+      final bucket = RequestBucket(http, logger: logger);
+      await bucket.post<Map<String, dynamic>>(
+        Request.json(endpoint: '/webhooks/$webhookId/$webhookToken'),
+      );
+
+      expect(logger.warnings, hasLength(1));
+      final logLine = logger.warnings.single;
+      // Token must not appear in the log
+      expect(logLine, isNot(contains(webhookToken)));
+      // Redaction marker must be present
+      expect(logLine, contains('***'));
+      // Webhook id must still appear (it is not a secret)
+      expect(logLine, contains(webhookId));
+    });
+
+    test('429 on interaction route logs redacted token, not the raw credential',
+        () async {
+      const interactionToken = 'supersecretinteractiontoken';
+      const interactionId = '222222222222222222';
+      final http = FakeHttpClient([
+        FakeResponse<Map<String, dynamic>>(
+          429,
+          const {'global': false, 'retry_after': 0.0},
+          bodyString: '{"global":false,"retry_after":0.0}',
+        ),
+        FakeResponse.ok(),
+      ]);
+      final bucket = RequestBucket(http, logger: logger);
+      await bucket.post<Map<String, dynamic>>(
+        Request.json(
+            endpoint: '/interactions/$interactionId/$interactionToken'),
+      );
+
+      expect(logger.warnings, hasLength(1));
+      final logLine = logger.warnings.single;
+      expect(logLine, isNot(contains(interactionToken)));
+      expect(logLine, contains('***'));
+    });
+
+    test('429 on normal route logs full route without masking', () async {
+      final http = FakeHttpClient([
+        FakeResponse<Map<String, dynamic>>(
+          429,
+          const {'global': false, 'retry_after': 0.0},
+          bodyString: '{"global":false,"retry_after":0.0}',
+        ),
+        FakeResponse.ok(),
+      ]);
+      final bucket = RequestBucket(http, logger: logger);
+      await bucket.get<Map<String, dynamic>>(
+        Request.json(endpoint: '/channels/111111111111111111/messages'),
+      );
+
+      expect(logger.warnings, hasLength(1));
+      final logLine = logger.warnings.single;
+      expect(logLine, contains('channels'));
+      expect(logLine, contains('messages'));
+      expect(logLine, isNot(contains('***')));
+    });
   });
 }

--- a/packages/core/test/datastore/route_key_test.dart
+++ b/packages/core/test/datastore/route_key_test.dart
@@ -69,4 +69,77 @@ void main() {
       expect(a.hashCode, equals(b.hashCode));
     });
   });
+
+  group('RouteKey.redactedString — token masking (CWE-532)', () {
+    test('webhook token is masked in redactedString', () {
+      final key =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken');
+      expect(key.redactedString, equals('POST /webhooks/111111111111111111/***'));
+    });
+
+    test('interaction token is masked in redactedString', () {
+      final key = RouteKey(
+          'POST', '/interactions/111111111111111111/supersecrettoken');
+      expect(key.redactedString, equals('POST /interactions/{id}/***'));
+    });
+
+    test('normal route is unchanged in redactedString', () {
+      final key = RouteKey('GET', '/channels/111111111111111111/messages');
+      expect(key.redactedString,
+          equals('GET /channels/111111111111111111/messages'));
+    });
+
+    test('users route is unchanged in redactedString', () {
+      final key = RouteKey('GET', '/users/@me');
+      expect(key.redactedString, equals('GET /users/@me'));
+    });
+
+    test('webhook bucketing key (normalizedPath) is preserved raw', () {
+      final key =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken');
+      // normalizedPath must contain the actual token for bucketing
+      expect(key.normalizedPath,
+          equals('/webhooks/111111111111111111/supersecrettoken'));
+    });
+
+    test('interaction bucketing key (normalizedPath) is preserved raw', () {
+      final key = RouteKey(
+          'POST', '/interactions/111111111111111111/supersecrettoken');
+      expect(key.normalizedPath,
+          equals('/interactions/{id}/supersecrettoken'));
+    });
+
+    test('two webhooks with same id+token map to same bucket', () {
+      final a =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken');
+      final b =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('two webhooks with different tokens map to different buckets', () {
+      final a =
+          RouteKey('POST', '/webhooks/111111111111111111/tokenA');
+      final b =
+          RouteKey('POST', '/webhooks/111111111111111111/tokenB');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('webhook route with trailing sub-path masks only the token segment',
+        () {
+      final key =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken/slack');
+      expect(key.redactedString,
+          equals('POST /webhooks/111111111111111111/***/slack'));
+    });
+
+    test('toString still exposes normalizedPath (not used in logs)', () {
+      final key =
+          RouteKey('POST', '/webhooks/111111111111111111/supersecrettoken');
+      // toString is the raw form; the test documents intentional behaviour
+      expect(key.toString(),
+          equals('POST /webhooks/111111111111111111/supersecrettoken'));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Fixes M1 (CWE-532): the 429 warn log printed routes containing full webhook/interaction tokens.

- New `RouteKey.redactedString` getter masks the segment after `/webhooks/{id}/` and `/interactions/{id}/` with `***`; used at the rate-limit log site.
- `toString()` / equality / `hashCode` (the bucketing key) are unchanged — raw value preserved for bucketing.

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] New tests (route_key + request_bucket): tokens masked in logs, normal routes untouched, bucketing key preserved, same/different tokens bucket correctly
- [x] Full suite 1322/1322

Closes #429