### PR TITLE
fix: TTL fallback, put() contract, memory/Redis copy parity (M22/M24/M25)

### DIFF
--- a/packages/cache/lib/src/providers/memory/memory_provider.dart
+++ b/packages/cache/lib/src/providers/memory/memory_provider.dart
@@ -90,7 +90,7 @@ final class MemoryProvider implements CacheProviderContract {
       _storage.remove(key);
       return null;
     }
-    return entry.value as Map<String, dynamic>?;
+    return _deepCopy(entry.value) as Map<String, dynamic>?;
   }
 
   @override
@@ -127,16 +127,25 @@ final class MemoryProvider implements CacheProviderContract {
   @override
   void put<T>(String key, T object, {Duration? ttl}) {
     final effectiveTtl = ttl ?? _ttlPolicy.ttlFor(key);
-    _storage[key] = _Entry(object, effectiveTtl);
+    _storage[key] = _Entry(_deepCopy(object), effectiveTtl);
   }
 
   @override
   void putMany<T>(Map<String, T> objects, {Duration? ttl}) {
     for (final entry in objects.entries) {
       final effectiveTtl = ttl ?? _ttlPolicy.ttlFor(entry.key);
-      _storage[entry.key] = _Entry(entry.value, effectiveTtl);
+      _storage[entry.key] = _Entry(_deepCopy(entry.value), effectiveTtl);
     }
   }
+
+  /// Returns a structural deep copy of [value] via a JSON round-trip.
+  ///
+  /// The marshaller normalises all entities to `Map<String, dynamic>` before
+  /// caching, so the stored values are always JSON-encodable.  The round-trip
+  /// matches Redis's serialisation semantics: after `put`, the caller cannot
+  /// mutate the cached entry by modifying the original object.
+  static dynamic _deepCopy(dynamic value) =>
+      jsonDecode(jsonEncode(value));
 
   @override
   void remove(String key) => _storage.remove(key);
@@ -168,7 +177,11 @@ final class MemoryProvider implements CacheProviderContract {
 
 final class _Entry {
   _Entry(this.value, Duration? ttl)
-      : expiresAt = ttl == null ? null : DateTime.now().add(ttl);
+      // Duration.zero is treated as "no expiry", matching Redis semantics
+      // where buildSetCommand omits PX for non-positive durations.
+      : expiresAt = (ttl == null || ttl <= Duration.zero)
+            ? null
+            : DateTime.now().add(ttl);
 
   final dynamic value;
   final DateTime? expiresAt;

--- a/packages/cache/test/memory_ttl_test.dart
+++ b/packages/cache/test/memory_ttl_test.dart
@@ -152,6 +152,75 @@ void main() {
       });
     });
   });
