### PR TITLE
chore: enable strict lints; typed throw; runtime pubspec guard (M9/M6/M8)

### DIFF
--- a/packages/cache/analysis_options.yaml
+++ b/packages/cache/analysis_options.yaml
@@ -13,11 +13,10 @@
 
 include: package:lints/recommended.yaml
 
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
+linter:
+  rules:
+    unawaited_futures: true
+    only_throw_errors: true
 
 # analyzer:
 #   exclude:

--- a/packages/core/analysis_options.yaml
+++ b/packages/core/analysis_options.yaml
@@ -52,6 +52,8 @@ linter:
     use_is_even_rather_than_modulo: true
     use_named_constants: true
     use_string_buffers: true
+    unawaited_futures: true
+    only_throw_errors: true
 
     # analyzer:
     #   exclude:

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/select_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/select_interaction_create_packet.dart
@@ -56,15 +56,15 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
 
       switch (selectMenuType) {
         case ComponentType.channelSelectMenu:
-          _dispatchChannelSelectMenu(ctx, payload, dispatch);
+          await _dispatchChannelSelectMenu(ctx, payload, dispatch);
         case ComponentType.roleSelectMenu:
-          _dispatchRoleSelectMenu(ctx, payload, dispatch);
+          await _dispatchRoleSelectMenu(ctx, payload, dispatch);
         case ComponentType.userSelectMenu:
-          _dispatchUserSelectMenu(ctx, payload, dispatch);
+          await _dispatchUserSelectMenu(ctx, payload, dispatch);
         case ComponentType.mentionableSelectMenu:
-          _dispatchMentionableSelectMenu(ctx, payload, dispatch);
+          await _dispatchMentionableSelectMenu(ctx, payload, dispatch);
         case ComponentType.textSelectMenu:
-          _dispatchTextSelectMenu(ctx, payload, dispatch);
+          await _dispatchTextSelectMenu(ctx, payload, dispatch);
         default:
           _logger.warn('Select menu type $selectMenuType not found');
       }

--- a/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
@@ -91,7 +91,7 @@ final class ShardAuthentication implements ShardAuthenticationContract {
     final message = ShardMessageBuilder()
       ..setOpCode(OpCode.heartbeat)
       ..setPayload(sequence);
-    shard.client.send(message.build());
+    await shard.client.send(message.build());
 
     attempts++;
   }

--- a/packages/core/lib/src/infrastructure/internals/wss/running_strategies/default_running_strategy.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/running_strategies/default_running_strategy.dart
@@ -7,9 +7,8 @@ import 'package:mineral/src/domains/services/packets/packet_dispatcher.dart';
 import 'package:mineral/src/domains/services/wss/running_strategy.dart';
 import 'package:mineral/src/infrastructure/services/wss/websocket_message.dart';
 import 'package:path/path.dart' as path;
-import 'package:yaml/yaml.dart';
 
