### PR TITLE
chore: fatal CI warnings + honest SDK floor (M12/M11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
         working-directory: packages/${{ matrix.package }}
       - name: Analyze
-        run: dart analyze --no-fatal-warnings
+        run: dart analyze
         working-directory: packages/${{ matrix.package }}
       - name: Test
         run: dart test

--- a/packages/cache/pubspec.yaml
+++ b/packages/cache/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 repository: https://github.com/mineral-dart/core
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 resolution: workspace
 

--- a/packages/core/lib/src/api/common/components/media_item.dart
+++ b/packages/core/lib/src/api/common/components/media_item.dart
@@ -66,7 +66,7 @@ final class MediaItem {
     return {
       if (description != null) 'description': description,
       'url': url,
-      if (bytes != null) 'bytes': bytes!,
+      'bytes': ?bytes,
       if (spoiler != null) 'spoiler': spoiler,
       'media': {
         'url': url,

--- a/packages/core/lib/src/api/guild/managers/member_voice_manager.dart
+++ b/packages/core/lib/src/api/guild/managers/member_voice_manager.dart
@@ -208,9 +208,9 @@ final class MemberVoiceManager {
       memberId: _memberId.value,
       reason: reason,
       payload: {
-        if (mute != null) 'mute': mute,
-        if (deafen != null) 'deaf': deafen,
-        if (channelId != null) 'channel_id': channelId,
+        'mute': ?mute,
+        'deaf': ?deafen,
+        'channel_id': ?channelId,
       },
     );
   }

--- a/packages/core/lib/src/api/guild/role.dart
+++ b/packages/core/lib/src/api/guild/role.dart
@@ -127,11 +127,11 @@ final class Role {
       guildId: guildId.value,
       reason: reason,
       payload: {
-        if (name != null) 'name': name,
+        'name': ?name,
         if (color != null) 'color': color.toInt(),
-        if (hoist != null) 'hoist': hoist,
-        if (emoji != null) 'unicode_emoji': emoji,
-        if (mentionable != null) 'mentionable': mentionable,
+        'hoist': ?hoist,
+        'unicode_emoji': ?emoji,
+        'mentionable': ?mentionable,
       },
     );
   }

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/guild_scheduled_event_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/guild_scheduled_event_part.dart
@@ -81,8 +81,8 @@ final class GuildScheduledEventPart extends BasePart
       if (entityMetadata != null) 'entity_metadata': entityMetadata.toJson(),
       if (scheduledEndTime != null)
         'scheduled_end_time': scheduledEndTime.toIso8601String(),
-      if (description != null) 'description': description,
-      if (image != null) 'image': image,
+      'description': ?description,
+      'image': ?image,
     };
 
     final req = Request.json(
@@ -117,16 +117,16 @@ final class GuildScheduledEventPart extends BasePart
     final body = <String, dynamic>{
       if (channelId != null) 'channel_id': channelId.toString(),
       if (entityMetadata != null) 'entity_metadata': entityMetadata.toJson(),
-      if (name != null) 'name': name,
+      'name': ?name,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
       if (scheduledStartTime != null)
         'scheduled_start_time': scheduledStartTime.toIso8601String(),
       if (scheduledEndTime != null)
         'scheduled_end_time': scheduledEndTime.toIso8601String(),
-      if (description != null) 'description': description,
+      'description': ?description,
       if (entityType != null) 'entity_type': entityType.value,
       if (status != null) 'status': status.value,
-      if (image != null) 'image': image,
+      'image': ?image,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/invite_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/invite_part.dart
@@ -59,9 +59,9 @@ final class InvitePart extends BasePart implements InvitePartContract {
   }) async {
     final body = <String, dynamic>{
       if (maxAge != null) 'max_age': maxAge.inSeconds,
-      if (maxUses != null) 'max_uses': maxUses,
-      if (temporary != null) 'temporary': temporary,
-      if (unique != null) 'unique': unique,
+      'max_uses': ?maxUses,
+      'temporary': ?temporary,
+      'unique': ?unique,
       if (targetType != null) 'target_type': targetType.value,
       if (targetUserId != null) 'target_user_id': targetUserId.toString(),
       if (targetApplicationId != null)

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/message_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/message_part.dart
@@ -20,7 +20,7 @@ final class MessagePart extends BasePart implements MessagePartContract {
       if (around != null) 'around': around.value,
       if (before != null) 'before': before.value,
       if (after != null) 'after': after.value,
-      if (limit != null) 'limit': limit,
+      'limit': ?limit,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
@@ -35,7 +35,7 @@ final class OnboardingPart extends BasePart
       if (defaultChannelIds != null)
         'default_channel_ids':
             defaultChannelIds.map((id) => id.toString()).toList(),
-      if (enabled != null) 'enabled': enabled,
+      'enabled': ?enabled,
       if (mode != null) 'mode': mode.value,
     };
 

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/soundboard_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/soundboard_part.dart
@@ -55,9 +55,9 @@ final class SoundboardPart extends BasePart implements SoundboardPartContract {
     final body = <String, dynamic>{
       'name': name,
       'sound': sound,
-      if (volume != null) 'volume': volume,
+      'volume': ?volume,
       if (emojiId != null) 'emoji_id': Snowflake.parse(emojiId).value,
-      if (emojiName != null) 'emoji_name': emojiName,
+      'emoji_name': ?emojiName,
     };
 
     final req = Request.json(
@@ -83,10 +83,10 @@ final class SoundboardPart extends BasePart implements SoundboardPartContract {
     final parsedGuildId = Snowflake.parse(guildId);
     final id = Snowflake.parse(soundId);
     final body = <String, dynamic>{
-      if (name != null) 'name': name,
-      if (volume != null) 'volume': volume,
+      'name': ?name,
+      'volume': ?volume,
       if (emojiId != null) 'emoji_id': Snowflake.parse(emojiId).value,
-      if (emojiName != null) 'emoji_name': emojiName,
+      'emoji_name': ?emojiName,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/stage_instance_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/stage_instance_part.dart
@@ -30,8 +30,7 @@ final class StageInstancePart extends BasePart
       'channel_id': Snowflake.parse(channelId).value,
       'topic': topic,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
-      if (sendStartNotification != null)
-        'send_start_notification': sendStartNotification,
+      'send_start_notification': ?sendStartNotification,
       if (guildScheduledEventId != null)
         'guild_scheduled_event_id':
             Snowflake.parse(guildScheduledEventId).value,
@@ -57,7 +56,7 @@ final class StageInstancePart extends BasePart
     final id = Snowflake.parse(channelId);
 
     final body = <String, dynamic>{
-      if (topic != null) 'topic': topic,
+      'topic': ?topic,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
     };
 

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/template_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/template_part.dart
@@ -34,7 +34,7 @@ final class TemplatePart extends BasePart implements TemplatePartContract {
     final parsedGuildId = Snowflake.parse(guildId);
     final body = <String, dynamic>{
       'name': name,
-      if (description != null) 'description': description,
+      'description': ?description,
     };
     final req = Request.json(endpoint: '/guilds/$parsedGuildId/templates', body: body);
     final result =
@@ -61,8 +61,8 @@ final class TemplatePart extends BasePart implements TemplatePartContract {
   }) async {
     final parsedGuildId = Snowflake.parse(guildId);
     final body = <String, dynamic>{
-      if (name != null) 'name': name,
-      if (description != null) 'description': description,
+      'name': ?name,
+      'description': ?description,
     };
     final req = Request.json(
         endpoint: '/guilds/$parsedGuildId/templates/$code', body: body);

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/webhook_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/webhook_part.dart
@@ -70,7 +70,7 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
   }) async {
     final body = <String, dynamic>{
       'name': name,
-      if (avatar != null) 'avatar': avatar,
+      'avatar': ?avatar,
     };
 
     final req = Request.json(
@@ -95,8 +95,8 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
     String? reason,
   }) async {
     final body = <String, dynamic>{
-      if (name != null) 'name': name,
-      if (avatar != null) 'avatar': avatar,
+      'name': ?name,
+      'avatar': ?avatar,
       if (channelId != null) 'channel_id': channelId.toString(),
     };
 
@@ -121,8 +121,8 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
     String? avatar,
   }) async {
     final body = <String, dynamic>{
-      if (name != null) 'name': name,
-      if (avatar != null) 'avatar': avatar,
+      'name': ?name,
+      'avatar': ?avatar,
     };
 
     final req =

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/welcome_screen_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/welcome_screen_part.dart
@@ -29,9 +29,9 @@ final class WelcomeScreenPart extends BasePart
     final parsedGuildId = Snowflake.parse(guildId);
 
     final body = <String, dynamic>{
-      if (enabled != null) 'enabled': enabled,
-      if (welcomeChannels != null) 'welcome_channels': welcomeChannels,
-      if (description != null) 'description': description,
+      'enabled': ?enabled,
+      'welcome_channels': ?welcomeChannels,
+      'description': ?description,
     };
 
     final req = Request.json(

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -14,7 +14,7 @@ hmr:
   entrypoint: bin/main.dart
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 resolution: workspace
 

--- a/packages/core/test/datastore/parts/monetization_part_test.dart
+++ b/packages/core/test/datastore/parts/monetization_part_test.dart
@@ -42,8 +42,8 @@ Map<String, dynamic> _entitlementPayload({
       'application_id': applicationId,
       'type': type,
       'deleted': deleted,
-      if (userId != null) 'user_id': userId,
-      if (guildId != null) 'guild_id': guildId,
+      'user_id': ?userId,
+      'guild_id': ?guildId,
     };
 
 Map<String, dynamic> _subscriptionPayload({

--- a/packages/core/test/datastore/parts/soundboard_part_test.dart
+++ b/packages/core/test/datastore/parts/soundboard_part_test.dart
@@ -27,11 +27,11 @@ Map<String, dynamic> _soundPayload({
       'sound_id': id ?? _soundId,
       'name': name,
       'volume': volume,
-      if (emojiId != null) 'emoji_id': emojiId,
-      if (emojiName != null) 'emoji_name': emojiName,
-      if (guildId != null) 'guild_id': guildId,
+      'emoji_id': ?emojiId,
+      'emoji_name': ?emojiName,
+      'guild_id': ?guildId,
       'available': available,
-      if (user != null) 'user': user,
+      'user': ?user,
     };
 
 (SoundboardPart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/core/test/datastore/parts/stage_instance_part_test.dart
+++ b/packages/core/test/datastore/parts/stage_instance_part_test.dart
@@ -23,8 +23,7 @@ Map<String, dynamic> _stageInstancePayload({
       'channel_id': _channelId,
       'topic': topic ?? 'Test Topic',
       'privacy_level': privacyLevel,
-      if (guildScheduledEventId != null)
-        'guild_scheduled_event_id': guildScheduledEventId,
+      'guild_scheduled_event_id': ?guildScheduledEventId,
     };
 
 (StageInstancePart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/core/test/datastore/parts/template_part_test.dart
+++ b/packages/core/test/datastore/parts/template_part_test.dart
@@ -38,7 +38,7 @@ Map<String, dynamic> _templatePayload({
       'updated_at': updatedAt,
       'source_guild_id': sourceGuildId,
       'serialized_source_guild': {'name': 'Test Guild'},
-      if (isDirty != null) 'is_dirty': isDirty,
+      'is_dirty': ?isDirty,
     };
 
 (TemplatePart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/core/test/wss/shard_authentication_test.dart
+++ b/packages/core/test/wss/shard_authentication_test.dart
@@ -133,7 +133,7 @@ void main() {
         // so we absorb the async error.
         runZonedGuarded(() {
           auth.heartbeat();
-        }, (_, __) {});
+        }, (_, _) {});
 
         // Give a tick for the async error log
         await Future<void>.delayed(Duration.zero);
@@ -199,7 +199,7 @@ void main() {
         // Trigger reconnects to increment the counter
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         // Give async reconnect time to start
         await Future<void>.delayed(Duration.zero);
@@ -209,7 +209,7 @@ void main() {
         // Should be able to reconnect again without hitting max
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -246,7 +246,7 @@ void main() {
       test('disconnects the client', () {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.disconnected, isTrue);
       });
@@ -256,7 +256,7 @@ void main() {
 
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.attempts, equals(0));
       });
@@ -264,7 +264,7 @@ void main() {
       test('sets intentionalDisconnect to true', () {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.intentionalDisconnect, isTrue);
       });
@@ -272,7 +272,7 @@ void main() {
       test('uses internal close code 4900', () {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.lastDisconnectCode, equals(4900));
       });
@@ -280,7 +280,7 @@ void main() {
       test('logs reconnect warning', () async {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -292,7 +292,7 @@ void main() {
       test('disconnects client', () {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.disconnected, isTrue);
       });
@@ -302,7 +302,7 @@ void main() {
 
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.attempts, equals(0));
       });
@@ -310,7 +310,7 @@ void main() {
       test('sets intentionalDisconnect to true', () {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.intentionalDisconnect, isTrue);
       });
@@ -318,7 +318,7 @@ void main() {
       test('uses internal close code 4900', () {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.lastDisconnectCode, equals(4900));
       });

--- a/packages/core/test/wss/shard_network_error_test.dart
+++ b/packages/core/test/wss/shard_network_error_test.dart
@@ -38,7 +38,7 @@ Object? _dispatchSilently(void Function() fn) {
     } on Object catch (e) {
       caught = e;
     }
-  }, (_, __) {
+  }, (_, _) {
     // Silently absorb uncaught async errors from resume()/reconnect()
   });
   return caught;

--- a/packages/core/test/wss/shard_reconnection_test.dart
+++ b/packages/core/test/wss/shard_reconnection_test.dart
@@ -54,7 +54,7 @@ void main() {
       test('disconnects with internal close code 4900', () {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.disconnected, isTrue);
         expect(fakeClient.lastDisconnectCode, equals(4900));
@@ -67,7 +67,7 @@ void main() {
 
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.attempts, equals(0));
       });
@@ -75,7 +75,7 @@ void main() {
       test('sets intentionalDisconnect to true', () {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.intentionalDisconnect, isTrue);
       });
@@ -83,7 +83,7 @@ void main() {
       test('logs reconnect warning with shard name', () async {
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -96,7 +96,7 @@ void main() {
       test('disconnects with internal close code 4900', () {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(fakeClient.disconnected, isTrue);
         expect(fakeClient.lastDisconnectCode, equals(4900));
@@ -115,7 +115,7 @@ void main() {
         // shard.init(), then simulate the identify call that would follow.
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -137,7 +137,7 @@ void main() {
       test('sets intentionalDisconnect to true', () {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         expect(auth.intentionalDisconnect, isTrue);
       });
@@ -145,7 +145,7 @@ void main() {
       test('logs resuming warning with shard name', () async {
         runZonedGuarded(() {
           auth.resume();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -224,7 +224,7 @@ void main() {
         // Increment reconnect attempts first
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -238,7 +238,7 @@ void main() {
         // (if _reconnectAttempts was not reset, this could fail with max=3)
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -263,7 +263,7 @@ void main() {
         // Trigger a reconnect to increment _reconnectAttempts
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -273,7 +273,7 @@ void main() {
         // Should be able to reconnect again from attempt 1
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
@@ -293,14 +293,14 @@ void main() {
         // First reconnect is allowed (attempt 1)
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 
         // Second would throw FatalGatewayException
         runZonedGuarded(() {
           auth.reconnect();
-        }, (_, __) {});
+        }, (_, _) {});
 
         await Future<void>.delayed(Duration.zero);
 

--- a/packages/test/pubspec.yaml
+++ b/packages/test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0-dev.1
 repository: https://github.com/mineral-dart/core
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 resolution: workspace
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mineral_workspace
 publish_to: none
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 workspace:
   - packages/core


### PR DESCRIPTION
## Summary
- **M12**: removed `--no-fatal-warnings` from CI `dart analyze` — warnings now fail CI.
- **M11**: raised the SDK floor `>=3.5.0` → `>=3.9.0` across all manifests to match the lockfile reality (the old bound was never tested and is contradicted by `pubspec.lock`).
- The language-version bump to 3.9 surfaced 71 info-level lints (`use_null_aware_elements`, `unnecessary_underscores`); all auto-fixed via `dart fix` (no behavior change).

## Test plan
- [x] `dart pub get` resolves
- [x] `dart analyze packages/core packages/cache packages/test` — no issues
- [x] `dart test` — core 1359, cache 86, test 19

Closes #439