### PR TITLE
test: api entity methods, channel serializer, shard glue (M13/M14/M15)

### DIFF
--- a/packages/core/test/api/entity_behaviour_test.dart
+++ b/packages/core/test/api/entity_behaviour_test.dart
@@ -1,0 +1,926 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/src/api/common/permissions.dart';
+import 'package:mineral/src/api/guild/managers/threads_manager.dart';
+import 'package:mineral/src/domains/common/entity_context.dart';
+import 'package:mineral/src/domains/common/runtime_state.dart';
+import 'package:mineral/src/testing/fake_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_websocket_orchestrator.dart';
+
+// ── Fakes & Mocks ──────────────────────────────────────────────────────────
+
+/// Minimal no-op [ChannelBuilderContract] needed as a mocktail fallback value.
+final class _FakeChannelBuilder extends Fake implements ChannelBuilderContract {}
+
+class _MockMemberPart extends Mock implements MemberPartContract {}
+
+class _MockRolePart extends Mock implements RolePartContract {}
+
+class _MockChannelPart extends Mock implements ChannelPartContract {}
+
+class _MockMessagePart extends Mock implements MessagePartContract {}
+
+// ── Minimal DataStoreContract implementations ──────────────────────────────
+//
+// Because DataStoreContract is an abstract interface (not final), we can
+// implement it directly and override only the parts we need.
+
+final class _MemberRoleDataStore implements DataStoreContract {
+  final MemberPartContract _member;
+  final RolePartContract _role;
+
+  _MemberRoleDataStore(this._member, this._role);
+
+  @override
+  MemberPartContract get member => _member;
+
+  @override
+  RolePartContract get role => _role;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+final class _ChannelMessageDataStore implements DataStoreContract {
+  final ChannelPartContract _channel;
+  final MessagePartContract _message;
+
+  _ChannelMessageDataStore(this._channel, this._message);
+
+  @override
+  ChannelPartContract get channel => _channel;
+
+  @override
+  MessagePartContract get message => _message;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+final class _MessageOnlyDataStore implements DataStoreContract {
+  final MessagePartContract _message;
+
+  _MessageOnlyDataStore(this._message);
+
+  @override
+  MessagePartContract get message => _message;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+final class _RoleDataStore implements DataStoreContract {
+  final RolePartContract _role;
+
+  _RoleDataStore(this._role);
+
+  @override
+  RolePartContract get role => _role;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+EntityContext _ctx(DataStoreContract dataStore) => EntityContext(
+      datastore: dataStore,
+      wss: FakeWebsocketOrchestrator(),
+      logger: FakeLogger(),
+      runtimeState: RuntimeState(),
+    );
+
+Member _buildMember(EntityContext ctx) => Member(
+      ctx: ctx,
+      id: Snowflake('111000111000111000'),
+      username: 'testuser',
+      nickname: null,
+      globalName: 'TestUser',
+      discriminator: '0',
+      assets: MemberAssets(avatar: null, avatarDecoration: null, banner: null),
+      flags: MemberFlagsManager([], ctx: ctx),
+      premiumSince: null,
+      publicFlags: 0,
+      roles: MemberRoleManager(
+        [Snowflake('333000333000333000')],
+        Snowflake('222000222000222000'),
+        Snowflake('111000111000111000'),
+        ctx: ctx,
+      ),
+      isBot: false,
+      isPending: false,
+      timeout: MemberTimeout(duration: null),
+      mfaEnabled: false,
+      locale: 'en-US',
+      premiumType: PremiumTier.none,
+      joinedAt: DateTime.parse('2024-01-15T10:30:00.000Z'),
+      permissions: Permissions.fromInt(0),
+      accentColor: null,
+      guildId: Snowflake('222000222000222000'),
+    );
+
+Role _buildRole(EntityContext ctx) => Role(
+      ctx: ctx,
+      id: Snowflake('444000444000444000'),
+      name: 'moderator',
+      color: Color.amber_500,
+      hoist: false,
+      position: 3,
+      permissions: Permissions.fromInt(0),
+      managed: false,
+      mentionable: true,
+      flags: 0,
+      icon: null,
+      unicodeEmoji: null,
+      guildId: Snowflake('222000222000222000'),
+    );
+
+ChannelProperties _buildTextProps(EntityContext ctx) => ChannelProperties(
+      ctx: ctx,
+      id: Snowflake('555000555000555000'),
+      type: ChannelType.guildText,
+      name: 'general',
+      description: null,
+      guildId: Snowflake('222000222000222000'),
+      categoryId: null,
+      position: 1,
+      nsfw: false,
+      lastMessageId: null,
+      bitrate: null,
+      userLimit: null,
+      rateLimitPerUser: null,
+      recipients: [],
+      icon: null,
+      ownerId: null,
+      applicationId: null,
+      lastPinTimestamp: null,
+      rtcRegion: null,
+      videoQualityMode: null,
+      messageCount: null,
+      memberCount: null,
+      defaultAutoArchiveDuration: null,
+      permissions: [],
+      flags: null,
+      totalMessageSent: null,
+      available: null,
+      appliedTags: [],
+      defaultReactions: null,
+      defaultSortOrder: null,
+      defaultForumLayout: null,
+      threads: ThreadsManager(
+        Snowflake('222000222000222000'),
+        Snowflake('555000555000555000'),
+        ctx: ctx,
+      ),
+    );
+
+ChannelProperties _buildVoiceProps(EntityContext ctx) => ChannelProperties(
+      ctx: ctx,
+      id: Snowflake('666000666000666000'),
+      type: ChannelType.guildVoice,
+      name: 'voice-chat',
+      description: null,
+      guildId: Snowflake('222000222000222000'),
+      categoryId: null,
+      position: 2,
+      nsfw: false,
+      lastMessageId: null,
+      bitrate: 64000,
+      userLimit: 5,
+      rateLimitPerUser: null,
+      recipients: [],
+      icon: null,
+      ownerId: null,
+      applicationId: null,
+      lastPinTimestamp: null,
+      rtcRegion: null,
+      videoQualityMode: null,
+      messageCount: null,
+      memberCount: null,
+      defaultAutoArchiveDuration: null,
+      permissions: [],
+      flags: null,
+      totalMessageSent: null,
+      available: null,
+      appliedTags: [],
+      defaultReactions: null,
+      defaultSortOrder: null,
+      defaultForumLayout: null,
+      threads: ThreadsManager(
+        Snowflake('222000222000222000'),
+        Snowflake('666000666000666000'),
+        ctx: ctx,
+      ),
+    );
+
+MessageProperties _buildMessageProps() => MessageProperties(
+      id: Snowflake('777000777000777000'),
+      content: 'hello world',
+      channelId: Snowflake('555000555000555000'),
+      authorId: Snowflake('111000111000111000'),
+      guildId: Snowflake('222000222000222000'),
+      authorIsBot: false,
+      embeds: [],
+      createdAt: DateTime.parse('2024-01-15T10:30:00.000Z'),
+      updatedAt: null,
+    );
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+    registerFallbackValue(MessageBuilder());
+    registerFallbackValue(Snowflake('0'));
+    registerFallbackValue(_FakeChannelBuilder());
+  });
+
+  // ── Member.ban / kick / setNickname / exclude / unExclude ───────────────
+
+  group('Member behavioural methods', () {
+    late _MockMemberPart mockMember;
+    late _MockRolePart mockRole;
+    late Member member;
+
+    setUp(() {
+      mockMember = _MockMemberPart();
+      mockRole = _MockRolePart();
+      final ctx = _ctx(_MemberRoleDataStore(mockMember, mockRole));
+      member = _buildMember(ctx);
+    });
+
+    group('ban', () {
+      test('delegates to member.ban with correct guildId and memberId',
+          () async {
+        when(() => mockMember.ban(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              deleteSince: any(named: 'deleteSince'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async {});
+
+        await member.ban();
+
+        verify(() => mockMember.ban(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              deleteSince: null,
+              reason: null,
+            )).called(1);
+      });
+
+      test('forwards deleteSince duration', () async {
+        when(() => mockMember.ban(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              deleteSince: any(named: 'deleteSince'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async {});
+
+        await member.ban(deleteSince: const Duration(days: 7));
+
+        final captured = verify(() => mockMember.ban(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              deleteSince: captureAny(named: 'deleteSince'),
+              reason: null,
+            )).captured;
+
+        expect(captured.single, equals(const Duration(days: 7)));
+      });
+    });
+
+    group('kick', () {
+      test('delegates to member.kick with correct ids', () async {
+        when(() => mockMember.kick(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async {});
+
+        await member.kick();
+
+        verify(() => mockMember.kick(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              reason: null,
+            )).called(1);
+      });
+
+      test('forwards reason', () async {
+        when(() => mockMember.kick(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async {});
+
+        await member.kick(reason: 'spamming');
+
+        verify(() => mockMember.kick(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              reason: 'spamming',
+            )).called(1);
+      });
+    });
+
+    group('setNickname', () {
+      test('calls member.update with nick payload', () async {
+        when(() => mockMember.update(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              payload: any(named: 'payload'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async => member);
+
+        await member.setNickname('newNick', 'Testing');
+
+        final captured = verify(() => mockMember.update(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              payload: captureAny(named: 'payload'),
+              reason: 'Testing',
+            )).captured;
+
+        expect((captured.single as Map<String, dynamic>)['nick'],
+            equals('newNick'));
+      });
+    });
+
+    group('exclude (timeout)', () {
+      test('calls member.update with communication_disabled_until', () async {
+        when(() => mockMember.update(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              payload: any(named: 'payload'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async => member);
+
+        await member.exclude(duration: const Duration(hours: 1));
+
+        final captured = verify(() => mockMember.update(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              payload: captureAny(named: 'payload'),
+              reason: null,
+            )).captured;
+
+        final payload = captured.single as Map<String, dynamic>;
+        expect(payload.containsKey('communication_disabled_until'), isTrue);
+        expect(payload['communication_disabled_until'], isNotNull);
+      });
+    });
+
+    group('unExclude', () {
+      test('calls member.update with null communication_disabled_until',
+          () async {
+        when(() => mockMember.update(
+              guildId: any(named: 'guildId'),
+              memberId: any(named: 'memberId'),
+              payload: any(named: 'payload'),
+              reason: any(named: 'reason'),
+            )).thenAnswer((_) async => member);
+
+        await member.unExclude();
+
+        final captured = verify(() => mockMember.update(
+              guildId: '222000222000222000',
+              memberId: '111000111000111000',
+              payload: captureAny(named: 'payload'),
+              reason: null,
+            )).captured;
+
+        final payload = captured.single as Map<String, dynamic>;
+        expect(payload['communication_disabled_until'], isNull);
+      });
+    });
+  });
+
+  // ── MemberRoleManager ───────────────────────────────────────────────────
+
+  group('MemberRoleManager behavioural methods', () {
+    late _MockMemberPart mockMember;
+    late _MockRolePart mockRole;
+    late Member member;
+
+    setUp(() {
+      mockMember = _MockMemberPart();
+      mockRole = _MockRolePart();
+      final ctx = _ctx(_MemberRoleDataStore(mockMember, mockRole));
+      member = _buildMember(ctx);
+    });
+
+    test('add delegates to role.add with correct ids', () async {
+      when(() => mockRole.add(
+            memberId: any(named: 'memberId'),
+            guildId: any(named: 'guildId'),
+            roleId: any(named: 'roleId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async {});
+
+      await member.roles.add('444000444000444000');
+
+      verify(() => mockRole.add(
+            memberId: '111000111000111000',
+            guildId: '222000222000222000',
+            roleId: '444000444000444000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('remove delegates to role.remove with correct ids', () async {
+      when(() => mockRole.remove(
+            memberId: any(named: 'memberId'),
+            guildId: any(named: 'guildId'),
+            roleId: any(named: 'roleId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async {});
+
+      await member.roles.remove('444000444000444000', reason: 'cleanup');
+
+      verify(() => mockRole.remove(
+            memberId: '111000111000111000',
+            guildId: '222000222000222000',
+            roleId: '444000444000444000',
+            reason: 'cleanup',
+          )).called(1);
+    });
+
+    test('sync delegates to role.sync with full list', () async {
+      when(() => mockRole.sync(
+            memberId: any(named: 'memberId'),
+            guildId: any(named: 'guildId'),
+            roleIds: any(named: 'roleIds'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async {});
+
+      await member.roles.sync(['444000444000444000', '555000555000555000']);
+
+      final captured = verify(() => mockRole.sync(
+            memberId: '111000111000111000',
+            guildId: '222000222000222000',
+            roleIds: captureAny(named: 'roleIds'),
+            reason: null,
+          )).captured;
+
+      expect(captured.single as List,
+          containsAll(['444000444000444000', '555000555000555000']));
+    });
+
+    test('clear delegates to role.sync with empty list', () async {
+      when(() => mockRole.sync(
+            memberId: any(named: 'memberId'),
+            guildId: any(named: 'guildId'),
+            roleIds: any(named: 'roleIds'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async {});
+
+      await member.roles.clear();
+
+      final captured = verify(() => mockRole.sync(
+            memberId: '111000111000111000',
+            guildId: '222000222000222000',
+            roleIds: captureAny(named: 'roleIds'),
+            reason: null,
+          )).captured;
+
+      expect(captured.single, isEmpty);
+    });
+  });
+
+  // ── Role ────────────────────────────────────────────────────────────────
+
+  group('Role behavioural methods', () {
+    late _MockRolePart mockRole;
+    late Role role;
+
+    setUp(() {
+      mockRole = _MockRolePart();
+      final ctx = _ctx(_RoleDataStore(mockRole));
+      role = _buildRole(ctx);
+    });
+
+    test('setName calls role.update with name payload', () async {
+      when(() => mockRole.update(
+            id: any(named: 'id'),
+            guildId: any(named: 'guildId'),
+            payload: any(named: 'payload'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await role.setName('admin', 'rename reason');
+
+      final captured = verify(() => mockRole.update(
+            id: '444000444000444000',
+            guildId: '222000222000222000',
+            payload: captureAny(named: 'payload'),
+            reason: 'rename reason',
+          )).captured;
+
+      expect(
+          (captured.single as Map<String, dynamic>)['name'], equals('admin'));
+    });
+
+    test('setColor calls role.update with color int payload', () async {
+      when(() => mockRole.update(
+            id: any(named: 'id'),
+            guildId: any(named: 'guildId'),
+            payload: any(named: 'payload'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await role.setColor(Color.blue_500, null);
+
+      final captured = verify(() => mockRole.update(
+            id: '444000444000444000',
+            guildId: '222000222000222000',
+            payload: captureAny(named: 'payload'),
+            reason: null,
+          )).captured;
+
+      final payload = captured.single as Map<String, dynamic>;
+      expect(payload.containsKey('color'), isTrue);
+      expect(payload['color'], isA<int>());
+    });
+
+    test('setMentionable calls role.update with mentionable payload', () async {
+      when(() => mockRole.update(
+            id: any(named: 'id'),
+            guildId: any(named: 'guildId'),
+            payload: any(named: 'payload'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await role.setMentionable(false, 'no-mention');
+
+      final captured = verify(() => mockRole.update(
+            id: '444000444000444000',
+            guildId: '222000222000222000',
+            payload: captureAny(named: 'payload'),
+            reason: 'no-mention',
+          )).captured;
+
+      expect(
+          (captured.single as Map<String, dynamic>)['mentionable'], isFalse);
+    });
+
+    test('delete calls role.delete with correct ids', () async {
+      when(() => mockRole.delete(
+            id: any(named: 'id'),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async {});
+
+      await role.delete(reason: 'cleanup');
+
+      verify(() => mockRole.delete(
+            id: '444000444000444000',
+            guildId: '222000222000222000',
+            reason: 'cleanup',
+          )).called(1);
+    });
+
+    test('update with multiple fields calls role.update', () async {
+      when(() => mockRole.update(
+            id: any(named: 'id'),
+            guildId: any(named: 'guildId'),
+            payload: any(named: 'payload'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await role.update(name: 'senior', hoist: true, mentionable: false);
+
+      final captured = verify(() => mockRole.update(
+            id: '444000444000444000',
+            guildId: '222000222000222000',
+            payload: captureAny(named: 'payload'),
+            reason: null,
+          )).captured;
+
+      final payload = captured.single as Map<String, dynamic>;
+      expect(payload['name'], equals('senior'));
+      expect(payload['hoist'], isTrue);
+      expect(payload['mentionable'], isFalse);
+    });
+  });
+
+  // ── GuildTextChannel ────────────────────────────────────────────────────
+
+  group('GuildTextChannel behavioural methods', () {
+    late _MockChannelPart mockChannel;
+    late _MockMessagePart mockMessage;
+    late GuildTextChannel channel;
+
+    setUp(() {
+      mockChannel = _MockChannelPart();
+      mockMessage = _MockMessagePart();
+      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      channel = GuildTextChannel(_buildTextProps(ctx));
+    });
+
+    test('setName calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await channel.setName('announcements');
+
+      verify(() => mockChannel.update(
+            '555000555000555000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('delete without reason calls channel.delete', () async {
+      when(() => mockChannel.delete(any(), any())).thenAnswer((_) async {});
+
+      await channel.delete();
+
+      verify(() => mockChannel.delete('555000555000555000', null)).called(1);
+    });
+
+    test('delete with reason forwards it', () async {
+      when(() => mockChannel.delete(any(), any())).thenAnswer((_) async {});
+
+      await channel.delete(reason: 'clean-up');
+
+      verify(() => mockChannel.delete('555000555000555000', 'clean-up'))
+          .called(1);
+    });
+
+    test('send delegates to message.send', () async {
+      final builder = MessageBuilder.text('hello');
+      when(() => mockMessage.send<Message>(any(), any(), any()))
+          .thenAnswer((_) async => throw UnimplementedError());
+
+      expect(() => channel.send(builder), throwsA(isA<UnimplementedError>()));
+
+      verify(() => mockMessage.send<Message>(
+            '222000222000222000',
+            '555000555000555000',
+            any(),
+          )).called(1);
+    });
+  });
+
+  // ── GuildVoiceChannel ───────────────────────────────────────────────────
+
+  group('GuildVoiceChannel behavioural methods', () {
+    late _MockChannelPart mockChannel;
+    late GuildVoiceChannel voiceChannel;
+
+    setUp(() {
+      mockChannel = _MockChannelPart();
+      final mockMessage = _MockMessagePart();
+      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      voiceChannel = GuildVoiceChannel(_buildVoiceProps(ctx))..members = [];
+    });
+
+    test('setBitrate calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await voiceChannel.setBitrate(96000);
+
+      verify(() => mockChannel.update(
+            '666000666000666000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('setUserLimit calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await voiceChannel.setUserLimit(10);
+
+      verify(() => mockChannel.update(
+            '666000666000666000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('setName calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await voiceChannel.setName('stage');
+
+      verify(() => mockChannel.update(
+            '666000666000666000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+  });
+
+  // ── Message ─────────────────────────────────────────────────────────────
+
+  group('Message behavioural methods', () {
+    late _MockMessagePart mockMessage;
+    late Message message;
+
+    setUp(() {
+      mockMessage = _MockMessagePart();
+      final ctx = _ctx(_MessageOnlyDataStore(mockMessage));
+      message = Message(_buildMessageProps(), ctx: ctx);
+    });
+
+    group('edit', () {
+      test('calls message.update with correct id and channelId', () async {
+        final builder = MessageBuilder.text('edited');
+        when(() => mockMessage.update<Message>(
+              id: any(named: 'id'),
+              channelId: any(named: 'channelId'),
+              builder: any(named: 'builder'),
+            )).thenAnswer((_) async => throw UnimplementedError());
+
+        expect(
+            () => message.edit(builder), throwsA(isA<UnimplementedError>()));
+
+        verify(() => mockMessage.update<Message>(
+              id: '777000777000777000',
+              channelId: '555000555000555000',
+              builder: any(named: 'builder'),
+            )).called(1);
+      });
+    });
+
+    group('delete', () {
+      test('calls message.delete with channelId and messageId', () async {
+        when(() => mockMessage.delete(any(), any())).thenAnswer((_) async {});
+
+        await message.delete();
+
+        verify(() => mockMessage.delete(
+              Snowflake('555000555000555000'),
+              Snowflake('777000777000777000'),
+            )).called(1);
+      });
+    });
+
+    group('pin', () {
+      test('calls message.pin with correct ids', () async {
+        when(() => mockMessage.pin(any(), any())).thenAnswer((_) async {});
+
+        await message.pin();
+
+        verify(() => mockMessage.pin(
+              Snowflake('555000555000555000'),
+              Snowflake('777000777000777000'),
+            )).called(1);
+      });
+    });
+
+    group('unpin', () {
+      test('calls message.unpin with correct ids', () async {
+        when(() => mockMessage.unpin(any(), any())).thenAnswer((_) async {});
+
+        await message.unpin();
+
+        verify(() => mockMessage.unpin(
+              Snowflake('555000555000555000'),
+              Snowflake('777000777000777000'),
+            )).called(1);
+      });
+    });
+
+    group('reply', () {
+      test('calls message.reply with message id and channelId', () async {
+        final builder = MessageBuilder.text('reply!');
+        when(() => mockMessage.reply<Channel, Message>(
+              any(),
+              any(),
+              any(),
+            )).thenAnswer((_) async => throw UnimplementedError());
+
+        expect(
+          () => message.reply<Message>(builder),
+          throwsA(isA<UnimplementedError>()),
+        );
+
+        verify(() => mockMessage.reply<Channel, Message>(
+              Snowflake('777000777000777000'),
+              Snowflake('555000555000555000'),
+              any(),
+            )).called(1);
+      });
+    });
+
+    group('forward', () {
+      test('calls message.forward with target channelId', () async {
+        final targetChannel = Snowflake('888000888000888000');
+        when(() => mockMessage.forward<Message>(
+              any(),
+              messageId: any(named: 'messageId'),
+              sourceChannelId: any(named: 'sourceChannelId'),
+              guildId: any(named: 'guildId'),
+            )).thenAnswer((_) async => throw UnimplementedError());
+
+        expect(
+          () => message.forward<Message>(targetChannel),
+          throwsA(isA<UnimplementedError>()),
+        );
+
+        verify(() => mockMessage.forward<Message>(
+              targetChannel,
+              messageId: Snowflake('777000777000777000'),
+              sourceChannelId: Snowflake('555000555000555000'),
+              guildId: any(named: 'guildId'),
+            )).called(1);
+      });
+    });
+  });
+
+  // ── ChannelMethods (shared) ──────────────────────────────────────────────
+
+  group('ChannelMethods — shared behaviour', () {
+    late _MockChannelPart mockChannel;
+    late ChannelMethods methods;
+
+    setUp(() {
+      mockChannel = _MockChannelPart();
+      final mockMessage = _MockMessagePart();
+      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      methods = ChannelMethods(
+        Snowflake('222000222000222000'),
+        Snowflake('555000555000555000'),
+        ctx: ctx,
+      );
+    });
+
+    test('setDescription calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await methods.setDescription('A text channel', null);
+
+      verify(() => mockChannel.update(
+            '555000555000555000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('setPosition calls channel.update', () async {
+      when(() => mockChannel.update(
+            any(),
+            any(),
+            guildId: any(named: 'guildId'),
+            reason: any(named: 'reason'),
+          )).thenAnswer((_) async => null);
+
+      await methods.setPosition(5, null);
+
+      verify(() => mockChannel.update(
+            '555000555000555000',
+            any(),
+            guildId: '222000222000222000',
+            reason: null,
+          )).called(1);
+    });
+
+    test('delete calls channel.delete with reason', () async {
+      when(() => mockChannel.delete(any(), any())).thenAnswer((_) async {});
+
+      await methods.delete('test-reason');
+
+      verify(() => mockChannel.delete('555000555000555000', 'test-reason'))
+          .called(1);
+    });
+  });
+}

--- a/packages/core/test/marshalling/serializers/channel_serializer_test.dart
+++ b/packages/core/test/marshalling/serializers/channel_serializer_test.dart
@@ -1,0 +1,447 @@
+import 'package:mineral/api.dart';
+import 'package:mineral/src/api/guild/channels/public_thread_channel.dart';
+import 'package:mineral/src/infrastructure/internals/marshaller/serializers/channel_serializer.dart';
+import 'package:test/test.dart';
+
+import '../../helpers/fake_cache_provider.dart';
+import '../../helpers/fake_entity_context.dart';
+import '../../helpers/fake_marshaller.dart';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Minimal normalised payload common to all guild text-like channels.
+Map<String, dynamic> _textChannelPayload({
+  String id = '100000000000000001',
+  int type = 0, // ChannelType.guildText
+  String name = 'general',
+  String guildId = '200000000000000001',
+}) =>
+    {
+      'id': id,
+      'type': type,
+      'name': name,
+      'position': 1,
+      'guild_id': guildId,
+      'parent_id': null,
+      'description': null,
+      'permission_overwrites': [],
+      'nsfw': false,
+    };
+
+/// Public thread channel normalised payload.
+Map<String, dynamic> _threadPayload({
+  String id = '300000000000000001',
+  int type = 11, // ChannelType.guildPublicThread
+  String name = 'thread-name',
+  String guildId = '200000000000000001',
+}) =>
+    {
+      'id': id,
+      'type': type,
+      'name': name,
+      'guild_id': guildId,
+      'parent_id': '100000000000000001',
+      'position': null,
+      'description': null,
+      'permission_overwrites': [],
+      'nsfw': false,
+      'last_message_id': null,
+      'flags': 0,
+      'rate_limit_per_user': 0,
+      'bitrate': 0,
+      'user_limit': 0,
+      'rtc_region': null,
+      'owner_id': '111000111000111000',
+      'thread_metadata': {
+        'archived': false,
+        'archive_timestamp': null,
+        'auto_archive_duration': 60,
+        'locked': false,
+      },
+      'message_count': 0,
+      'member_count': 0,
+      'total_message_sent': 0,
+    };
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+void main() {
+  group('ChannelSerializer', () {
+    late ChannelSerializer serializer;
+    late FakeCacheProvider cache;
+
+    setUp(() {
+      cache = FakeCacheProvider();
+      serializer = ChannelSerializer(
+        FakeMarshaller(cache: cache),
+        fakeEntityContext(),
+      );
+    });
+
+    // ── GuildTextChannel ─────────────────────────────────────────────────
+
+    group('guildText (type 0)', () {
+      test('serialize returns a GuildTextChannel', () async {
+        final payload = _textChannelPayload(type: 0);
+        final channel =
+            await serializer.serialize(payload) as GuildTextChannel;
+
+        expect(channel.type, equals(ChannelType.guildText));
+        expect(channel.id, equals(Snowflake('100000000000000001')));
+        expect(channel.name, equals('general'));
+        expect(channel.guildId, equals(Snowflake('200000000000000001')));
+      });
+
+      test('normalize caches channel payload under channel key', () async {
+        final raw = {
+          'id': '100000000000000001',
+          'type': 0,
+          'name': 'general',
+          'position': 1,
+          'guild_id': '200000000000000001',
+          'parent_id': null,
+          'topic': 'A test topic',
+          'permission_overwrites': [],
+        };
+
+        final result = await serializer.normalize(raw);
+
+        expect(result['id'], equals('100000000000000001'));
+        expect(result['type'], equals(0));
+        expect(result['name'], equals('general'));
+        // topic is remapped to description
+        expect(result['description'], equals('A test topic'));
+
+        // cache should contain the entry
+        final cacheKey = FakeMarshaller().cacheKey.channel('100000000000000001');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+
+      test('deserialize produces map with expected keys', () async {
+        final payload = _textChannelPayload(type: 0);
+        final channel = await serializer.serialize(payload) as GuildTextChannel;
+        final result = await serializer.deserialize(channel);
+
+        expect(result['id'], equals('100000000000000001'));
+        expect(result['type'], equals(0));
+        expect(result['name'], equals('general'));
+        expect(result['guild_id'], equals(Snowflake('200000000000000001')));
+      });
+    });
+
+    // ── GuildVoiceChannel ────────────────────────────────────────────────
+
+    group('guildVoice (type 2)', () {
+      test('serialize returns a GuildVoiceChannel with empty members list',
+          () async {
+        final payload = _textChannelPayload(type: 2);
+        final channel =
+            await serializer.serialize(payload) as GuildVoiceChannel;
+
+        expect(channel.type, equals(ChannelType.guildVoice));
+        expect(channel.members, isEmpty);
+      });
+
+      test('normalize caches voice channel payload', () async {
+        final raw = {
+          'id': '100000000000000002',
+          'type': 2,
+          'name': 'voice-chat',
+          'position': 2,
+          'guild_id': '200000000000000001',
+          'parent_id': null,
+          'permission_overwrites': [],
+        };
+
+        await serializer.normalize(raw);
+
+        final cacheKey = FakeMarshaller().cacheKey.channel('100000000000000002');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+
+      test('deserialize produces map with expected keys', () async {
+        final payload = _textChannelPayload(
+            id: '100000000000000002', type: 2, name: 'voice-chat');
+        final channel = await serializer.serialize(payload) as GuildVoiceChannel;
+        final result = await serializer.deserialize(channel);
+
+        expect(result['id'], equals('100000000000000002'));
+        expect(result['type'], equals(2));
+        expect(result['name'], equals('voice-chat'));
+      });
+    });
+
+    // ── GuildCategoryChannel ─────────────────────────────────────────────
+
+    group('guildCategory (type 4)', () {
+      test('serialize returns a GuildCategoryChannel', () async {
+        final payload = _textChannelPayload(
+            id: '100000000000000003', type: 4, name: 'category');
+        final channel =
+            await serializer.serialize(payload) as GuildCategoryChannel;
+
+        expect(channel.type, equals(ChannelType.guildCategory));
+        expect(channel.name, equals('category'));
+      });
+
+      test('normalize caches category payload', () async {
+        final raw = {
+          'id': '100000000000000003',
+          'type': 4,
+          'name': 'category',
+          'position': 0,
+          'guild_id': '200000000000000001',
+          'topic': null,
+          'nsfw': false,
+          'parent_id': null,
+          'permission_overwrites': [],
+        };
+
+        await serializer.normalize(raw);
+
+        final cacheKey = FakeMarshaller().cacheKey.channel('100000000000000003');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+    });
+
+    // ── GuildAnnouncementChannel ─────────────────────────────────────────
+
+    group('guildAnnouncement (type 5)', () {
+      test('serialize returns a GuildAnnouncementChannel', () async {
+        final payload = _textChannelPayload(
+            id: '100000000000000004', type: 5, name: 'announcements');
+        final channel =
+            await serializer.serialize(payload) as GuildAnnouncementChannel;
+
+        expect(channel.type, equals(ChannelType.guildAnnouncement));
+      });
+
+      test('deserialize produces map with expected keys', () async {
+        final payload = _textChannelPayload(
+            id: '100000000000000004', type: 5, name: 'announcements');
+        final channel =
+            await serializer.serialize(payload) as GuildAnnouncementChannel;
+        final result = await serializer.deserialize(channel);
+
+        expect(result['id'], equals('100000000000000004'));
+        expect(result['type'], equals(5));
+      });
+
+      test('normalize uses parent_id as category_id for announcement channels',
+          () async {
+        final raw = {
+          'id': '100000000000000004',
+          'type': 5,
+          'name': 'announcements',
+          'position': 1,
+          'guild_id': '200000000000000001',
+          'topic': null,
+          'nsfw': false,
+          'parent_id': '100000000000000003',
+          'permission_overwrites': [],
+        };
+
+        final result = await serializer.normalize(raw);
+
+        // GuildAnnouncementChannelFactory maps parent_id → category_id
+        expect(result['category_id'], equals('100000000000000003'));
+      });
+    });
+
+    // ── GuildForumChannel ────────────────────────────────────────────────
+
+    group('guildForum (type 15)', () {
+      test('serialize returns a GuildForumChannel', () async {
+        final payload = {
+          'id': '100000000000000005',
+          'type': 15,
+          'name': 'forum',
+          'guild_id': '200000000000000001',
+          'position': 1,
+          'parent_id': null,
+          'description': 'Forum channel',
+          'permission_overwrites': [],
+          'nsfw': false,
+          'default_sort_order': null,
+          'default_forum_layout': null,
+          // applied_tags intentionally omitted — defaults to empty list
+        };
+
+        final channel =
+            await serializer.serialize(payload) as GuildForumChannel;
+
+        expect(channel.type, equals(ChannelType.guildForum));
+        expect(channel.name, equals('forum'));
+      });
+
+      test('normalize caches forum payload', () async {
+        final raw = {
+          'id': '100000000000000005',
+          'type': 15,
+          'name': 'forum',
+          'position': 1,
+          'guild_id': '200000000000000001',
+          'topic': 'Forum discussions',
+          'nsfw': false,
+          'parent_id': null,
+          'permission_overwrites': [],
+        };
+
+        await serializer.normalize(raw);
+
+        final cacheKey = FakeMarshaller().cacheKey.channel('100000000000000005');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+    });
+
+    // ── GuildStageChannel ────────────────────────────────────────────────
+
+    group('guildStageVoice (type 13)', () {
+      test('serialize returns a GuildStageChannel', () async {
+        final payload = _textChannelPayload(
+            id: '100000000000000006', type: 13, name: 'stage');
+        final channel =
+            await serializer.serialize(payload) as GuildStageChannel;
+
+        expect(channel.type, equals(ChannelType.guildStageVoice));
+        expect(channel.name, equals('stage'));
+      });
+
+      test('normalize caches stage channel payload', () async {
+        final raw = {
+          'id': '100000000000000006',
+          'type': 13,
+          'name': 'stage',
+          'position': 1,
+          'guild_id': '200000000000000001',
+          'topic': null,
+          'parent_id': null,
+          'permission_overwrites': [],
+        };
+
+        await serializer.normalize(raw);
+
+        final cacheKey = FakeMarshaller().cacheKey.channel('100000000000000006');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+    });
+
+    // ── PublicThreadChannel ──────────────────────────────────────────────
+
+    group('guildPublicThread (type 11)', () {
+      test('serialize returns a PublicThreadChannel', () async {
+        final payload = _threadPayload(type: 11);
+        final channel =
+            await serializer.serialize(payload) as PublicThreadChannel;
+
+        expect(channel.type, equals(ChannelType.guildPublicThread));
+        expect(channel.name, equals('thread-name'));
+      });
+
+      test('serialize exposes ThreadMetadata with archived=false, locked=false',
+          () async {
+        final payload = _threadPayload(type: 11);
+        final channel =
+            await serializer.serialize(payload) as PublicThreadChannel;
+
+        expect(channel.metadata.archived, isFalse);
+        expect(channel.metadata.locked, isFalse);
+      });
+
+      test('normalize caches thread payload', () async {
+        final raw = {
+          'id': '300000000000000001',
+          'type': 11,
+          'name': 'cached-thread',
+          'guild_id': '200000000000000001',
+          'parent_id': '100000000000000001',
+          'position': null,
+          'permission_overwrites': [],
+          'last_message_id': null,
+          'flags': 0,
+          'rate_limit_per_user': 0,
+          'bitrate': 0,
+          'user_limit': 0,
+          'rtc_region': null,
+          'owner_id': '111000111000111000',
+          'thread_metadata': {
+            'archived': false,
+            'archive_timestamp': null,
+            'auto_archive_duration': 60,
+            'locked': false,
+          },
+          'message_count': 0,
+          'member_count': 0,
+          'total_message_sent': 0,
+        };
+
+        await serializer.normalize(raw);
+
+        final cacheKey = FakeMarshaller().cacheKey.channel('300000000000000001');
+        expect(cache.store.containsKey(cacheKey), isTrue);
+      });
+
+      test('deserialize produces map with expected keys', () async {
+        final payload = _threadPayload(type: 11);
+        final channel =
+            await serializer.serialize(payload) as PublicThreadChannel;
+        final result = await serializer.deserialize(channel);
+
+        expect(result['id'], equals('300000000000000001'));
+        expect(result['type'], equals(11));
+        expect(result['name'], equals('thread-name'));
+        expect(result['guild_id'], equals(Snowflake('200000000000000001')));
+        expect(result['thread_metadata'], isA<Map>());
+        expect(result['thread_metadata']['archived'], isFalse);
+      });
+    });
+
+    // ── Unknown channel type ─────────────────────────────────────────────
+
+    group('unknown channel type', () {
+      test('serialize falls back to unknown factory', () async {
+        // Unknown type value — no factory matches except UnknownChannelFactory
+        final payload = _textChannelPayload(type: 999);
+        // UnknownChannelFactory is the fallback
+        final channel = await serializer.serialize(payload);
+
+        expect(channel, isNotNull);
+        expect(channel!.type, equals(ChannelType.unknown));
+      });
+    });
+
+    // ── Channel type dispatch via type field ─────────────────────────────
+
+    group('type-based dispatch', () {
+      test('dispatches to GuildTextChannel for type 0', () async {
+        final channel = await serializer.serialize(
+            _textChannelPayload(id: '1', type: 0));
+        expect(channel, isA<GuildTextChannel>());
+      });
+
+      test('dispatches to GuildVoiceChannel for type 2', () async {
+        final channel = await serializer.serialize(
+            _textChannelPayload(id: '2', type: 2));
+        expect(channel, isA<GuildVoiceChannel>());
+      });
+
+      test('dispatches to GuildCategoryChannel for type 4', () async {
+        final channel = await serializer.serialize(
+            _textChannelPayload(id: '3', type: 4));
+        expect(channel, isA<GuildCategoryChannel>());
+      });
+
+      test('dispatches to GuildAnnouncementChannel for type 5', () async {
+        final channel = await serializer.serialize(
+            _textChannelPayload(id: '4', type: 5));
+        expect(channel, isA<GuildAnnouncementChannel>());
+      });
+
+      test('dispatches to GuildStageChannel for type 13', () async {
+        final channel = await serializer.serialize(
+            _textChannelPayload(id: '5', type: 13));
+        expect(channel, isA<GuildStageChannel>());
+      });
+    });
+  });
+}

--- a/packages/core/test/wss/shard_dispatch_test.dart
+++ b/packages/core/test/wss/shard_dispatch_test.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+
+import 'package:mineral/src/domains/services/packets/packet_dispatcher.dart';
+import 'package:mineral/src/domains/services/packets/packet_type.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
+import 'package:mineral/src/domains/services/wss/running_strategy.dart';
+import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
+import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart';
+import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_data.dart';
+import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart';
+import 'package:mineral/src/infrastructure/internals/wss/running_strategies/default_running_strategy.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mineral/src/infrastructure/services/wss/websocket_message.dart';
+import 'package:mineral/src/testing/fake_logger.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_websocket_client.dart';
+import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Minimal [PacketDispatcherContract] that records every payload dispatched.
+final class _SpyPacketDispatcher implements PacketDispatcherContract {
+  final List<dynamic> dispatched = [];
+
+  @override
+  void dispatch(dynamic payload) {
+    dispatched.add(payload);
+  }
+
+  @override
+  void listen(PacketTypeContract packet,
+      Function(ShardMessage, DispatchEvent) listener) {}
+
+  @override
+  void dispose() {}
+}
+
+/// A [DefaultRunningStrategy] subclass that short-circuits the filesystem
+/// pubspec read so tests do not need a real pubspec.yaml.
+final class _NoPubspecStrategy extends DefaultRunningStrategy {
+  _NoPubspecStrategy(super.packetDispatcher) : super(logger: FakeLogger());
+
+  @override
+  Future<Map> readPubspec(String location) async =>
+      {'version': '5.0.0', 'dependencies': {}};
+}
+
+WebsocketMessage<ShardMessage> _message(ShardMessage content) =>
+    WebsocketMessageImpl(
+      channelName: 'test',
+      originalContent: null,
+      content: content,
+    );
+
+Shard _shard({required RunningStrategy strategy, FakeLogger? logger}) => Shard(
+      shardName: 'test-shard-0',
+      shardIndex: 0,
+      shardCount: 1,
+      url: 'wss://fake',
+      wss: FakeWebsocketOrchestrator(),
+      logger: logger ?? FakeLogger(),
+      strategy: strategy,
+    )..client = FakeWebsocketClient();
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+void main() {
+  // ── DefaultRunningStrategy.dispatch ──────────────────────────────────────
+
+  group('DefaultRunningStrategy.dispatch', () {
+    late _SpyPacketDispatcher spy;
+    late DefaultRunningStrategy strategy;
+
+    setUp(() {
+      spy = _SpyPacketDispatcher();
+      strategy = _NoPubspecStrategy(spy);
+    });
+
+    test('forwards payload.content to packetDispatcher.dispatch', () {
+      final msg = ShardMessage(
+        type: 'GUILD_CREATE',
+        opCode: OpCode.dispatch,
+        sequence: 1,
+        payload: {'id': '123'},
+      );
+      strategy.dispatch(_message(msg));
+
+      expect(spy.dispatched, hasLength(1));
+      expect(spy.dispatched.first, same(msg));
+    });
+
+    test('dispatches multiple messages in order', () {
+      final messages = [
+        ShardMessage(
+            type: 'M1', opCode: OpCode.dispatch, sequence: 1, payload: {}),
+        ShardMessage(
+            type: 'M2', opCode: OpCode.dispatch, sequence: 2, payload: {}),
+        ShardMessage(
+            type: 'M3', opCode: OpCode.dispatch, sequence: 3, payload: {}),
+      ];
+
+      for (final m in messages) {
+        strategy.dispatch(_message(m));
+      }
+
+      expect(spy.dispatched, hasLength(3));
+      expect((spy.dispatched[0] as ShardMessage).type, equals('M1'));
+      expect((spy.dispatched[1] as ShardMessage).type, equals('M2'));
+      expect((spy.dispatched[2] as ShardMessage).type, equals('M3'));
+    });
+
+    test('dispatches messages with null type', () {
+      final msg = ShardMessage(
+        type: null,
+        opCode: OpCode.heartbeatAck,
+        sequence: null,
+        payload: null,
+      );
+      strategy.dispatch(_message(msg));
+
+      expect(spy.dispatched, hasLength(1));
+    });
+  });
+
+  // ── DefaultRunningStrategy.init ───────────────────────────────────────────
+
+  group('DefaultRunningStrategy.init', () {
+    late _SpyPacketDispatcher spy;
+    late _NoPubspecStrategy strategy;
+
+    setUp(() {
+      spy = _SpyPacketDispatcher();
+      strategy = _NoPubspecStrategy(spy);
+    });
+
+    test('init calls createShards with the strategy itself', () async {
+      RunningStrategy? received;
+      await strategy.init((s) async {
+        received = s;
+      });
+
+      expect(received, same(strategy));
+    });
+
+    test('init calls createShards exactly once', () async {
+      var callCount = 0;
+      await strategy.init((_) async {
+        callCount++;
+      });
+
+      expect(callCount, equals(1));
+    });
+
+    test('init propagates exceptions from createShards', () async {
+      expect(
+        () => strategy.init((_) async => throw Exception('shard init failed')),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  // ── Shard constructor wiring ──────────────────────────────────────────────
+
+  group('Shard constructor wiring', () {
+    test('creates ShardAuthentication linked to this shard', () {
+      final shard = _shard(strategy: FakeRunningStrategy());
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.authentication, isA<ShardAuthentication>());
+    });
+
+    test('creates ShardNetworkError linked to this shard', () {
+      final shard = _shard(strategy: FakeRunningStrategy());
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.networkError, isA<ShardNetworkError>());
+    });
+
+    test('creates ShardData (dispatchEvent) linked to this shard', () {
+      final shard = _shard(strategy: FakeRunningStrategy());
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.dispatchEvent, isA<ShardData>());
+    });
+
+    test('exposes correct shardName', () {
+      final shard = _shard(strategy: FakeRunningStrategy());
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.shardName, equals('test-shard-0'));
+    });
+
+    test('exposes correct shardIndex and shardCount', () {
+      final shard = Shard(
+        shardName: 'test-shard-2',
+        shardIndex: 2,
+        shardCount: 4,
+        url: 'wss://fake',
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        strategy: FakeRunningStrategy(),
+      )..client = FakeWebsocketClient();
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.shardIndex, equals(2));
+      expect(shard.shardCount, equals(4));
+    });
+
+    test('onceEventQueue starts empty', () {
+      final shard = _shard(strategy: FakeRunningStrategy());
+      shard.authentication.cancelHeartbeat();
+
+      expect(shard.onceEventQueue, isEmpty);
+    });
+  });
+
+  // ── Shard dispatch integration: ShardData → strategy ────────────────────
+
+  group('Shard ShardData dispatch integration', () {
+    late _SpyPacketDispatcher spy;
+    late Shard shard;
+
+    setUp(() {
+      spy = _SpyPacketDispatcher();
+      final strategy = _NoPubspecStrategy(spy);
+      shard = Shard(
+        shardName: 'test-shard-0',
+        shardIndex: 0,
+        shardCount: 1,
+        url: 'wss://fake',
+        wss: FakeWebsocketOrchestrator(),
+        logger: FakeLogger(),
+        strategy: strategy,
+      )..client = FakeWebsocketClient();
+    });
+
+    tearDown(() {
+      shard.authentication.cancelHeartbeat();
+    });
+
+    test('ShardData.dispatch delegates to the running strategy', () {
+      final msg = _message(ShardMessage(
+        type: 'MESSAGE_CREATE',
+        opCode: OpCode.dispatch,
+        sequence: 5,
+        payload: {'content': 'hello'},
+      ));
+
+      shard.dispatchEvent.dispatch(msg);
+
+      expect(spy.dispatched, hasLength(1));
+      expect(
+          (spy.dispatched.first as ShardMessage).type, equals('MESSAGE_CREATE'));
+    });
+
+    test('ShardData.dispatch updates shard sequence', () {
+      shard.dispatchEvent.dispatch(_message(ShardMessage(
+        type: 'CHANNEL_UPDATE',
+        opCode: OpCode.dispatch,
+        sequence: 77,
+        payload: {},
+      )));
+
+      expect(shard.authentication.sequence, equals(77));
+    });
+
+    test('ShardData.dispatch stores READY payload in sessionId', () {
+      shard.dispatchEvent.dispatch(_message(ShardMessage(
+        type: 'READY',
+        opCode: OpCode.dispatch,
+        sequence: 1,
+        payload: {
+          'session_id': 'sess-abc',
+          'resume_gateway_url': 'wss://resume.discord.gg',
+        },
+      )));
+
+      expect(shard.authentication.sessionId, equals('sess-abc'));
+      expect(
+          shard.authentication.resumeUrl, equals('wss://resume.discord.gg'));
+    });
+
+    test('ShardData.dispatch handles null payload type gracefully', () {
+      expect(
+        () => shard.dispatchEvent.dispatch(_message(ShardMessage(
+          type: null,
+          opCode: OpCode.heartbeatAck,
+          sequence: null,
+          payload: null,
+        ))),
+        returnsNormally,
+      );
+    });
+  });
+
+  // ── Shard sequence tracking ───────────────────────────────────────────────
+
+  group('Shard sequence tracking', () {
+    late Shard shard;
+
+    setUp(() {
+      shard = _shard(strategy: FakeRunningStrategy());
+    });
+
+    tearDown(() {
+      shard.authentication.cancelHeartbeat();
+    });
+
+    test('sequence starts null', () {
+      expect(shard.authentication.sequence, isNull);
+    });
+
+    test('sequence is updated after each dispatch', () {
+      shard.dispatchEvent.dispatch(_message(ShardMessage(
+        type: 'EVT',
+        opCode: OpCode.dispatch,
+        sequence: 10,
+        payload: {},
+      )));
+
+      expect(shard.authentication.sequence, equals(10));
+
+      shard.dispatchEvent.dispatch(_message(ShardMessage(
+        type: 'EVT',
+        opCode: OpCode.dispatch,
+        sequence: 20,
+        payload: {},
+      )));
+
+      expect(shard.authentication.sequence, equals(20));
+    });
+
+    test('sequence is not overwritten by messages without a sequence', () {
+      shard.authentication.sequence = 42;
+
+      shard.dispatchEvent.dispatch(_message(ShardMessage(
+        type: null,
+        opCode: OpCode.heartbeatAck,
+        sequence: null,
+        payload: null,
+      )));
+
+      expect(shard.authentication.sequence, equals(42));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **M13** (32 tests): behavioural methods on `Member` (ban/kick/timeout), `MemberRoleManager`, `Role`, `GuildTextChannel`/`GuildVoiceChannel`/`ChannelMethods`, `Message` (edit/delete/pin/reply/forward) — each asserts the right datastore/part call + payload.
- **M14** (25 tests): `channel_serializer_test.dart` covering text/voice/category/announcement/forum/stage/public-thread + unknown fallback (serialize/normalize/deserialize + polymorphic dispatch).
- **M15** (19 tests): `DefaultRunningStrategy` dispatch/init, `Shard` constructor wiring, `ShardData` sequence/READY handling. `Shard.init()` skipped (instantiates `WebsocketClientImpl` directly — needs injection; auth/reconnect already covered elsewhere).

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] `dart test packages/core` — 1575/1575 (+76)

Closes #451