-final class DefaultRunningStrategy implements RunningStrategy {
+class DefaultRunningStrategy implements RunningStrategy {
   final PacketDispatcherContract packetDispatcher;
   final LoggerContract _logger;
 
@@ -18,24 +17,44 @@ final class DefaultRunningStrategy implements RunningStrategy {
 
   @override
   Future<void> init(RunningStrategyFactory createShards) async {
-    final package = await readPubspec(Directory.current.path);
-
-    final coreVersion = package['dependencies']['mineral'];
-    String version = 'not found';
-
-    if (coreVersion case final YamlMap dep) {
-      if (dep['path'] != null) {
-        final location = path.join(Directory.current.path, dep['path'] as String);
-        final remoteCorePackage = await readPubspec(location);
-        version = remoteCorePackage['version'] as String;
-      }
-    } else {
-      version = package['dependencies']['mineral'] as String;
-    }
-
+    final version = await resolveVersion();
     _logger.info('Core version: $version');
-
     await createShards(this);
+  }
+
+  /// Reads the core version from pubspec.yaml files at runtime.
+  ///
+  /// Returns 'unknown' if the pubspec cannot be read (e.g. in a compiled
+  /// binary or Docker image without sources present). All dynamic map accesses
+  /// use safe [is]-checks to avoid [TypeError]/[NoSuchMethodError].
+  Future<String> resolveVersion() async {
+    try {
+      final package = await readPubspec(Directory.current.path);
+
+      final deps = package['dependencies'];
+      if (deps is! Map) {
+        return 'unknown';
+      }
+
+      final coreVersion = deps['mineral'];
+
+      // YamlMap is a subtype of Map; accepting Map covers both real YAML
+      // parsing and plain-Map test doubles.
+      if (coreVersion is Map) {
+        final depPath = coreVersion['path'];
+        if (depPath is! String) {
+          return 'unknown';
+        }
+        final location = path.join(Directory.current.path, depPath);
+        final remoteCorePackage = await readPubspec(location);
+        final version = remoteCorePackage['version'];
+        return version is String ? version : 'unknown';
+      }
+
+      return coreVersion is String ? coreVersion : 'unknown';
+    } on Exception {
+      return 'unknown';
+    }
   }
 
   Future<Map> readPubspec(String location) async {

--- a/packages/core/lib/src/infrastructure/internals/wss/shard.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/shard.dart
@@ -93,7 +93,7 @@ final class Shard implements ShardContract {
 
     client.interceptor.request.add(wss.config.encoding.encode);
 
-    client.listen((message) {
+    await client.listen((message) {
       if (message.content
           case ShardMessage(opCode: final code, payload: final payload)) {
         try {

--- a/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
@@ -180,7 +180,7 @@ final class WebsocketOrchestrator implements WebsocketOrchestratorContract {
         response.body as Map<String, dynamic>,
       int() when _httpClient.status.isError(response.statusCode) =>
         throw TokenException('This token is invalid or expired'),
-      _ => throw (response.bodyString),
+      _ => throw HttpStatusException(response.statusCode, response.bodyString),
     };
   }
 

--- a/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
+++ b/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
@@ -99,7 +99,7 @@ final class WebsocketClientImpl implements WebsocketClient {
 
       if (_onOpen != null) {
         final firstMessage = await stream?.first;
-        _handleMessage(_onOpen, firstMessage);
+        await _handleMessage(_onOpen, firstMessage);
       }
     } on io.WebSocketException catch (err) {
       _logger.error('WebSocket connection failed: $err');
@@ -115,7 +115,7 @@ final class WebsocketClientImpl implements WebsocketClient {
   Future<void> disconnect({int? code = 1000, String? reason}) async {
     _refillTimer?.cancel();
     _sendQueue.clear();
-    _channelListener?.cancel();
+    await _channelListener?.cancel();
     await _channel?.close(code, reason);
   }
 

--- a/packages/core/test/wss/default_running_strategy_test.dart
+++ b/packages/core/test/wss/default_running_strategy_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:mineral/src/domains/services/packets/packet_dispatcher.dart';
+import 'package:mineral/src/domains/services/packets/packet_type.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/wss/running_strategies/default_running_strategy.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_logger.dart';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// A [DefaultRunningStrategy] subclass that overrides [readPubspec] so tests
+/// control what the strategy reads without touching the filesystem.
+final class _FakeReadStrategy extends DefaultRunningStrategy {
+  final Future<Map<dynamic, dynamic>> Function(String) _readFn;
+
+  _FakeReadStrategy(this._readFn)
+      : super(
+          _NoopPacketDispatcher(),
+          logger: FakeLogger(),
+        );
+
+  @override
+  Future<Map<dynamic, dynamic>> readPubspec(String location) => _readFn(location);
+}
+
+/// Minimal [PacketDispatcherContract] stub — tests here do not exercise it.
+final class _NoopPacketDispatcher implements PacketDispatcherContract {
+  @override
+  void dispatch(dynamic payload) {}
+
+  @override
+  void listen(PacketTypeContract packet,
+      Function(ShardMessage, DispatchEvent) listener) {}
+
+  @override
+  void dispose() {}
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+void main() {
+  group('DefaultRunningStrategy.resolveVersion (M8 fallback)', () {
+    test('returns version string from a plain mineral dependency', () async {
+      final strategy = _FakeReadStrategy((_) async => {
+            'dependencies': {'mineral': '5.0.0'},
+          });
+
+      expect(await strategy.resolveVersion(), equals('5.0.0'));
+    });
+
+    test('returns version from path-based mineral dependency', () async {
+      final strategy = _FakeReadStrategy((location) async {
+        if (location.endsWith('my_core')) {
+          return {'version': '5.1.0'};
+        }
+        return {
+          'dependencies': {
+            'mineral': {'path': 'my_core'},
+          },
+        };
+      });
+
+      expect(await strategy.resolveVersion(), equals('5.1.0'));
+    });
+
+    test('returns "unknown" when pubspec file is missing (FileSystemException)',
+        () async {
+      final strategy = _FakeReadStrategy(
+          (_) => Future.error(FileSystemException('not found')));
+
+      expect(await strategy.resolveVersion(), equals('unknown'));
+    });
+
+    test('returns "unknown" when dependencies key is absent', () async {
+      final strategy = _FakeReadStrategy((_) async => <dynamic, dynamic>{});
+
+      expect(await strategy.resolveVersion(), equals('unknown'));
+    });
+
+    test('returns "unknown" when mineral version value is not a String',
+        () async {
+      final strategy = _FakeReadStrategy((_) async => {
+            'dependencies': {'mineral': 42},
+          });
+
+      expect(await strategy.resolveVersion(), equals('unknown'));
+    });
+
+    test(
+        'returns "unknown" when path dep but remote pubspec version is not a String',
+        () async {
+      final strategy = _FakeReadStrategy((location) async {
+        if (location.endsWith('my_core')) {
+          return {'version': 999};
+        }
+        return {
+          'dependencies': {
+            'mineral': {'path': 'my_core'},
+          },
+        };
+      });
+
+      expect(await strategy.resolveVersion(), equals('unknown'));
+    });
+
+    test('returns "unknown" when path dep has no path key', () async {
+      final strategy = _FakeReadStrategy((_) async => {
+            'dependencies': {
+              'mineral': {'git': 'https://example.com'},
+            },
+          });
+
+      expect(await strategy.resolveVersion(), equals('unknown'));
+    });
+  });
+}

--- a/packages/test/analysis_options.yaml
+++ b/packages/test/analysis_options.yaml
@@ -44,3 +44,5 @@ linter:
     use_is_even_rather_than_modulo: true
     use_named_constants: true
     use_string_buffers: true
+    unawaited_futures: true
+    only_throw_errors: true


### PR DESCRIPTION
## Summary
- **M9**: enabled `unawaited_futures` + `only_throw_errors` in all three packages' `analysis_options.yaml`. Fixed all 9 surfaced violations (1 string-throw + 8 dropped futures — all genuine sequencing/error-propagation bugs, `await`ed; no `unawaited()` needed, zero `// ignore:`).
- **M6**: `throw (response.bodyString)` → `throw HttpStatusException(statusCode, body)` (extends `Exception`, caught by `Kernel.init()`'s `on Exception`).
- **M8**: `DefaultRunningStrategy.resolveVersion()` extracted + wrapped (IO via `on Exception`, dynamic access via `is`-checks) → returns `'unknown'` instead of crashing boot when sources/pubspec are unavailable (compiled/Docker).

## Test plan
- [x] `dart analyze packages/core packages/cache packages/test` — no issues (with new lints active)
- [x] `dart test packages/core` 1359/1359, `cache` 86/86, `test` 19/19
- [x] +7 tests for `resolveVersion()` fallback paths

Closes #438