### PR TITLE
fix: revert null-aware element syntax (SDK compatibility regression)

### DIFF
--- a/packages/cache/analysis_options.yaml
+++ b/packages/cache/analysis_options.yaml
@@ -17,6 +17,7 @@ linter:
   rules:
     unawaited_futures: true
     only_throw_errors: true
+    use_null_aware_elements: false
 
 # analyzer:
 #   exclude:

--- a/packages/core/analysis_options.yaml
+++ b/packages/core/analysis_options.yaml
@@ -54,6 +54,10 @@ linter:
     use_string_buffers: true
     unawaited_futures: true
     only_throw_errors: true
+    # Disabled: the null-aware element syntax (`{'k': ?v}`) requires a newer
+    # language version than the supported SDK floor and breaks consumers on
+    # older SDKs. Keep the explicit `if (v != null)` form instead.
+    use_null_aware_elements: false
 
     # analyzer:
     #   exclude:

--- a/packages/core/lib/src/api/common/components/media_item.dart
+++ b/packages/core/lib/src/api/common/components/media_item.dart
@@ -66,7 +66,7 @@ final class MediaItem {
     return {
       if (description != null) 'description': description,
       'url': url,
-      'bytes': ?bytes,
+      if (bytes != null) 'bytes': bytes,
       if (spoiler != null) 'spoiler': spoiler,
       'media': {
         'url': url,

--- a/packages/core/lib/src/api/guild/managers/member_voice_manager.dart
+++ b/packages/core/lib/src/api/guild/managers/member_voice_manager.dart
@@ -208,9 +208,9 @@ final class MemberVoiceManager {
       memberId: _memberId.value,
       reason: reason,
       payload: {
-        'mute': ?mute,
-        'deaf': ?deafen,
-        'channel_id': ?channelId,
+        if (mute != null) 'mute': mute,
+        if (deafen != null) 'deaf': deafen,
+        if (channelId != null) 'channel_id': channelId,
       },
     );
   }

--- a/packages/core/lib/src/api/guild/role.dart
+++ b/packages/core/lib/src/api/guild/role.dart
@@ -127,11 +127,11 @@ final class Role {
       guildId: guildId.value,
       reason: reason,
       payload: {
-        'name': ?name,
+        if (name != null) 'name': name,
         if (color != null) 'color': color.toInt(),
-        'hoist': ?hoist,
-        'unicode_emoji': ?emoji,
-        'mentionable': ?mentionable,
+        if (hoist != null) 'hoist': hoist,
+        if (emoji != null) 'unicode_emoji': emoji,
+        if (mentionable != null) 'mentionable': mentionable,
       },
     );
   }

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/guild_scheduled_event_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/guild_scheduled_event_part.dart
@@ -81,8 +81,8 @@ final class GuildScheduledEventPart extends BasePart
       if (entityMetadata != null) 'entity_metadata': entityMetadata.toJson(),
       if (scheduledEndTime != null)
         'scheduled_end_time': scheduledEndTime.toIso8601String(),
-      'description': ?description,
-      'image': ?image,
+      if (description != null) 'description': description,
+      if (image != null) 'image': image,
     };
 
     final req = Request.json(
@@ -117,16 +117,16 @@ final class GuildScheduledEventPart extends BasePart
     final body = <String, dynamic>{
       if (channelId != null) 'channel_id': channelId.toString(),
       if (entityMetadata != null) 'entity_metadata': entityMetadata.toJson(),
-      'name': ?name,
+      if (name != null) 'name': name,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
       if (scheduledStartTime != null)
         'scheduled_start_time': scheduledStartTime.toIso8601String(),
       if (scheduledEndTime != null)
         'scheduled_end_time': scheduledEndTime.toIso8601String(),
-      'description': ?description,
+      if (description != null) 'description': description,
       if (entityType != null) 'entity_type': entityType.value,
       if (status != null) 'status': status.value,
-      'image': ?image,
+      if (image != null) 'image': image,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/invite_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/invite_part.dart
@@ -59,9 +59,9 @@ final class InvitePart extends BasePart implements InvitePartContract {
   }) async {
     final body = <String, dynamic>{
       if (maxAge != null) 'max_age': maxAge.inSeconds,
-      'max_uses': ?maxUses,
-      'temporary': ?temporary,
-      'unique': ?unique,
+      if (maxUses != null) 'max_uses': maxUses,
+      if (temporary != null) 'temporary': temporary,
+      if (unique != null) 'unique': unique,
       if (targetType != null) 'target_type': targetType.value,
       if (targetUserId != null) 'target_user_id': targetUserId.toString(),
       if (targetApplicationId != null)

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/message_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/message_part.dart
@@ -20,7 +20,7 @@ final class MessagePart extends BasePart implements MessagePartContract {
       if (around != null) 'around': around.value,
       if (before != null) 'before': before.value,
       if (after != null) 'after': after.value,
-      'limit': ?limit,
+      if (limit != null) 'limit': limit,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/onboarding_part.dart
@@ -35,7 +35,7 @@ final class OnboardingPart extends BasePart
       if (defaultChannelIds != null)
         'default_channel_ids':
             defaultChannelIds.map((id) => id.toString()).toList(),
-      'enabled': ?enabled,
+      if (enabled != null) 'enabled': enabled,
       if (mode != null) 'mode': mode.value,
     };
 

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/soundboard_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/soundboard_part.dart
@@ -55,9 +55,9 @@ final class SoundboardPart extends BasePart implements SoundboardPartContract {
     final body = <String, dynamic>{
       'name': name,
       'sound': sound,
-      'volume': ?volume,
+      if (volume != null) 'volume': volume,
       if (emojiId != null) 'emoji_id': Snowflake.parse(emojiId).value,
-      'emoji_name': ?emojiName,
+      if (emojiName != null) 'emoji_name': emojiName,
     };
 
     final req = Request.json(
@@ -83,10 +83,10 @@ final class SoundboardPart extends BasePart implements SoundboardPartContract {
     final parsedGuildId = Snowflake.parse(guildId);
     final id = Snowflake.parse(soundId);
     final body = <String, dynamic>{
-      'name': ?name,
-      'volume': ?volume,
+      if (name != null) 'name': name,
+      if (volume != null) 'volume': volume,
       if (emojiId != null) 'emoji_id': Snowflake.parse(emojiId).value,
-      'emoji_name': ?emojiName,
+      if (emojiName != null) 'emoji_name': emojiName,
     };
 
     final req = Request.json(

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/stage_instance_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/stage_instance_part.dart
@@ -30,7 +30,7 @@ final class StageInstancePart extends BasePart
       'channel_id': Snowflake.parse(channelId).value,
       'topic': topic,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
-      'send_start_notification': ?sendStartNotification,
+      if (sendStartNotification != null) 'send_start_notification': sendStartNotification,
       if (guildScheduledEventId != null)
         'guild_scheduled_event_id':
             Snowflake.parse(guildScheduledEventId).value,
@@ -56,7 +56,7 @@ final class StageInstancePart extends BasePart
     final id = Snowflake.parse(channelId);
 
     final body = <String, dynamic>{
-      'topic': ?topic,
+      if (topic != null) 'topic': topic,
       if (privacyLevel != null) 'privacy_level': privacyLevel.value,
     };
 

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/template_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/template_part.dart
@@ -34,7 +34,7 @@ final class TemplatePart extends BasePart implements TemplatePartContract {
     final parsedGuildId = Snowflake.parse(guildId);
     final body = <String, dynamic>{
       'name': name,
-      'description': ?description,
+      if (description != null) 'description': description,
     };
     final req = Request.json(endpoint: '/guilds/$parsedGuildId/templates', body: body);
     final result =
@@ -61,8 +61,8 @@ final class TemplatePart extends BasePart implements TemplatePartContract {
   }) async {
     final parsedGuildId = Snowflake.parse(guildId);
     final body = <String, dynamic>{
-      'name': ?name,
-      'description': ?description,
+      if (name != null) 'name': name,
+      if (description != null) 'description': description,
     };
     final req = Request.json(
         endpoint: '/guilds/$parsedGuildId/templates/$code', body: body);

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/webhook_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/webhook_part.dart
@@ -70,7 +70,7 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
   }) async {
     final body = <String, dynamic>{
       'name': name,
-      'avatar': ?avatar,
+      if (avatar != null) 'avatar': avatar,
     };
 
     final req = Request.json(
@@ -95,8 +95,8 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
     String? reason,
   }) async {
     final body = <String, dynamic>{
-      'name': ?name,
-      'avatar': ?avatar,
+      if (name != null) 'name': name,
+      if (avatar != null) 'avatar': avatar,
       if (channelId != null) 'channel_id': channelId.toString(),
     };
 
@@ -121,8 +121,8 @@ final class WebhookPart extends BasePart implements WebhookPartContract {
     String? avatar,
   }) async {
     final body = <String, dynamic>{
-      'name': ?name,
-      'avatar': ?avatar,
+      if (name != null) 'name': name,
+      if (avatar != null) 'avatar': avatar,
     };
 
     final req =

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/welcome_screen_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/welcome_screen_part.dart
@@ -29,9 +29,9 @@ final class WelcomeScreenPart extends BasePart
     final parsedGuildId = Snowflake.parse(guildId);
 
     final body = <String, dynamic>{
-      'enabled': ?enabled,
-      'welcome_channels': ?welcomeChannels,
-      'description': ?description,
+      if (enabled != null) 'enabled': enabled,
+      if (welcomeChannels != null) 'welcome_channels': welcomeChannels,
+      if (description != null) 'description': description,
     };
 
     final req = Request.json(

--- a/packages/core/test/datastore/parts/monetization_part_test.dart
+++ b/packages/core/test/datastore/parts/monetization_part_test.dart
@@ -42,8 +42,8 @@ Map<String, dynamic> _entitlementPayload({
       'application_id': applicationId,
       'type': type,
       'deleted': deleted,
-      'user_id': ?userId,
-      'guild_id': ?guildId,
+      if (userId != null) 'user_id': userId,
+      if (guildId != null) 'guild_id': guildId,
     };
 
 Map<String, dynamic> _subscriptionPayload({

--- a/packages/core/test/datastore/parts/soundboard_part_test.dart
+++ b/packages/core/test/datastore/parts/soundboard_part_test.dart
@@ -27,11 +27,11 @@ Map<String, dynamic> _soundPayload({
       'sound_id': id ?? _soundId,
       'name': name,
       'volume': volume,
-      'emoji_id': ?emojiId,
-      'emoji_name': ?emojiName,
-      'guild_id': ?guildId,
+      if (emojiId != null) 'emoji_id': emojiId,
+      if (emojiName != null) 'emoji_name': emojiName,
+      if (guildId != null) 'guild_id': guildId,
       'available': available,
-      'user': ?user,
+      if (user != null) 'user': user,
     };
 
 (SoundboardPart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/core/test/datastore/parts/stage_instance_part_test.dart
+++ b/packages/core/test/datastore/parts/stage_instance_part_test.dart
@@ -23,7 +23,7 @@ Map<String, dynamic> _stageInstancePayload({
       'channel_id': _channelId,
       'topic': topic ?? 'Test Topic',
       'privacy_level': privacyLevel,
-      'guild_scheduled_event_id': ?guildScheduledEventId,
+      if (guildScheduledEventId != null) 'guild_scheduled_event_id': guildScheduledEventId,
     };
 
 (StageInstancePart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/core/test/datastore/parts/template_part_test.dart
+++ b/packages/core/test/datastore/parts/template_part_test.dart
@@ -38,7 +38,7 @@ Map<String, dynamic> _templatePayload({
       'updated_at': updatedAt,
       'source_guild_id': sourceGuildId,
       'serialized_source_guild': {'name': 'Test Guild'},
-      'is_dirty': ?isDirty,
+      if (isDirty != null) 'is_dirty': isDirty,
     };
 
 (TemplatePart, void Function() restore) _buildPart(FakeHttpClient client) {

--- a/packages/test/analysis_options.yaml
+++ b/packages/test/analysis_options.yaml
@@ -46,3 +46,4 @@ linter:
     use_string_buffers: true
     unawaited_futures: true
     only_throw_errors: true
+    use_null_aware_elements: false


### PR DESCRIPTION
## Summary
Regression from the SDK-bump card (#443): `dart fix` rewrote `if (x != null) 'k': x` map entries into the **null-aware element** syntax (`'k': ?x`). That syntax needs a language version that isn't stably available on the supported SDK floor, so consumer bots fail with *"requires the experimental 'null-aware-elements' language feature"*. It slipped through because the local toolchain (Dart 3.12) has the feature stable.

- Reverted all 44 null-aware element map entries back to the universally-compatible `if (x != null) 'k': x` form (lib + tests).
- Disabled `use_null_aware_elements` in all three packages' `analysis_options.yaml` so it can't be reintroduced.

## Test plan
- [x] `grep ': ?'` → 0 occurrences in code
- [x] `dart analyze packages/core packages/cache packages/test` — no issues
- [x] `dart test` — core 1361, cache 90, test 19

Refs #439