### PR TITLE
refactor: keep build() synchronous, move cache init to Client.init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Register providers and start the bot. Each provider groups related commands, eve
 
 ```dart
 void main() async {
-  final client = await ClientBuilder()
+  final client = ClientBuilder()
     .setIntent(Intent.allNonPrivileged)
     .registerProvider(WelcomeProvider.new)
     .registerProvider(FeedbackProvider.new)

--- a/packages/core/example/main.dart
+++ b/packages/core/example/main.dart
@@ -10,7 +10,7 @@ import 'welcome/welcome_provider.dart';
 
 // Run from `hmr` command, configuration available via `pubspec.yaml`
 void main() async {
-  final client = await ClientBuilder()
+  final client = ClientBuilder()
       .setIntent(Intent.allNonPrivileged)
       .registerProvider(WelcomeProvider.new)
       .registerProvider(PollProvider.new)

--- a/packages/core/lib/src/domains/client/client.dart
+++ b/packages/core/lib/src/domains/client/client.dart
@@ -18,6 +18,8 @@ final class Client {
 
   final CommandInteractionManagerContract _commands;
 
+  final CacheProviderContract? _cache;
+
   IocContainer get container => ioc;
 
   LoggerContract get logger => _kernel.logger;
@@ -30,9 +32,11 @@ final class Client {
     Kernel kernel, {
     required this.rest,
     required CommandInteractionManagerContract commandManager,
+    CacheProviderContract? cache,
   })  : events = EventBucket(kernel),
         commands = CommandBucket(commandManager),
         _commands = commandManager,
+        _cache = cache,
         _kernel = kernel;
 
   void register<T>(Listenable Function() constructor) {
@@ -54,7 +58,10 @@ final class Client {
     _commands.onCommandError = handler;
   }
 
-  Future<void> init() => _kernel.init();
+  Future<void> init() async {
+    await _cache?.init();
+    await _kernel.init();
+  }
 
   Future<void> dispose() => _kernel.dispose();
 }

--- a/packages/core/lib/src/domains/client/client_builder.dart
+++ b/packages/core/lib/src/domains/client/client_builder.dart
@@ -82,13 +82,7 @@ final class ClientBuilder {
     env.defineOf(AppEnv.new);
   }
 
-  Future<void> _createCache() async {
-    if (_cache case final CacheProviderContract cache) {
-      await cache.init();
-    }
-  }
-
-  Future<Client> build() async {
+  Client build() {
     _validateEnvironment();
 
     final logLevel = env.get(AppEnv.logLevel);
@@ -109,8 +103,6 @@ final class ClientBuilder {
     final httpLogger = labelled('http');
     final dataStoreLogger = labelled('datastore');
     final marshallerLogger = labelled('marshaller');
-
-    await _createCache();
 
     final token = env.get<String>(AppEnv.token, defaultValue: _token);
     final intent = env.get<int>(AppEnv.intent, defaultValue: _intent);
@@ -245,6 +237,7 @@ final class ClientBuilder {
       appState.kernel,
       rest: appState.dataStore,
       commandManager: appState.commandManager,
+      cache: _cache,
     );
 
     for (final provider in _providers) {


### PR DESCRIPTION
## Summary
Follow-up correction to #435: `ClientBuilder.build()` should stay synchronous (builder pattern). The awaited `cache.init()` now lives in `Client.init()` instead.

- `ClientBuilder.build()` reverts to `Client build()` (returns `Client`, not `Future<Client>`); `_createCache()` helper removed.
- `Client` takes an optional `cache` and `Client.init()` does `await _cache?.init();` before `await _kernel.init();` — preserving the M20/M7 fix (cache connect/AUTH failure still fails boot cleanly, just at `init()` time).
- Reverted the `await ...build()` in `example/main.dart` and `README.md`.

The Redis correctness fixes from #435 (length, MGET race, empty lists) are untouched.

## Test plan
- [x] `dart analyze packages/core packages/cache` — no issues
- [x] `dart test packages/core` — 1359/1359