### PR TITLE
refactor: contract-typed DataStore getters; PacketListener DI (M3/M5)

### DIFF
--- a/packages/core/lib/src/domains/client/client_builder.dart
+++ b/packages/core/lib/src/domains/client/client_builder.dart
@@ -132,7 +132,6 @@ final class ClientBuilder {
         version: shardVersion,
         encoding: wsEncodingStrategy.strategy(logger: wssLogger));
 
-    final packetListener = PacketListener();
     final eventListener = EventListener();
     final providerManager = ProviderManager(logger: logger);
     final globalStateManager = GlobalStateManager();
@@ -161,6 +160,20 @@ final class ClientBuilder {
       dataStore: dataStore,
       marshaller: marshaller,
       ctx: entityContext,
+    );
+
+    // PacketListener is constructed here — after all its dependencies are
+    // available but before Kernel, because Kernel takes PacketListener as a
+    // required argument. The only field that cannot be passed here is `kernel`
+    // itself (genuine cycle), which is wired via the setter below.
+    final packetListener = PacketListener(
+      marshaller: marshaller,
+      dataStore: dataStore,
+      interactiveComponent: interactiveComponent,
+      commandManager: commandManager,
+      entityContext: entityContext,
+      runtimeState: runtimeState,
+      cacheConfig: _cacheConfig,
     );
 
     final kernel = Kernel(
@@ -221,15 +234,9 @@ final class ClientBuilder {
       ..require<InteractiveComponentManagerContract>()
       ..validateBindings();
 
+    // Wire the one field that could not be passed at construction time (cycle).
     packetListener
       ..kernel = appState.kernel
-      ..marshaller = appState.marshaller
-      ..dataStore = appState.dataStore
-      ..interactiveComponent = appState.interactiveComponent
-      ..commandManager = appState.commandManager
-      ..entityContext = entityContext
-      ..runtimeState = runtimeState
-      ..cacheConfig = appState.cacheConfig
       ..init();
 
     eventListener.kernel = appState.kernel;

--- a/packages/core/lib/src/domains/services/datastore/datastore.dart
+++ b/packages/core/lib/src/domains/services/datastore/datastore.dart
@@ -1,10 +1,10 @@
 import 'package:mineral/contracts.dart';
+import 'package:mineral/src/domains/services/datastore/parts.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/http/http.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 
 abstract class DataStoreContract {
-  RequestBucket get requestBucket;
+  RequestBucketContract get requestBucket;
 
   HttpClientContract get client;
 
@@ -30,7 +30,7 @@ abstract class DataStoreContract {
 
   ReactionPartContract get reaction;
 
-  ThreadPart get thread;
+  ThreadPartContract get thread;
 
   InvitePartContract get invite;
 

--- a/packages/core/lib/src/domains/services/datastore/request_bucket_contract.dart
+++ b/packages/core/lib/src/domains/services/datastore/request_bucket_contract.dart
@@ -1,0 +1,33 @@
+import 'package:mineral/services.dart';
+
+/// Domain-layer contract for the HTTP request bucket.
+///
+/// Callers in the domain only need the five HTTP-verb helpers; concrete
+/// infrastructure details (rate-limit registry, queuing) are hidden behind
+/// this interface.
+abstract interface class RequestBucketContract {
+  Future<T> get<T>(RequestContract request,
+      {void Function(T)? onSuccess,
+      Exception Function(Response)? onError,
+      void Function(Duration)? onRateLimit});
+
+  Future<T> post<T>(RequestContract request,
+      {void Function(T)? onSuccess,
+      Exception Function(Response)? onError,
+      void Function(Duration)? onRateLimit});
+
+  Future<T> put<T>(RequestContract request,
+      {void Function(T)? onSuccess,
+      Exception Function(Response)? onError,
+      void Function(Duration)? onRateLimit});
+
+  Future<T> patch<T>(RequestContract request,
+      {void Function(T)? onSuccess,
+      Exception Function(Response)? onError,
+      void Function(Duration)? onRateLimit});
+
+  Future<T> delete<T>(RequestContract request,
+      {void Function(T)? onSuccess,
+      Exception Function(Response)? onError,
+      void Function(Duration)? onRateLimit});
+}

--- a/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:mineral/contracts.dart';
 import 'package:mineral/services.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/rate_limit_registry.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/route_key.dart';
 
@@ -120,7 +121,7 @@ final class QueueableRequest<T> {
   }
 }
 
-final class RequestBucket {
+final class RequestBucket implements RequestBucketContract {
   final HttpClientContract client;
   final RateLimitRegistry registry;
   final LoggerContract logger;
@@ -129,6 +130,7 @@ final class RequestBucket {
   RequestBucket(this.client, {required this.logger, RateLimitRegistry? registry})
       : registry = registry ?? RateLimitRegistry();
 
+  @override
   Future<T> get<T>(RequestContract request,
           {void Function(T)? onSuccess,
           Exception Function(Response)? onError,
@@ -136,6 +138,7 @@ final class RequestBucket {
       _send<T>('GET', request, client.get,
           onSuccess: onSuccess, onError: onError, onRateLimit: onRateLimit);
 
+  @override
   Future<T> post<T>(RequestContract request,
           {void Function(T)? onSuccess,
           Exception Function(Response)? onError,
@@ -143,6 +146,7 @@ final class RequestBucket {
       _send<T>('POST', request, client.post,
           onSuccess: onSuccess, onError: onError, onRateLimit: onRateLimit);
 
+  @override
   Future<T> put<T>(RequestContract request,
           {void Function(T)? onSuccess,
           Exception Function(Response)? onError,
@@ -150,6 +154,7 @@ final class RequestBucket {
       _send<T>('PUT', request, client.put,
           onSuccess: onSuccess, onError: onError, onRateLimit: onRateLimit);
 
+  @override
   Future<T> patch<T>(RequestContract request,
           {void Function(T)? onSuccess,
           Exception Function(Response)? onError,
@@ -157,6 +162,7 @@ final class RequestBucket {
       _send<T>('PATCH', request, client.patch,
           onSuccess: onSuccess, onError: onError, onRateLimit: onRateLimit);
 
+  @override
   Future<T> delete<T>(RequestContract request,
           {void Function(T)? onSuccess,
           Exception Function(Response)? onError,

--- a/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/packet_listener.dart
@@ -88,14 +88,30 @@ final class PacketListener implements PacketListenerContract {
   @override
   late final PacketDispatcherContract dispatcher;
 
-  late final Kernel kernel;
-  late final MarshallerContract marshaller;
-  late final DataStoreContract dataStore;
-  late final InteractiveComponentManagerContract interactiveComponent;
-  late final CommandInteractionManagerContract commandManager;
-  late final EntityContext entityContext;
-  late final RuntimeState runtimeState;
-  CacheConfig? cacheConfig;
+  // `kernel` is the only field kept as a settable late field because of a
+  // genuine construction cycle: Kernel receives PacketListener as a required
+  // argument, so the kernel cannot be available when PacketListener is
+  // constructed. Every other dependency is available before Kernel is built
+  // and is therefore passed as a required constructor parameter.
+  late Kernel kernel;
+
+  final MarshallerContract marshaller;
+  final DataStoreContract dataStore;
+  final InteractiveComponentManagerContract interactiveComponent;
+  final CommandInteractionManagerContract commandManager;
+  final EntityContext entityContext;
+  final RuntimeState runtimeState;
+  final CacheConfig? cacheConfig;
+
+  PacketListener({
+    required this.marshaller,
+    required this.dataStore,
+    required this.interactiveComponent,
+    required this.commandManager,
+    required this.entityContext,
+    required this.runtimeState,
+    this.cacheConfig,
+  });
 
   void subscribe(ListenablePacket packet) {
     dispatcher.listen(packet.packetType, packet.listen);

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -3,8 +3,7 @@ import 'package:mineral/contracts.dart';
 import 'package:mineral/services.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_logger.dart';
@@ -70,7 +69,7 @@ final class _FakeDataStore implements DataStoreContract {
   InteractionPartContract get interaction => _interaction;
 
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
   @override
@@ -94,7 +93,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override

--- a/packages/core/test/commands/command_interaction_dispatcher_test.dart
+++ b/packages/core/test/commands/command_interaction_dispatcher_test.dart
@@ -3,8 +3,7 @@ import 'package:mineral/contracts.dart';
 import 'package:mineral/services.dart';
 import 'package:mineral/src/domains/commands/command_interaction_dispatcher.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_entity_context.dart';
@@ -69,7 +68,7 @@ final class _FakeChannelPart implements ChannelPartContract {
 
 final class _FakeDataStore implements DataStoreContract {
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClient get client => throw UnimplementedError();
   @override
@@ -95,7 +94,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override

--- a/packages/core/test/helpers/fake_datastore.dart
+++ b/packages/core/test/helpers/fake_datastore.dart
@@ -1,6 +1,6 @@
 import 'package:mineral/contracts.dart';
 import 'package:mineral/services.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/testing/fake_logger.dart';
 
@@ -11,7 +11,7 @@ import 'package:mineral/src/testing/fake_logger.dart';
 /// or use a real Part instance passed directly to the system under test.
 final class FakeDataStore implements DataStoreContract {
   @override
-  late final RequestBucket requestBucket;
+  late final RequestBucketContract requestBucket;
 
   @override
   final HttpClientContract client;
@@ -55,7 +55,7 @@ final class FakeDataStore implements DataStoreContract {
   ReactionPartContract get reaction => throw UnimplementedError('reaction');
 
   @override
-  ThreadPart get thread => throw UnimplementedError('thread');
+  ThreadPartContract get thread => throw UnimplementedError('thread');
 
   @override
   InvitePartContract get invite => throw UnimplementedError('invite');

--- a/packages/core/test/packets/application_command_permissions_update_packet_test.dart
+++ b/packages/core/test/packets/application_command_permissions_update_packet_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/application_command_permissions_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
@@ -56,7 +55,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -78,7 +77,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }
@@ -113,7 +112,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -137,7 +136,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }
@@ -178,7 +177,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -200,7 +199,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/integration_packets_test.dart
+++ b/packages/core/test/packets/integration_packets_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_delete_packet.dart';
@@ -64,7 +63,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -75,7 +74,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }
@@ -115,7 +114,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -126,7 +125,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
+++ b/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
@@ -56,7 +55,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => _resolve().reaction;
   @override
-  ThreadPart get thread => _resolve().thread;
+  ThreadPartContract get thread => _resolve().thread;
   @override
   InvitePartContract get invite => _resolve().invite;
   @override
@@ -80,7 +79,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => _resolve().soundboard;
   @override
-  RequestBucket get requestBucket => _resolve().requestBucket;
+  RequestBucketContract get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
 }
@@ -107,7 +106,7 @@ final class _FakeDataStore implements DataStoreContract {
   MessagePartContract get message => _messagePart;
 
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
   @override
@@ -127,7 +126,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -757,7 +756,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -777,7 +776,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/scheduled_event_packets_test.dart
+++ b/packages/core/test/packets/scheduled_event_packets_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/cache_key.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/serializer_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_scheduled_event_create_packet.dart';
@@ -72,7 +71,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -83,7 +82,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError('client');
 }
@@ -745,7 +744,7 @@ final class _LazyDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -756,7 +755,7 @@ final class _LazyDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/soundboard_packets_test.dart
+++ b/packages/core/test/packets/soundboard_packets_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_soundboard_sound_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_soundboard_sound_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_soundboard_sound_update_packet.dart';
@@ -63,7 +62,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -74,7 +73,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/stage_instance_packets_test.dart
+++ b/packages/core/test/packets/stage_instance_packets_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_update_packet.dart';
@@ -61,7 +60,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -72,7 +71,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
+++ b/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
@@ -7,9 +7,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/voice_channel_effect_send_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
@@ -56,7 +55,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -76,7 +75,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }
@@ -114,7 +113,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -138,7 +137,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }
@@ -184,7 +183,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -204,7 +203,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/webhooks_update_packet_test.dart
+++ b/packages/core/test/packets/webhooks_update_packet_test.dart
@@ -6,9 +6,8 @@ import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/parts/thread_part.dart';
-import 'package:mineral/src/infrastructure/internals/datastore/request_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/webhooks_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
@@ -53,7 +52,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => _resolve().reaction;
   @override
-  ThreadPart get thread => _resolve().thread;
+  ThreadPartContract get thread => _resolve().thread;
   @override
   InvitePartContract get invite => _resolve().invite;
   @override
@@ -77,7 +76,7 @@ final class _DeferredDataStore implements DataStoreContract {
   @override
   SoundboardPartContract get soundboard => _resolve().soundboard;
   @override
-  RequestBucket get requestBucket => _resolve().requestBucket;
+  RequestBucketContract get requestBucket => _resolve().requestBucket;
   @override
   HttpClientContract get client => _resolve().client;
 }
@@ -99,7 +98,7 @@ final class _FakeDataStore implements DataStoreContract {
   GuildPartContract get guild => _guildPart;
 
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
   @override
@@ -121,7 +120,7 @@ final class _FakeDataStore implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -236,7 +235,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   ReactionPartContract get reaction => throw UnimplementedError();
   @override
-  ThreadPart get thread => throw UnimplementedError();
+  ThreadPartContract get thread => throw UnimplementedError();
   @override
   InvitePartContract get invite => throw UnimplementedError();
   @override
@@ -256,7 +255,7 @@ final class _NoopDs implements DataStoreContract {
   @override
   StageInstancePartContract get stageInstance => throw UnimplementedError();
   @override
-  RequestBucket get requestBucket => throw UnimplementedError();
+  RequestBucketContract get requestBucket => throw UnimplementedError();
   @override
   HttpClientContract get client => throw UnimplementedError();
 }


### PR DESCRIPTION
## Summary
- **M3**: `DataStoreContract` no longer names concrete infra types — `thread` → `ThreadPartContract`, `requestBucket` → new domain `RequestBucketContract` (5 HTTP-verb methods; `RequestBucket implements` it).
- **M5**: `PacketListener`'s 7 injectable `late final` fields are now required constructor params (constructed after the data layer in `build()`). `kernel` remains a late setter — genuine cycle (`Kernel` requires the `PacketListener`, which then builds its dispatcher from `kernel`), documented in code.

## Test plan
- [x] `dart analyze packages/core packages/cache packages/test` — no issues
- [x] `dart test packages/core` — 1361/1361
- [x] 10 test fakes updated to the contract return types

Closes #445