### PR TITLE
ci: gate and pin the publish workflow, harden CI (H7/M10/L10/L11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
@@ -13,15 +16,21 @@ jobs:
       matrix:
         package: [core, cache, test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
           sdk: stable
       - name: Install dependencies
         run: dart pub get
+      - name: Format check
+        run: dart format --output=none --set-exit-if-changed .
+        working-directory: packages/${{ matrix.package }}
       - name: Analyze
         run: dart analyze --no-fatal-warnings
         working-directory: packages/${{ matrix.package }}
       - name: Test
         run: dart test
+        working-directory: packages/${{ matrix.package }}
+      - name: Dry-run publish
+        run: dart pub publish --dry-run
         working-directory: packages/${{ matrix.package }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,24 +9,77 @@ on:
 
 jobs:
   publish:
+    environment: pub-dev
     permissions:
       id-token: write # Required for OIDC authentication
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
           sdk: stable
-      - name: Install dependencies
+
+      # ── mineral (packages/core) ──────────────────────────────────────────
+      - name: "core: Install dependencies"
+        if: startsWith(github.ref, 'refs/tags/core-v')
         run: dart pub get
+        working-directory: packages/core
+      - name: "core: Analyze"
+        if: startsWith(github.ref, 'refs/tags/core-v')
+        run: dart analyze
+        working-directory: packages/core
+      - name: "core: Test"
+        if: startsWith(github.ref, 'refs/tags/core-v')
+        run: dart test
+        working-directory: packages/core
+      - name: "core: Dry-run publish"
+        if: startsWith(github.ref, 'refs/tags/core-v')
+        run: dart pub publish --dry-run
+        working-directory: packages/core
       - name: Publish mineral
         if: startsWith(github.ref, 'refs/tags/core-v')
         run: dart pub publish --force
         working-directory: packages/core
+
+      # ── mineral_cache (packages/cache) ───────────────────────────────────
+      - name: "cache: Install dependencies"
+        if: startsWith(github.ref, 'refs/tags/cache-v')
+        run: dart pub get
+        working-directory: packages/cache
+      - name: "cache: Analyze"
+        if: startsWith(github.ref, 'refs/tags/cache-v')
+        run: dart analyze
+        working-directory: packages/cache
+      - name: "cache: Test"
+        if: startsWith(github.ref, 'refs/tags/cache-v')
+        run: dart test
+        working-directory: packages/cache
+      - name: "cache: Dry-run publish"
+        if: startsWith(github.ref, 'refs/tags/cache-v')
+        run: dart pub publish --dry-run
+        working-directory: packages/cache
       - name: Publish mineral_cache
         if: startsWith(github.ref, 'refs/tags/cache-v')
         run: dart pub publish --force
         working-directory: packages/cache
+
+      # ── mineral_test (packages/test) ─────────────────────────────────────
+      - name: "test: Install dependencies"
+        if: startsWith(github.ref, 'refs/tags/test-v')
+        run: dart pub get
+        working-directory: packages/test
+      - name: "test: Analyze"
+        if: startsWith(github.ref, 'refs/tags/test-v')
+        run: dart analyze
+        working-directory: packages/test
+      - name: "test: Test"
+        if: startsWith(github.ref, 'refs/tags/test-v')
+        run: dart test
+        working-directory: packages/test
+      - name: "test: Dry-run publish"
+        if: startsWith(github.ref, 'refs/tags/test-v')
+        run: dart pub publish --dry-run
+        working-directory: packages/test
       - name: Publish mineral_test
         if: startsWith(github.ref, 'refs/tags/test-v')
         run: dart pub publish --force


### PR DESCRIPTION
## Summary
Hardens the release/CI pipeline.

- **publish.yml (H7)**: each package now runs `pub get` → `analyze` → `test` → `pub publish --dry-run` before the gated `pub publish --force`; added `environment: pub-dev` (protected-environment gate) and scoped `id-token: write` to the publish job.
- **M10**: `actions/checkout` and `dart-lang/setup-dart` pinned by full commit SHA (verified) with version comments, in both workflows.
- **ci.yml (L10/L11)**: added `permissions: contents: read`, `dart format --set-exit-if-changed`, and a `pub publish --dry-run` step; actions SHA-pinned.

## Test plan
- [x] Both workflows are valid YAML
- [x] Pinned SHAs re-resolved and match the upstream tags
- [x] `dart analyze packages/core` unaffected — no issues

Note: the `pub-dev` GitHub Environment must be created/configured (protection rules) in repo settings to take effect.

Closes #430