+
+  // ── M24: Duration.zero semantics ─────────────────────────────────────────
+
+  group('Duration.zero semantics (M24)', () {
+    test('Duration.zero on put means no expiry (matches Redis semantics)',
+        () async {
+      final provider = MemoryProvider(env);
+      provider.put('k', {'v': 1}, ttl: Duration.zero);
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      // Duration.zero must NOT cause immediate eviction; it means "no expiry",
+      // matching Redis buildSetCommand which emits a plain SET (no PX) for
+      // non-positive durations.
+      expect(provider.has('k'), isTrue);
+      expect(provider.get('k'), {'v': 1});
+    });
+
+    test('Duration.zero via putMany means no expiry', () async {
+      final provider = MemoryProvider(env);
+      provider.putMany({'k1': {'a': 1}, 'k2': {'b': 2}}, ttl: Duration.zero);
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(provider.has('k1'), isTrue);
+      expect(provider.has('k2'), isTrue);
+    });
+  });
+
+  // ── M25: copy-on-store / copy-on-get semantics ────────────────────────────
+
+  group('MemoryProvider copy semantics (M25)', () {
+    test('mutating the original map after put does not corrupt the cache', () {
+      final provider = MemoryProvider(env);
+      final original = <String, dynamic>{'name': 'Alice', 'score': 10};
+      provider.put('users/1', original);
+
+      // Mutate the original object after storing it.
+      original['name'] = 'Eve';
+      original['score'] = 99;
+
+      final cached = provider.get('users/1');
+      expect(cached, {'name': 'Alice', 'score': 10});
+    });
+
+    test('mutating a value returned by get does not corrupt the cache', () {
+      final provider = MemoryProvider(env);
+      provider.put('users/2', {'name': 'Bob', 'score': 5});
+
+      final first = provider.get('users/2')!;
+      first['score'] = 999; // mutate the returned copy
+
+      final second = provider.get('users/2')!;
+      expect(second['score'], 5); // cache is untouched
+    });
+
+    test('putMany copies each entry independently', () {
+      final provider = MemoryProvider(env);
+      final a = <String, dynamic>{'x': 1};
+      final b = <String, dynamic>{'x': 2};
+      provider.putMany({'k1': a, 'k2': b});
+
+      a['x'] = 100;
+      b['x'] = 200;
+
+      expect(provider.get('k1'), {'x': 1});
+      expect(provider.get('k2'), {'x': 2});
+    });
+  });
 }
 
 final class _NoopLogger implements LoggerContract {

--- a/packages/core/lib/src/domains/services/cache/cache_provider_contract.dart
+++ b/packages/core/lib/src/domains/services/cache/cache_provider_contract.dart
@@ -25,13 +25,23 @@ abstract interface class CacheProviderContract {
 
   /// Stores [object] under [key].
   ///
-  /// If [ttl] is provided, the entry expires after that duration. Providers
-  /// that support expiration (e.g. memory, Redis) honor this; providers that
-  /// don't may ignore it. A `null` [ttl] means "never expire".
+  /// [ttl] semantics (identical across all providers):
+  /// - `null` — the TTL policy attached to this provider resolves the
+  ///   duration from the key.  If the policy returns `null` the entry
+  ///   never expires.
+  /// - `Duration.zero` — treated as "no expiry" (equivalent to the policy
+  ///   returning `null`).  Do **not** pass `Duration.zero` expecting
+  ///   immediate eviction.
+  /// - Any positive [Duration] — the entry expires after that duration.
+  ///
+  /// Both providers (memory and Redis) honor these semantics identically and
+  /// store a structural deep copy of [object], so caller mutations after
+  /// `put` cannot corrupt the cached value.
   FutureOr<void> put<T>(String key, T object, {Duration? ttl});
 
   /// Stores all entries from [object]. The optional [ttl] applies uniformly
-  /// to every entry; pass `null` to skip expiration.
+  /// to every entry; pass `null` to let the TTL policy decide per key,
+  /// `Duration.zero` for no expiry.
   FutureOr<void> putMany<T>(Map<String, T> object, {Duration? ttl});
 
   FutureOr<void> remove(String key);

--- a/packages/core/lib/src/domains/services/cache/cache_ttl_policy.dart
+++ b/packages/core/lib/src/domains/services/cache/cache_ttl_policy.dart
@@ -41,7 +41,13 @@ final class CacheTtlPolicy {
 
   static const _disabled = CacheTtlPolicy._([], null);
 
-  static const _defaults = CacheTtlPolicy._(_defaultRules, null);
+  /// Conservative non-null TTL used for any key family not matched by an
+  /// explicit rule.  Chosen to match the shortest top-level family TTL
+  /// (users / invites = 1 h) so unlisted families cannot grow without bound.
+  static const _conservativeFallback = Duration(hours: 1);
+
+  static const _defaults =
+      CacheTtlPolicy._(_defaultRules, _conservativeFallback);
 }
 
 const _defaultRules = <_Rule>[
@@ -61,6 +67,7 @@ const _defaultRules = <_Rule>[
   _Rule._prefix('threads/', Duration(hours: 2)),
   _Rule._prefix('messages/', Duration(minutes: 10)),
   _Rule._prefix('invites/', Duration(hours: 1)),
+  _Rule._prefix('webhooks/', Duration(hours: 1)),
 ];
 
 final class _Rule {

--- a/packages/core/test/services/cache/cache_ttl_policy_test.dart
+++ b/packages/core/test/services/cache/cache_ttl_policy_test.dart
@@ -78,8 +78,14 @@ void main() {
       expect(policy.ttlFor('ref:users/789'), isNull);
     });
 
-    test('unknown keys fall through to null (no expiry)', () {
-      expect(policy.ttlFor('foo/bar'), isNull);
+    test('webhooks are cached for 1 hour', () {
+      expect(policy.ttlFor('webhooks/123456789'), const Duration(hours: 1));
+    });
+
+    test('unlisted key families fall through to the conservative 1-hour default',
+        () {
+      expect(policy.ttlFor('foo/bar'), const Duration(hours: 1));
+      expect(policy.ttlFor('arbitrary/unlisted/key'), const Duration(hours: 1));
     });
   });
 


### PR DESCRIPTION
## Summary
- **M22**: TTL policy now has a `webhooks/` rule (1h) and a conservative non-null fallback (1h) for unlisted families instead of "never expire" → no unbounded growth. (`disabled()` keeps the legacy v4 null fallback.)
- **M24**: unified `Duration.zero` = **no expiry** across both providers; corrected the `put()` contract doc (null → policy, zero → no expiry, positive → that duration, both providers deep-copy).
- **M25**: `MemoryProvider` now deep-copies on `put`/`putMany`/`get` (JSON round-trip; stored values are always normalized maps), matching Redis — caller mutations can no longer corrupt the cache.

## Test plan
- [x] `dart analyze packages/core packages/cache` — no issues
- [x] `dart test packages/cache` — 86/86 (+ Duration.zero & copy-semantics tests)
- [x] `dart test packages/core` — 1323/1323 (+ TTL fallback tests)

Closes #434