### PR TITLE
refactor: inject CacheConfig; remove invalidation service-locator (M2/M23)

### DIFF
--- a/packages/cache/lib/src/providers/memory/memory_provider.dart
+++ b/packages/cache/lib/src/providers/memory/memory_provider.dart
@@ -9,14 +9,14 @@ final class MemoryProvider implements CacheProviderContract {
   final Map<String, _Entry> _storage = {};
   Timer? _sweeper;
 
+  @override
+  CacheConfig config = CacheConfig.defaults();
+
   LoggerContract get logger => ioc.resolve<LoggerContract>();
 
-  CacheTtlPolicy get _ttlPolicy =>
-      ioc.resolveOrNull<CacheConfig>()?.ttlPolicy ??
-      CacheTtlPolicy.disabled();
+  CacheTtlPolicy get _ttlPolicy => config.ttlPolicy;
 
-  Duration get _sweeperInterval =>
-      ioc.resolveOrNull<CacheConfig>()?.sweeperInterval ?? Duration.zero;
+  Duration get _sweeperInterval => config.sweeperInterval;
 
   MemoryProvider(Env env);
 

--- a/packages/cache/lib/src/providers/redis/redis_provider.dart
+++ b/packages/cache/lib/src/providers/redis/redis_provider.dart
@@ -17,11 +17,12 @@ final class RedisProvider implements CacheProviderContract {
 
   String? _password;
 
+  @override
+  CacheConfig config = CacheConfig.defaults();
+
   LoggerContract get logger => ioc.resolve<LoggerContract>();
 
-  CacheTtlPolicy get _ttlPolicy =>
-      ioc.resolveOrNull<CacheConfig>()?.ttlPolicy ??
-      CacheTtlPolicy.disabled();
+  CacheTtlPolicy get _ttlPolicy => config.ttlPolicy;
 
   RedisProvider({required String host, required int port, String? password})
       : _password = password {

--- a/packages/cache/test/memory_ttl_test.dart
+++ b/packages/cache/test/memory_ttl_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(provider.get('key'), isNull);
     });
 
-    test('entries without ttl never expire (no CacheConfig in IoC)',
+    test('entries without ttl never expire (default config has disabled TTL policy)',
         () async {
       final provider = MemoryProvider(env);
       provider.put('key', {'a': 1});
@@ -91,65 +91,72 @@ void main() {
     });
   });
 
-  group('MemoryProvider with CacheConfig in IoC', () {
-    test('put without ttl uses the configured policy', () async {
-      final container = IocContainer()
-        ..bind<CacheConfig>(() => CacheConfig(
-              ttlPolicy: CacheTtlPolicy.disabled().override({
-                'users/': const Duration(milliseconds: 20),
-              }),
-            ));
+  // ── M23: provider holds its own CacheConfig (no IoC required) ────────────
 
-      await runWithIoc(container, () async {
-        final provider = MemoryProvider(env);
-        provider.put('users/1', {'id': 1});
+  group('MemoryProvider with injected CacheConfig (M23)', () {
+    test('put without ttl uses the policy from injected config', () async {
+      final provider = MemoryProvider(env)
+        ..config = CacheConfig(
+          ttlPolicy: CacheTtlPolicy.disabled().override({
+            'users/': const Duration(milliseconds: 20),
+          }),
+        );
+      provider.put('users/1', {'id': 1});
 
-        expect(provider.has('users/1'), isTrue);
+      expect(provider.has('users/1'), isTrue);
 
-        await Future<void>.delayed(const Duration(milliseconds: 40));
+      await Future<void>.delayed(const Duration(milliseconds: 40));
 
-        expect(provider.has('users/1'), isFalse);
-      });
+      expect(provider.has('users/1'), isFalse);
     });
 
-    test('explicit ttl on put overrides the policy', () async {
-      final container = IocContainer()
-        ..bind<CacheConfig>(() => CacheConfig(
-              ttlPolicy: CacheTtlPolicy.disabled().override({
-                'users/': const Duration(milliseconds: 20),
-              }),
-            ));
+    test('explicit ttl on put overrides the injected policy', () async {
+      final provider = MemoryProvider(env)
+        ..config = CacheConfig(
+          ttlPolicy: CacheTtlPolicy.disabled().override({
+            'users/': const Duration(milliseconds: 20),
+          }),
+        );
+      provider.put('users/1', {'id': 1}, ttl: const Duration(seconds: 30));
 
-      await runWithIoc(container, () async {
-        final provider = MemoryProvider(env);
-        provider.put('users/1', {'id': 1}, ttl: const Duration(seconds: 30));
+      await Future<void>.delayed(const Duration(milliseconds: 40));
 
-        await Future<void>.delayed(const Duration(milliseconds: 40));
-
-        expect(provider.has('users/1'), isTrue);
-      });
+      expect(provider.has('users/1'), isTrue);
     });
 
-    test('sweeper actively removes expired entries', () async {
+    test('sweeper actively removes expired entries when configured via injected config',
+        () async {
+      final provider = MemoryProvider(env)
+        ..config = CacheConfig(
+          sweeperInterval: const Duration(milliseconds: 30),
+        );
+
+      // LoggerContract is still resolved from IoC for the init() trace log.
       final container = IocContainer()
-        ..bind<LoggerContract>(_NoopLogger.new)
-        ..bind<CacheConfig>(() => CacheConfig(
-              sweeperInterval: const Duration(milliseconds: 30),
-            ));
+        ..bind<LoggerContract>(_NoopLogger.new);
 
       await runWithIoc(container, () async {
-        final provider = MemoryProvider(env)..init();
+        provider.init();
         provider.put('k', {'v': 1}, ttl: const Duration(milliseconds: 20));
 
         await Future<void>.delayed(const Duration(milliseconds: 80));
 
         // The sweeper should have removed the entry without any read call.
-        // We verify by checking the underlying length, which itself runs a
-        // sweep — but the entry must have been removed before that anyway.
         expect(provider.length(), 0);
 
         provider.dispose();
       });
+    });
+
+    test('config field defaults to CacheConfig.defaults() (no explicit assignment)', () {
+      final provider = MemoryProvider(env);
+      // CacheConfig.defaults() has invalidationEnabled=true and the default TTL policy.
+      expect(provider.config.invalidationEnabled, isTrue);
+    });
+
+    test('injected legacy config disables invalidation flag', () {
+      final provider = MemoryProvider(env)..config = CacheConfig.legacy();
+      expect(provider.config.invalidationEnabled, isFalse);
     });
   });
 

--- a/packages/core/lib/src/domains/client/client_builder.dart
+++ b/packages/core/lib/src/domains/client/client_builder.dart
@@ -58,7 +58,8 @@ final class ClientBuilder {
   }) {
     _cacheConfig = config ?? CacheConfig.defaults();
     ioc.bind<CacheConfig>(() => _cacheConfig);
-    _cache = ioc.make<CacheProviderContract>(() => cache(env));
+    _cache = ioc.make<CacheProviderContract>(() => cache(env))
+      ..config = _cacheConfig;
     return this;
   }
 

--- a/packages/core/lib/src/domains/services/cache/cache_invalidation.dart
+++ b/packages/core/lib/src/domains/services/cache/cache_invalidation.dart
@@ -1,13 +1,12 @@
-import 'package:mineral/src/domains/container/ioc_container.dart';
-import 'package:mineral/src/domains/services/cache/cache_config.dart';
 import 'package:mineral/src/domains/services/cache/cache_provider_contract.dart';
 
 /// Removes [key] from the cache when automatic invalidation is enabled.
 ///
-/// Resolves [CacheConfig] via the IoC container and short-circuits when
-/// `invalidationEnabled` is false (e.g. `CacheConfig.legacy()`). When no
-/// `CacheConfig` is bound — typical for older tests — defaults to `true` so
-/// existing behavior is preserved.
+/// Reads [CacheConfig.invalidationEnabled] directly from the provider's own
+/// [CacheProviderContract.config] — no IoC look-up required. When the
+/// provider carries [CacheConfig.defaults] (the default), invalidation is
+/// enabled. Pass a provider configured with [CacheConfig.legacy] (or any
+/// config whose [CacheConfig.invalidationEnabled] is `false`) to suppress it.
 extension CacheInvalidation on CacheProviderContract? {
   Future<void> invalidate(String key) async {
     final cache = this;
@@ -15,9 +14,7 @@ extension CacheInvalidation on CacheProviderContract? {
       return;
     }
 
-    final enabled =
-        ioc.resolveOrNull<CacheConfig>()?.invalidationEnabled ?? true;
-    if (!enabled) {
+    if (!cache.config.invalidationEnabled) {
       return;
     }
 

--- a/packages/core/lib/src/domains/services/cache/cache_provider_contract.dart
+++ b/packages/core/lib/src/domains/services/cache/cache_provider_contract.dart
@@ -1,7 +1,16 @@
 import 'dart:async';
 
+import 'package:mineral/src/domains/services/cache/cache_config.dart';
+
 abstract interface class CacheProviderContract {
   String get name;
+
+  /// The [CacheConfig] that governs this provider's TTL policy and
+  /// invalidation behaviour. Assigned by [ClientBuilder] after construction.
+  /// Defaults to [CacheConfig.defaults] so providers remain usable in tests
+  /// without a full application wiring.
+  CacheConfig get config;
+  set config(CacheConfig value);
 
   FutureOr<void> init();
 

--- a/packages/core/lib/src/testing/fake_cache_provider.dart
+++ b/packages/core/lib/src/testing/fake_cache_provider.dart
@@ -13,6 +13,9 @@ final class FakeCacheProvider implements CacheProviderContract {
   String get name => 'fake';
 
   @override
+  CacheConfig config = CacheConfig.defaults();
+
+  @override
   FutureOr<void> init() {}
 
   @override

--- a/packages/core/test/services/cache/cache_invalidation_test.dart
+++ b/packages/core/test/services/cache/cache_invalidation_test.dart
@@ -1,4 +1,3 @@
-import 'package:mineral/src/domains/container/ioc_container.dart';
 import 'package:mineral/src/domains/services/cache/cache_config.dart';
 import 'package:mineral/src/domains/services/cache/cache_invalidation.dart';
 import 'package:mineral/src/domains/services/cache/cache_provider_contract.dart';
@@ -7,52 +6,65 @@ import 'package:test/test.dart';
 
 void main() {
   group('CacheInvalidation.invalidate', () {
-    test('removes the key when invalidationEnabled is true', () async {
-      final cache = FakeCacheProvider()..store['users/1'] = {'id': '1'};
-      final container = IocContainer()
-        ..bind<CacheConfig>(CacheConfig.defaults);
+    test('removes the key when invalidationEnabled is true (defaults)', () async {
+      final cache = FakeCacheProvider()
+        ..store['users/1'] = {'id': '1'}
+        ..config = CacheConfig.defaults();
 
-      await runWithIoc(container, () async {
-        final CacheProviderContract nullable = cache;
-        await nullable.invalidate('users/1');
-      });
+      final CacheProviderContract nullable = cache;
+      await nullable.invalidate('users/1');
 
       expect(cache.store.containsKey('users/1'), isFalse);
     });
 
-    test('keeps the key when invalidationEnabled is false', () async {
-      final cache = FakeCacheProvider()..store['users/1'] = {'id': '1'};
-      final container = IocContainer()
-        ..bind<CacheConfig>(CacheConfig.legacy);
+    test('keeps the key when invalidationEnabled is false (legacy)', () async {
+      final cache = FakeCacheProvider()
+        ..store['users/1'] = {'id': '1'}
+        ..config = CacheConfig.legacy();
 
-      await runWithIoc(container, () async {
-        final CacheProviderContract nullable = cache;
-        await nullable.invalidate('users/1');
-      });
+      final CacheProviderContract nullable = cache;
+      await nullable.invalidate('users/1');
 
       expect(cache.store['users/1'], {'id': '1'});
     });
 
-    test('defaults to enabled when no CacheConfig is bound', () async {
-      final cache = FakeCacheProvider()..store['users/1'] = {'id': '1'};
-      final container = IocContainer();
+    test('keeps the key when invalidationEnabled is false (disabled config)', () async {
+      final cache = FakeCacheProvider()
+        ..store['users/1'] = {'id': '1'}
+        ..config = const CacheConfig(invalidationEnabled: false);
 
-      await runWithIoc(container, () async {
-        final CacheProviderContract nullable = cache;
-        await nullable.invalidate('users/1');
-      });
+      final CacheProviderContract nullable = cache;
+      await nullable.invalidate('users/1');
 
-      expect(cache.store.containsKey('users/1'), isFalse);
+      expect(cache.store['users/1'], {'id': '1'});
+    });
+
+    test('removes the key when invalidationEnabled is true (explicit config)', () async {
+      final cache = FakeCacheProvider()
+        ..store['users/2'] = {'id': '2'}
+        ..config = const CacheConfig(invalidationEnabled: true);
+
+      final CacheProviderContract nullable = cache;
+      await nullable.invalidate('users/2');
+
+      expect(cache.store.containsKey('users/2'), isFalse);
     });
 
     test('is a no-op when the cache is null', () async {
-      final container = IocContainer()
-        ..bind<CacheConfig>(CacheConfig.defaults);
+      const CacheProviderContract? nullable = null;
+      // Must not throw — null-safe extension guard.
+      await nullable.invalidate('users/1');
+    });
 
-      await runWithIoc(container, () async {
-        const CacheProviderContract? nullable = null;
-        await nullable.invalidate('users/1');
-      });
+    test('no IoC binding is required for invalidation to work', () async {
+      // This test intentionally runs WITHOUT any IoC container or CacheConfig
+      // bound in a container. The provider carries its own config, so this
+      // must work without ioc.resolveOrNull<CacheConfig>().
+      final cache = FakeCacheProvider()..store['k'] = {'v': 1};
+      // config defaults to CacheConfig.defaults() → invalidationEnabled=true
+      final CacheProviderContract nullable = cache;
+      await nullable.invalidate('k');
+      expect(cache.store.containsKey('k'), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary
- **M2**: `CacheInvalidation.invalidate` now reads `cache.config.invalidationEnabled` from the provider instance instead of `ioc.resolveOrNull<CacheConfig>()`; the `ioc_container` import is gone.
- **M23**: both providers carry a `CacheConfig` (contract `config` getter/setter), assigned in `ClientBuilder.setCache` right after construction. Providers use `config.ttlPolicy`/`config.sweeperInterval` directly instead of resolving via IoC or defaulting to `disabled()`.

No runtime cache path resolves `CacheConfig` from the container anymore.

## Test plan
- [x] `dart analyze packages/core packages/cache` — no issues
- [x] `grep ioc cache_invalidation.dart` → 0
- [x] `dart test packages/core` 1361/1361, `dart test packages/cache` 90/90
- [x] Invalidation + provider TTL tests migrated off the IoC binding

Closes #444