### PR TITLE
test: consolidate inline DataStore fakes onto a shared mock (M4/M16)

### DIFF
--- a/packages/core/test/api/entity_behaviour_test.dart
+++ b/packages/core/test/api/entity_behaviour_test.dart
@@ -9,6 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 
 // ── Fakes & Mocks ──────────────────────────────────────────────────────────
 
@@ -23,69 +24,33 @@ class _MockChannelPart extends Mock implements ChannelPartContract {}
 
 class _MockMessagePart extends Mock implements MessagePartContract {}
 
-// ── Minimal DataStoreContract implementations ──────────────────────────────
-//
-// Because DataStoreContract is an abstract interface (not final), we can
-// implement it directly and override only the parts we need.
+// ── DataStore factory helpers ──────────────────────────────────────────────
 
-final class _MemberRoleDataStore implements DataStoreContract {
-  final MemberPartContract _member;
-  final RolePartContract _role;
-
-  _MemberRoleDataStore(this._member, this._role);
-
-  @override
-  MemberPartContract get member => _member;
-
-  @override
-  RolePartContract get role => _role;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
+MockDataStore _memberRoleDs(MemberPartContract member, RolePartContract role) {
+  final ds = MockDataStore();
+  when(() => ds.member).thenReturn(member);
+  when(() => ds.role).thenReturn(role);
+  return ds;
 }
 
-final class _ChannelMessageDataStore implements DataStoreContract {
-  final ChannelPartContract _channel;
-  final MessagePartContract _message;
-
-  _ChannelMessageDataStore(this._channel, this._message);
-
-  @override
-  ChannelPartContract get channel => _channel;
-
-  @override
-  MessagePartContract get message => _message;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
+MockDataStore _channelMessageDs(
+    ChannelPartContract channel, MessagePartContract message) {
+  final ds = MockDataStore();
+  when(() => ds.channel).thenReturn(channel);
+  when(() => ds.message).thenReturn(message);
+  return ds;
 }
 
-final class _MessageOnlyDataStore implements DataStoreContract {
-  final MessagePartContract _message;
-
-  _MessageOnlyDataStore(this._message);
-
-  @override
-  MessagePartContract get message => _message;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
+MockDataStore _messageOnlyDs(MessagePartContract message) {
+  final ds = MockDataStore();
+  when(() => ds.message).thenReturn(message);
+  return ds;
 }
 
-final class _RoleDataStore implements DataStoreContract {
-  final RolePartContract _role;
-
-  _RoleDataStore(this._role);
-
-  @override
-  RolePartContract get role => _role;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
+MockDataStore _roleOnlyDs(RolePartContract role) {
+  final ds = MockDataStore();
+  when(() => ds.role).thenReturn(role);
+  return ds;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -252,7 +217,7 @@ void main() {
     setUp(() {
       mockMember = _MockMemberPart();
       mockRole = _MockRolePart();
-      final ctx = _ctx(_MemberRoleDataStore(mockMember, mockRole));
+      final ctx = _ctx(_memberRoleDs(mockMember, mockRole));
       member = _buildMember(ctx);
     });
 
@@ -413,7 +378,7 @@ void main() {
     setUp(() {
       mockMember = _MockMemberPart();
       mockRole = _MockRolePart();
-      final ctx = _ctx(_MemberRoleDataStore(mockMember, mockRole));
+      final ctx = _ctx(_memberRoleDs(mockMember, mockRole));
       member = _buildMember(ctx);
     });
 
@@ -503,7 +468,7 @@ void main() {
 
     setUp(() {
       mockRole = _MockRolePart();
-      final ctx = _ctx(_RoleDataStore(mockRole));
+      final ctx = _ctx(_roleOnlyDs(mockRole));
       role = _buildRole(ctx);
     });
 
@@ -621,7 +586,7 @@ void main() {
     setUp(() {
       mockChannel = _MockChannelPart();
       mockMessage = _MockMessagePart();
-      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      final ctx = _ctx(_channelMessageDs(mockChannel, mockMessage));
       channel = GuildTextChannel(_buildTextProps(ctx));
     });
 
@@ -684,7 +649,7 @@ void main() {
     setUp(() {
       mockChannel = _MockChannelPart();
       final mockMessage = _MockMessagePart();
-      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      final ctx = _ctx(_channelMessageDs(mockChannel, mockMessage));
       voiceChannel = GuildVoiceChannel(_buildVoiceProps(ctx))..members = [];
     });
 
@@ -751,7 +716,7 @@ void main() {
 
     setUp(() {
       mockMessage = _MockMessagePart();
-      final ctx = _ctx(_MessageOnlyDataStore(mockMessage));
+      final ctx = _ctx(_messageOnlyDs(mockMessage));
       message = Message(_buildMessageProps(), ctx: ctx);
     });
 
@@ -870,7 +835,7 @@ void main() {
     setUp(() {
       mockChannel = _MockChannelPart();
       final mockMessage = _MockMessagePart();
-      final ctx = _ctx(_ChannelMessageDataStore(mockChannel, mockMessage));
+      final ctx = _ctx(_channelMessageDs(mockChannel, mockMessage));
       methods = ChannelMethods(
         Snowflake('222000222000222000'),
         Snowflake('555000555000555000'),

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -1,15 +1,15 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
 import '../helpers/ioc_test_helper.dart';
+import '../helpers/mocks.dart';
 
 // ── Fake interaction part that captures sendAutocompleteResult calls ──────────
 
@@ -58,70 +58,10 @@ final class _FakeInteractionPart implements InteractionPartContract {
       throw UnimplementedError();
 }
 
-// ── Minimal DataStore that routes interaction to the fake part ────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final _FakeInteractionPart _interaction;
-
-  _FakeDataStore(this._interaction);
-
-  @override
-  InteractionPartContract get interaction => _interaction;
-
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-}
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 CommandInteractionManager _buildManager({
-  required _FakeDataStore dataStore,
+  required MockDataStore dataStore,
   required MarshallerContract marshaller,
 }) {
   return CommandInteractionManager(
@@ -141,7 +81,7 @@ CommandInteractionManager _buildManager({
 void main() {
   group('CommandInteractionManager.handleAutocomplete', () {
     late _FakeInteractionPart fakePart;
-    late _FakeDataStore fakeDataStore;
+    late MockDataStore fakeDataStore;
     late FakeLogger logger;
     late FakeMarshaller marshaller;
     late CommandInteractionManager manager;
@@ -149,7 +89,8 @@ void main() {
 
     setUp(() {
       fakePart = _FakeInteractionPart();
-      fakeDataStore = _FakeDataStore(fakePart);
+      fakeDataStore = MockDataStore();
+      when(() => fakeDataStore.interaction).thenReturn(fakePart);
       logger = FakeLogger();
       marshaller = FakeMarshaller(logger: logger);
 

--- a/packages/core/test/commands/command_interaction_dispatcher_test.dart
+++ b/packages/core/test/commands/command_interaction_dispatcher_test.dart
@@ -1,9 +1,8 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/domains/commands/command_interaction_dispatcher.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_entity_context.dart';
@@ -12,6 +11,24 @@ import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
 import '../helpers/ioc_test_helper.dart';
 import '../helpers/mocks.dart';
+
+/// Builds a [MockDataStore] pre-stubbed with channel (returns null) and user
+/// (returns a minimal User) — the only parts exercised by the dispatcher tests.
+MockDataStore _buildFakeDataStore() {
+  final ds = MockDataStore();
+
+  // channel part: always returns null (no active DM / guild channel lookup)
+  final channelPart = MockChannelPart();
+  when(() => channelPart.get<Channel>(any(), any())).thenAnswer((_) async => null);
+  when(() => ds.channel).thenReturn(channelPart);
+
+  // user part: returns a minimal User for any id
+  final ctx = fakeEntityContext();
+  final userPart = _FakeUserPart(ctx);
+  when(() => ds.user).thenReturn(userPart);
+
+  return ds;
+}
 
 final class _FakeUserPart implements UserPartContract {
   final EntityContext _ctx;
@@ -41,85 +58,6 @@ final class _FakeUserPart implements UserPartContract {
   }
 }
 
-final class _FakeChannelPart implements ChannelPartContract {
-  @override
-  Future<T?> get<T extends Channel>(Object id, bool force) async => null;
-  @override
-  Future<Map<Snowflake, T>> fetch<T extends Channel>(
-          Object guildId, bool force) async =>
-      {};
-  @override
-  Future<T> create<T extends Channel>(
-          Object? guildId, ChannelBuilderContract builder,
-          {String? reason}) =>
-      throw UnimplementedError();
-  @override
-  Future<PrivateChannel?> createPrivateChannel(
-          Object id, String recipientId) async =>
-      null;
-  @override
-  Future<T?> update<T extends Channel>(
-          Object id, ChannelBuilderContract builder,
-          {Object? guildId, String? reason}) =>
-      throw UnimplementedError();
-  @override
-  Future<void> delete(Object id, String? reason) async {}
-}
-
-final class _FakeDataStore implements DataStoreContract {
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClient get client => throw UnimplementedError();
-  @override
-  ChannelPartContract get channel => _FakeChannelPart();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => _FakeUserPart(fakeEntityContext());
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 void main() {
@@ -137,7 +75,7 @@ void main() {
       manager = FakeCommandInteractionManager();
 
       final fakeMarshaller = FakeMarshaller(logger: logger);
-      final fakeDataStore = _FakeDataStore();
+      final fakeDataStore = _buildFakeDataStore();
 
       dispatcher = CommandInteractionDispatcher(
         manager,

--- a/packages/core/test/helpers/mocks.dart
+++ b/packages/core/test/helpers/mocks.dart
@@ -38,6 +38,12 @@ class MockInteractiveComponentManager extends Mock
 
 class MockChannelPart extends Mock implements ChannelPartContract {}
 
+/// A mocktail mock for [DataStoreContract].
+///
+/// All getters are handled by mocktail's [noSuchMethod]; stub the ones you
+/// need with `when(() => ds.guild).thenReturn(myPart)`.
+class MockDataStore extends Mock implements DataStoreContract {}
+
 class MockRunningStrategy extends Mock implements RunningStrategy {}
 
 class MockHttpClient extends Mock implements HttpClientContract {}

--- a/packages/core/test/packets/application_command_permissions_update_packet_test.dart
+++ b/packages/core/test/packets/application_command_permissions_update_packet_test.dart
@@ -1,20 +1,15 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/application_command_permissions_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── Test IDs ──────────────────────────────────────────────────────────────────
 
@@ -24,257 +19,6 @@ const _commandId = '111000111000111000';
 const _roleId = '333444555666777888';
 const _userId = '444555666777888999';
 const _channelId = '555666777888999000';
-
-// ── No-op stub ────────────────────────────────────────────────────────────────
-
-final class _NoopDs implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Deferred data store ───────────────────────────────────────────────────────
-
-final class _DeferredDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-
-  _DeferredDataStore(this._resolve);
-
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  ChannelPartContract get channel => _resolve().channel;
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Fake data store ───────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-
-  _FakeDataStore({required GuildPartContract guildPart})
-      : _guildPart = guildPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Fake guild part ──────────────────────────────────────────────────────────
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-// ── Domain object builder ─────────────────────────────────────────────────────
-
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
 
 // ── Shard message factory ─────────────────────────────────────────────────────
 
@@ -302,7 +46,7 @@ void main() {
 
     test('packetType is applicationCommandPermissionsUpdate', () {
       final packet =
-          ApplicationCommandPermissionsUpdatePacket(dataStore: _NoopDs());
+          ApplicationCommandPermissionsUpdatePacket(dataStore: buildMockDs());
       expect(packet.packetType,
           equals(PacketType.applicationCommandPermissionsUpdate));
       expect(packet.packetType.name,
@@ -316,19 +60,9 @@ void main() {
       late Guild guild;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
-        guild = _buildServer(ctx);
-
-        ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
-
+        final ds = MockDataStore();
+        guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+        when(() => ds.guild).thenReturn(FakeGuildPart(guild));
         packet = ApplicationCommandPermissionsUpdatePacket(dataStore: ds);
       });
 

--- a/packages/core/test/packets/automoderation_packets_test.dart
+++ b/packages/core/test/packets/automoderation_packets_test.dart
@@ -3,8 +3,6 @@ library;
 
 import 'package:mineral/api.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/automoderation_rule_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/automoderation_rule_delete_packet.dart';
@@ -14,9 +12,9 @@ import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -70,12 +68,7 @@ void main() {
 
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => throw UnimplementedError()),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: MockDataStore(), wss: wss),
     );
   });
 

--- a/packages/core/test/packets/channel_packets_test.dart
+++ b/packages/core/test/packets/channel_packets_test.dart
@@ -1,11 +1,7 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/channel_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/channel_delete_packet.dart';
@@ -13,12 +9,14 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/channel_p
 import 'package:mineral/src/infrastructure/internals/packets/listeners/channel_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
 import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -65,31 +63,17 @@ void main() {
     cache = FakeCacheProvider();
     logger = FakeLogger();
 
-    late _FakeDataStore dsFinal;
+    final ds = MockDataStore();
+    final ctx = buildCtx(dataStore: ds, wss: wss);
+    fakeGuild = buildMinimalGuild(_guildId, ctx);
+    fakeChannel = _buildGuildTextChannel(ctx);
+    when(() => ds.guild).thenReturn(FakeGuildPart(fakeGuild));
+    when(() => ds.channel).thenReturn(FakeChannelPart(fakeChannel));
+
     marshaller = FakeMarshaller(
       cache: cache,
       logger: logger,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: logger,
-        runtimeState: RuntimeState(),
-      ),
-    );
-
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: logger,
-      runtimeState: RuntimeState(),
-    );
-
-    fakeGuild = buildMinimalGuild(_guildId, ctx);
-    fakeChannel = _buildGuildTextChannel(ctx);
-
-    dsFinal = _FakeDataStore(
-      guildPart: FakeGuildPart(fakeGuild),
-      channelPart: FakeChannelPart(fakeChannel),
+      entityContext: buildCtx(dataStore: ds, wss: wss),
     );
   });
 
@@ -309,12 +293,12 @@ void main() {
   // ── CHANNEL_PINS_UPDATE ────────────────────────────────────────────────────
 
   group('ChannelPinsUpdatePacket', () {
-    late _FakeDataStore dataStore;
+    late MockDataStore dataStore;
 
     setUp(() {
-      dataStore = _FakeDataStore(
-        guildPart: FakeGuildPart(fakeGuild),
-        channelPart: FakeChannelPart(fakeChannel),
+      dataStore = buildMockDs(
+        guild: FakeGuildPart(fakeGuild),
+        channel: FakeChannelPart(fakeChannel),
       );
     });
 
@@ -418,71 +402,3 @@ GuildTextChannel _buildGuildTextChannel(EntityContext ctx) => GuildTextChannel(
       ),
     );
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final ChannelPartContract _channelPart;
-
-  _FakeDataStore({
-    required GuildPartContract guildPart,
-    required ChannelPartContract channelPart,
-  })  : _guildPart = guildPart,
-        _channelPart = channelPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  ChannelPartContract get channel => _channelPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/guild_assets_packets_test.dart
+++ b/packages/core/test/packets/guild_assets_packets_test.dart
@@ -2,23 +2,19 @@
 library;
 
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_emojis_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_stickers_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -77,33 +73,22 @@ void main() {
   late FakeCacheProvider cache;
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
-  late _FakeGuildDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() {
     wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeGuildDataStore dsFinal;
+    dataStore = MockDataStore();
+
+    final ctx = buildCtx(dataStore: dataStore, wss: wss);
+    fakeGuild = buildMinimalGuild(_guildId, ctx);
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
     );
-
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-    fakeGuild = buildMinimalGuild(_guildId, ctx);
-    dsFinal = _FakeGuildDataStore(FakeGuildPart(fakeGuild));
-    dataStore = dsFinal;
   });
 
   // ── GUILD_EMOJIS_UPDATE ────────────────────────────────────────────────────
@@ -211,65 +196,3 @@ void main() {
   });
 }
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeGuildDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  _FakeGuildDataStore(this._guildPart);
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/guild_audit_log_packet_test.dart
+++ b/packages/core/test/packets/guild_audit_log_packet_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 
 import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
-import 'helpers/packet_test_helpers.dart';
+import '../helpers/mocks.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
@@ -50,7 +50,7 @@ void main() {
   setUp(() {
     logger = FakeLogger();
     ctx = EntityContext(
-      datastore: LazyDataStore(() => throw UnimplementedError()),
+      datastore: MockDataStore(),
       wss: FakeWebsocketOrchestrator(),
       logger: logger,
       runtimeState: RuntimeState(),

--- a/packages/core/test/packets/guild_ban_packets_test.dart
+++ b/packages/core/test/packets/guild_ban_packets_test.dart
@@ -1,21 +1,17 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_ban_add_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_ban_remove_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -53,31 +49,21 @@ void main() {
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
   late User fakeUser;
-  late _FakeDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() async {
     final wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeDataStore dsFinal;
+    dataStore = MockDataStore();
+    final ctx = buildCtx(dataStore: dataStore, wss: wss);
+    fakeGuild = buildMinimalGuild(_guildId, ctx);
+
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
     );
 
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-    fakeGuild = buildMinimalGuild(_guildId, ctx);
     fakeUser = await marshaller.serializers.user.serialize(
       await marshaller.serializers.user.normalize({
         'id': _userId,
@@ -90,11 +76,8 @@ void main() {
       }),
     );
 
-    dsFinal = _FakeDataStore(
-      guildPart: FakeGuildPart(fakeGuild),
-      userPart: FakeUserPart(fakeUser),
-    );
-    dataStore = dsFinal;
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+    when(() => dataStore.user).thenReturn(FakeUserPart(fakeUser));
   });
 
   // ── GUILD_BAN_ADD ──────────────────────────────────────────────────────────
@@ -214,71 +197,3 @@ void main() {
   });
 }
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final UserPartContract _userPart;
-
-  _FakeDataStore({
-    required GuildPartContract guildPart,
-    required UserPartContract userPart,
-  })  : _guildPart = guildPart,
-        _userPart = userPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  UserPartContract get user => _userPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/guild_create_packet_test.dart
+++ b/packages/core/test/packets/guild_create_packet_test.dart
@@ -14,6 +14,7 @@ import '../helpers/fake_cache_provider.dart';
 import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
@@ -136,7 +137,7 @@ void main() {
       runtimeState = RuntimeState();
 
       ctx = EntityContext(
-        datastore: _NullDataStore(),
+        datastore: MockDataStore(),
         wss: wss,
         logger: logger,
         runtimeState: runtimeState,
@@ -252,8 +253,3 @@ void main() {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-final class _NullDataStore implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}

--- a/packages/core/test/packets/guild_lifecycle_packets_test.dart
+++ b/packages/core/test/packets/guild_lifecycle_packets_test.dart
@@ -3,8 +3,6 @@ library;
 
 import 'package:mineral/api.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_update_packet.dart';
@@ -13,9 +11,9 @@ import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -77,12 +75,7 @@ void main() {
 
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => throw UnimplementedError()),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: MockDataStore(), wss: wss),
     );
   });
 

--- a/packages/core/test/packets/guild_member_packets_test.dart
+++ b/packages/core/test/packets/guild_member_packets_test.dart
@@ -1,12 +1,6 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_add_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_chunk_packet.dart';
@@ -14,12 +8,14 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_mem
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_member_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
@@ -93,6 +89,17 @@ ShardMessage<dynamic> _msg(String type, Map<String, dynamic> payload) =>
       payload: payload,
     );
 
+// ── Fake member part ──────────────────────────────────────────────────────────
+
+class _FakeMemberPart extends Mock implements MemberPartContract {
+  final Member _member;
+  _FakeMemberPart(this._member);
+
+  @override
+  Future<Member?> get(Object guildId, Object memberId, bool force) async =>
+      _member;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 void main() {
@@ -100,31 +107,20 @@ void main() {
   late FakeCacheProvider cache;
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
-  late _FakeDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() async {
     wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeDataStore dsFinal;
+    dataStore = MockDataStore();
+
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: _LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
     );
 
-    // Build guild through the serializer so managers get correct context.
-    final ctx = EntityContext(
-      datastore: _LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-    fakeGuild = _minimalGuild(ctx);
+    fakeGuild = buildMinimalGuild(_guildId, buildCtx(dataStore: dataStore, wss: wss));
 
     // Also pre-populate a normalized member in cache (needed for update test).
     final normalizedMember = await marshaller.serializers.member.normalize({
@@ -132,26 +128,23 @@ void main() {
       'guild_id': _guildId,
     });
 
-    dsFinal = _FakeDataStore(
-      guildPart: _FakeGuildPart(fakeGuild),
-      userPart: _FakeUserPart(
-        await marshaller.serializers.user.serialize(
-          await marshaller.serializers.user.normalize({
-            'id': _userId,
-            'username': 'TestMember',
-            'discriminator': '0001',
-            'avatar': null,
-            'bot': false,
-            'global_name': null,
-            'public_flags': 0,
-          }),
-        ),
-      ),
-      memberPart: _FakeMemberPart(
-        await marshaller.serializers.member.serialize(normalizedMember),
-      ),
+    final user = await marshaller.serializers.user.serialize(
+      await marshaller.serializers.user.normalize({
+        'id': _userId,
+        'username': 'TestMember',
+        'discriminator': '0001',
+        'avatar': null,
+        'bot': false,
+        'global_name': null,
+        'public_flags': 0,
+      }),
     );
-    dataStore = dsFinal;
+
+    final member = await marshaller.serializers.member.serialize(normalizedMember);
+
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+    when(() => dataStore.user).thenReturn(FakeUserPart(user));
+    when(() => dataStore.member).thenReturn(_FakeMemberPart(member));
   });
 
   // ── GUILD_MEMBER_ADD ───────────────────────────────────────────────────────
@@ -375,227 +368,4 @@ void main() {
       expect(args!.members, hasLength(1));
     });
   });
-}
-
-// ── Domain object helpers ─────────────────────────────────────────────────────
-
-Guild _minimalGuild(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
-
-// ── Shared fakes ──────────────────────────────────────────────────────────────
-
-final class _FakeGuildPart implements GuildPartContract {
-  final Guild _guild;
-  _FakeGuildPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeUserPart implements UserPartContract {
-  final User _user;
-  _FakeUserPart(this._user);
-
-  @override
-  Future<User?> get(Object id, bool force) async => _user;
-}
-
-final class _FakeMemberPart implements MemberPartContract {
-  final Member _member;
-  _FakeMemberPart(this._member);
-
-  @override
-  Future<Member?> get(Object guildId, Object memberId, bool force) async =>
-      _member;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final UserPartContract _userPart;
-  final MemberPartContract _memberPart;
-
-  _FakeDataStore({
-    required GuildPartContract guildPart,
-    required UserPartContract userPart,
-    required MemberPartContract memberPart,
-  })  : _guildPart = guildPart,
-        _userPart = userPart,
-        _memberPart = memberPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  UserPartContract get user => _userPart;
-  @override
-  MemberPartContract get member => _memberPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class _LazyDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-  _LazyDataStore(this._resolve);
-
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  MemberPartContract get member => _resolve().member;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/guild_role_packets_test.dart
+++ b/packages/core/test/packets/guild_role_packets_test.dart
@@ -1,22 +1,18 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_role_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_role_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_role_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -54,33 +50,23 @@ void main() {
   late FakeCacheProvider cache;
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
-  late _FakeDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() {
     wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeDataStore dsFinal;
-    marshaller = FakeMarshaller(
-      cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
-    );
+    dataStore = MockDataStore();
 
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
+    final ctx = buildCtx(dataStore: dataStore, wss: wss);
 
     fakeGuild = buildMinimalGuild(_guildId, ctx);
-    dsFinal = _FakeDataStore(FakeGuildPart(fakeGuild));
-    dataStore = dsFinal;
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+
+    marshaller = FakeMarshaller(
+      cache: cache,
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
+    );
   });
 
   // ── GUILD_ROLE_CREATE ──────────────────────────────────────────────────────
@@ -322,65 +308,3 @@ void main() {
   });
 }
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  _FakeDataStore(this._guildPart);
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/helpers/packet_test_helpers.dart
+++ b/packages/core/test/packets/helpers/packet_test_helpers.dart
@@ -2,24 +2,25 @@
 ///
 /// Provides:
 /// - [buildMinimalGuild]: construct a Guild with managers wired.
-/// - [LazyDataStore]: deferred DataStoreContract for circular init.
-/// - [GuildOnlyDataStore]: minimal DataStoreContract exposing only [guild].
-/// - [GuildAndChannelDataStore]: exposes [guild] + [channel].
-/// - [GuildAndUserDataStore]: exposes [guild] + [user].
-/// - [GuildUserAndChannelDataStore]: exposes [guild], [user], [channel].
+/// - [buildMockDs]: create a [MockDataStore] with any combination of parts
+///   pre-stubbed.  Any unstubbed part raises a MissingStubError on access,
+///   which behaves exactly like the old UnimplementedError.
+/// - [buildCtx]: create an [EntityContext] backed by a [MockDataStore].
+/// - [FakeGuildPart], [FakeUserPart], [FakeChannelPart]: concrete part stubs
+///   that return a fixed domain object.
 library;
 
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
 import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/fake_logger.dart';
 import '../../helpers/fake_websocket_orchestrator.dart';
+import '../../helpers/mocks.dart';
 
 // ── Domain builders ───────────────────────────────────────────────────────────
 
@@ -78,277 +79,59 @@ Guild buildMinimalGuild(String guildId, EntityContext ctx) {
   );
 }
 
-/// Creates a minimal EntityContext pointing at a lazy-resolved datastore.
+// ── MockDataStore factory ─────────────────────────────────────────────────────
+
+/// Creates a [MockDataStore] with the requested parts pre-stubbed.
+///
+/// Any part not provided here will raise a [MissingStubError] if accessed —
+/// which is the same failure mode as the old `UnimplementedError` stubs.
+MockDataStore buildMockDs({
+  GuildPartContract? guild,
+  ChannelPartContract? channel,
+  UserPartContract? user,
+  MemberPartContract? member,
+  MessagePartContract? message,
+  RolePartContract? role,
+  InteractionPartContract? interaction,
+}) {
+  final ds = MockDataStore();
+  if (guild != null) {
+    when(() => ds.guild).thenReturn(guild);
+  }
+  if (channel != null) {
+    when(() => ds.channel).thenReturn(channel);
+  }
+  if (user != null) {
+    when(() => ds.user).thenReturn(user);
+  }
+  if (member != null) {
+    when(() => ds.member).thenReturn(member);
+  }
+  if (message != null) {
+    when(() => ds.message).thenReturn(message);
+  }
+  if (role != null) {
+    when(() => ds.role).thenReturn(role);
+  }
+  if (interaction != null) {
+    when(() => ds.interaction).thenReturn(interaction);
+  }
+  return ds;
+}
+
+// ── Context builder ───────────────────────────────────────────────────────────
+
+/// Creates a minimal [EntityContext] pointing at the provided datastore.
 EntityContext buildCtx({
-  required DataStoreContract Function() dataStoreRef,
+  required DataStoreContract dataStore,
   WebsocketOrchestratorContract? wss,
 }) =>
     EntityContext(
-      datastore: LazyDataStore(dataStoreRef),
+      datastore: dataStore,
       wss: wss ?? FakeWebsocketOrchestrator(),
       logger: FakeLogger(),
       runtimeState: RuntimeState(),
     );
-
-// ── Lazy DataStore ────────────────────────────────────────────────────────────
-
-final class LazyDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-  LazyDataStore(this._resolve);
-
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  ChannelPartContract get channel => _resolve().channel;
-  @override
-  UserPartContract get user => _resolve().user;
-  @override
-  MemberPartContract get member => _resolve().member;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── DataStore specializations ─────────────────────────────────────────────────
-
-final class GuildOnlyDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  GuildOnlyDataStore(this._guildPart);
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class GuildAndChannelDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final ChannelPartContract _channelPart;
-
-  GuildAndChannelDataStore({
-    required GuildPartContract guildPart,
-    required ChannelPartContract channelPart,
-  })  : _guildPart = guildPart,
-        _channelPart = channelPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  ChannelPartContract get channel => _channelPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class GuildAndUserDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final UserPartContract _userPart;
-
-  GuildAndUserDataStore({
-    required GuildPartContract guildPart,
-    required UserPartContract userPart,
-  })  : _guildPart = guildPart,
-        _userPart = userPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  UserPartContract get user => _userPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
 
 // ── Part stubs ────────────────────────────────────────────────────────────────
 

--- a/packages/core/test/packets/integration_packets_test.dart
+++ b/packages/core/test/packets/integration_packets_test.dart
@@ -1,12 +1,5 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_integrations_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_create_packet.dart';
@@ -14,10 +7,12 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/integrati
 import 'package:mineral/src/infrastructure/internals/packets/listeners/integration_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── Test IDs ──────────────────────────────────────────────────────────────────
 
@@ -26,181 +21,6 @@ const _integrationId = '111222333444555666';
 const _applicationId = '999888777666555444';
 const _roleId = '333444555666777888';
 const _userId = '444555666777888999';
-
-// ── Stub DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-
-  _FakeDataStore({required GuildPartContract guildPart})
-      : _guildPart = guildPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Deferred DataStore (for breaking circular dep in EntityContext setup) ─────
-
-final class _DeferredDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-
-  _DeferredDataStore(this._resolve);
-
-  @override
-  GuildPartContract get guild => _resolve().guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Fake guild part ──────────────────────────────────────────────────────────
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-// ── Domain object builder ─────────────────────────────────────────────────────
-
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
 
 // ── Shard message factories ───────────────────────────────────────────────────
 
@@ -270,29 +90,25 @@ void main() {
 
   group('PacketType identity', () {
     test('GuildIntegrationsUpdatePacket has correct packetType', () {
-      final packet = GuildIntegrationsUpdatePacket(
-          dataStore: _FakeDataStore(guildPart: _DummyServerPart()));
+      final packet = GuildIntegrationsUpdatePacket(dataStore: buildMockDs());
       expect(packet.packetType, equals(PacketType.guildIntegrationsUpdate));
       expect(packet.packetType.name, equals('GUILD_INTEGRATIONS_UPDATE'));
     });
 
     test('IntegrationCreatePacket has correct packetType', () {
-      final packet = IntegrationCreatePacket(
-          dataStore: _FakeDataStore(guildPart: _DummyServerPart()));
+      final packet = IntegrationCreatePacket(dataStore: buildMockDs());
       expect(packet.packetType, equals(PacketType.integrationCreate));
       expect(packet.packetType.name, equals('INTEGRATION_CREATE'));
     });
 
     test('IntegrationUpdatePacket has correct packetType', () {
-      final packet = IntegrationUpdatePacket(
-          dataStore: _FakeDataStore(guildPart: _DummyServerPart()));
+      final packet = IntegrationUpdatePacket(dataStore: buildMockDs());
       expect(packet.packetType, equals(PacketType.integrationUpdate));
       expect(packet.packetType.name, equals('INTEGRATION_UPDATE'));
     });
 
     test('IntegrationDeletePacket has correct packetType', () {
-      final packet = IntegrationDeletePacket(
-          dataStore: _FakeDataStore(guildPart: _DummyServerPart()));
+      final packet = IntegrationDeletePacket(dataStore: buildMockDs());
       expect(packet.packetType, equals(PacketType.integrationDelete));
       expect(packet.packetType.name, equals('INTEGRATION_DELETE'));
     });
@@ -301,17 +117,12 @@ void main() {
   // ── GUILD_INTEGRATIONS_UPDATE ────────────────────────────────────────────
 
   group('GuildIntegrationsUpdatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _DeferredDataStore(() => ds),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildIntegrationsUpdate', () async {
@@ -354,17 +165,12 @@ void main() {
   // ── INTEGRATION_CREATE ───────────────────────────────────────────────────
 
   group('IntegrationCreatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _DeferredDataStore(() => ds),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildIntegrationCreate', () async {
@@ -419,17 +225,12 @@ void main() {
   // ── INTEGRATION_UPDATE ───────────────────────────────────────────────────
 
   group('IntegrationUpdatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _DeferredDataStore(() => ds),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildIntegrationUpdate', () async {
@@ -480,17 +281,12 @@ void main() {
   // ── INTEGRATION_DELETE ───────────────────────────────────────────────────
 
   group('IntegrationDeletePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _DeferredDataStore(() => ds),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildIntegrationDelete', () async {
@@ -552,15 +348,4 @@ void main() {
       expect(args!.applicationId, equals(Snowflake.parse(_applicationId)));
     });
   });
-}
-
-// ── Dummy guild part (for packetType identity tests that don't dispatch) ─────
-
-final class _DummyServerPart implements GuildPartContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  Future<Guild> get(Object id, bool force) => throw UnimplementedError();
 }

--- a/packages/core/test/packets/invite_packets_test.dart
+++ b/packages/core/test/packets/invite_packets_test.dart
@@ -2,24 +2,21 @@
 library;
 
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/invite_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/invite_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -68,33 +65,21 @@ void main() {
   late FakeCacheProvider cache;
   late FakeMarshaller marshaller;
   late GuildTextChannel fakeChannel;
-  late _FakeChannelDataStore channelDataStore;
+  late MockDataStore channelDataStore;
 
   setUp(() {
     final wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeChannelDataStore dsFinal;
+    channelDataStore = MockDataStore();
+    final ctx = buildCtx(dataStore: channelDataStore, wss: wss);
+    fakeChannel = _buildGuildTextChannel(ctx);
+    when(() => channelDataStore.channel).thenReturn(FakeChannelPart(fakeChannel));
+
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: channelDataStore, wss: wss),
     );
-
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-    fakeChannel = _buildGuildTextChannel(ctx);
-    dsFinal = _FakeChannelDataStore(FakeChannelPart(fakeChannel));
-    channelDataStore = dsFinal;
   });
 
   // ── INVITE_CREATE ──────────────────────────────────────────────────────────
@@ -233,65 +218,3 @@ GuildTextChannel _buildGuildTextChannel(EntityContext ctx) => GuildTextChannel(
       ),
     );
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeChannelDataStore implements DataStoreContract {
-  final ChannelPartContract _channelPart;
-  _FakeChannelDataStore(this._channelPart);
-
-  @override
-  ChannelPartContract get channel => _channelPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/message_delete_packets_test.dart
+++ b/packages/core/test/packets/message_delete_packets_test.dart
@@ -2,24 +2,21 @@
 library;
 
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_delete_bulk_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -58,38 +55,25 @@ void main() {
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
   late GuildTextChannel fakeChannel;
-  late _FakeDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() {
     final wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeDataStore dsFinal;
-    marshaller = FakeMarshaller(
-      cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
-    );
+    dataStore = MockDataStore();
 
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
+    final ctx = buildCtx(dataStore: dataStore, wss: wss);
     fakeGuild = buildMinimalGuild(_guildId, ctx);
     fakeChannel = _buildGuildTextChannel(ctx);
 
-    dsFinal = _FakeDataStore(
-      guildPart: FakeGuildPart(fakeGuild),
-      channelPart: FakeChannelPart(fakeChannel),
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+    when(() => dataStore.channel).thenReturn(FakeChannelPart(fakeChannel));
+
+    marshaller = FakeMarshaller(
+      cache: cache,
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
     );
-    dataStore = dsFinal;
   });
 
   // ── MESSAGE_DELETE ─────────────────────────────────────────────────────────
@@ -314,71 +298,3 @@ GuildTextChannel _buildGuildTextChannel(EntityContext ctx) => GuildTextChannel(
       ),
     );
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final ChannelPartContract _channelPart;
-
-  _FakeDataStore({
-    required GuildPartContract guildPart,
-    required ChannelPartContract channelPart,
-  })  : _guildPart = guildPart,
-        _channelPart = channelPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  ChannelPartContract get channel => _channelPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
+++ b/packages/core/test/packets/message_reaction_remove_emoji_packet_test.dart
@@ -1,20 +1,18 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/message_reaction_remove_emoji_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── Test IDs ─────────────────────────────────────────────────────────────────
 
@@ -22,233 +20,19 @@ const _channelId = '111222333444555666';
 const _messageId = '777888999000111222';
 const _guildId = '123456789012345678';
 
-// ── Fake data store helpers ───────────────────────────────────────────────────
+// ── Fake message part ─────────────────────────────────────────────────────────
 
-/// Delegates every accessor to a lazily-resolved [DataStoreContract].
-/// Used to break the circular dependency: EntityContext → DataStoreContract →
-/// channels/messages built with EntityContext.
-final class _DeferredDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-
-  _DeferredDataStore(this._resolve);
-
-  @override
-  ChannelPartContract get channel => _resolve().channel;
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  MessagePartContract get message => _resolve().message;
-  @override
-  MemberPartContract get member => _resolve().member;
-  @override
-  UserPartContract get user => _resolve().user;
-  @override
-  RolePartContract get role => _resolve().role;
-  @override
-  InteractionPartContract get interaction => _resolve().interaction;
-  @override
-  StickerPartContract get sticker => _resolve().sticker;
-  @override
-  EmojiPartContract get emoji => _resolve().emoji;
-  @override
-  RulesPartContract get rules => _resolve().rules;
-  @override
-  ReactionPartContract get reaction => _resolve().reaction;
-  @override
-  ThreadPartContract get thread => _resolve().thread;
-  @override
-  InvitePartContract get invite => _resolve().invite;
-  @override
-  WebhookPartContract get webhook => _resolve().webhook;
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      _resolve().scheduledEvent;
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      _resolve().applicationEmoji;
-  @override
-  WelcomeScreenPartContract get welcomeScreen => _resolve().welcomeScreen;
-  @override
-  OnboardingPartContract get onboarding => _resolve().onboarding;
-  @override
-  TemplatePartContract get template => _resolve().template;
-  @override
-  StageInstancePartContract get stageInstance => _resolve().stageInstance;
-  @override
-  MonetizationPartContract get monetization => _resolve().monetization;
-  @override
-  SoundboardPartContract get soundboard => _resolve().soundboard;
-  @override
-  RequestBucketContract get requestBucket => _resolve().requestBucket;
-  @override
-  HttpClientContract get client => _resolve().client;
-}
-
-/// Minimal [DataStoreContract] that wires channel, guild, and message parts.
-final class _FakeDataStore implements DataStoreContract {
-  final ChannelPartContract _channelPart;
-  final GuildPartContract _guildPart;
-  final MessagePartContract _messagePart;
-
-  _FakeDataStore({
-    required ChannelPartContract channelPart,
-    required GuildPartContract guildPart,
-    required MessagePartContract messagePart,
-  })  : _channelPart = channelPart,
-        _guildPart = guildPart,
-        _messagePart = messagePart;
-
-  @override
-  ChannelPartContract get channel => _channelPart;
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  MessagePartContract get message => _messagePart;
-
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-}
-
-/// [ChannelPartContract] that returns a pre-built [Channel].
-final class _FakeChannelPart implements ChannelPartContract {
-  final Channel _channel;
-
-  _FakeChannelPart(this._channel);
-
-  @override
-  Future<T?> get<T extends Channel>(Object id, bool force) async {
-    if (_channel is T) {
-      // ignore: unnecessary_cast
-      return _channel as T;
-    }
-    return null;
-  }
-
-  @override
-  Future<Map<Snowflake, T>> fetch<T extends Channel>(
-          Object guildId, bool force) async =>
-      {};
-
-  @override
-  Future<T> create<T extends Channel>(
-          Object? guildId, ChannelBuilderContract builder,
-          {String? reason}) =>
-      throw UnimplementedError();
-
-  @override
-  Future<PrivateChannel?> createPrivateChannel(
-          Object id, String recipientId) async =>
-      null;
-
-  @override
-  Future<T?> update<T extends Channel>(
-          Object id, ChannelBuilderContract builder,
-          {Object? guildId, String? reason}) =>
-      throw UnimplementedError();
-
-  @override
-  Future<void> delete(Object id, String? reason) async {}
-}
-
-/// [GuildPartContract] that returns a pre-built [Guild].
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  Future<Guild> update(Object id, Map<String, dynamic> payload,
-          [String? reason]) =>
-      throw UnimplementedError();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-/// [MessagePartContract] that returns a pre-built [Message].
-final class _FakeMessagePart implements MessagePartContract {
+class _FakeMessagePart extends Mock implements MessagePartContract {
   final Message _message;
-
   _FakeMessagePart(this._message);
 
   @override
   Future<T?> get<T extends BaseMessage>(
           Object channelId, Object messageId, bool force) async =>
       _message as T?;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-/// Stub [GuildPartContract] for tests that never hit the guild branch.
-final class _NoopServerPart implements GuildPartContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-/// Stub [MessagePartContract] for tests that skip message resolution.
-final class _NoopMessagePart implements MessagePartContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
 }
 
 // ── Domain object builders ────────────────────────────────────────────────────
-
-EntityContext _buildCtx(DataStoreContract dataStore) => EntityContext(
-      datastore: dataStore,
-      wss: FakeWebsocketOrchestrator(),
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
 
 Message _buildMessage(EntityContext ctx) => Message(
       MessageProperties(
@@ -344,61 +128,6 @@ PrivateChannel _buildPrivateChannel(EntityContext ctx) => PrivateChannel(
       ),
     );
 
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
-
 // ── Shard message factories ───────────────────────────────────────────────────
 
 ShardMessage<dynamic> _guildShardMessage(Map<String, dynamic> emojiPayload) =>
@@ -435,111 +164,7 @@ void main() {
     // ── packetType identity ─────────────────────────────────────────────────
 
     test('packetType is messageReactionRemoveEmoji', () {
-      // Construct the packet with a do-nothing dataStore; we only check identity.
-      final ds = _FakeDataStore(
-        channelPart: _FakeChannelPart(
-            _buildPrivateChannel(_buildCtx(_FakeDataStore(
-          channelPart: _FakeChannelPart(PrivateChannel(ChannelProperties(
-            ctx: EntityContext(
-              datastore: _FakeDataStore(
-                channelPart: _FakeChannelPart(PrivateChannel(
-                    ChannelProperties(
-                        ctx: EntityContext(
-                          datastore: _NoopDs(),
-                          wss: FakeWebsocketOrchestrator(),
-                          logger: FakeLogger(),
-                          runtimeState: RuntimeState(),
-                        ),
-                        id: Snowflake.parse(_channelId),
-                        type: ChannelType.dm,
-                        name: null,
-                        description: null,
-                        guildId: null,
-                        categoryId: null,
-                        position: null,
-                        nsfw: false,
-                        lastMessageId: null,
-                        bitrate: null,
-                        userLimit: null,
-                        rateLimitPerUser: null,
-                        recipients: [],
-                        icon: null,
-                        ownerId: null,
-                        applicationId: null,
-                        lastPinTimestamp: null,
-                        rtcRegion: null,
-                        videoQualityMode: null,
-                        messageCount: null,
-                        memberCount: null,
-                        defaultAutoArchiveDuration: null,
-                        permissions: [],
-                        flags: null,
-                        totalMessageSent: null,
-                        available: null,
-                        appliedTags: [],
-                        defaultReactions: null,
-                        defaultSortOrder: null,
-                        defaultForumLayout: null,
-                        threads: ThreadsManager(null, null,
-                            ctx: EntityContext(
-                              datastore: _NoopDs(),
-                              wss: FakeWebsocketOrchestrator(),
-                              logger: FakeLogger(),
-                              runtimeState: RuntimeState(),
-                            ))))),
-                guildPart: _NoopServerPart(),
-                messagePart: _NoopMessagePart(),
-              ),
-              wss: FakeWebsocketOrchestrator(),
-              logger: FakeLogger(),
-              runtimeState: RuntimeState(),
-            ),
-            id: Snowflake.parse(_channelId),
-            type: ChannelType.dm,
-            name: null,
-            description: null,
-            guildId: null,
-            categoryId: null,
-            position: null,
-            nsfw: false,
-            lastMessageId: null,
-            bitrate: null,
-            userLimit: null,
-            rateLimitPerUser: null,
-            recipients: [],
-            icon: null,
-            ownerId: null,
-            applicationId: null,
-            lastPinTimestamp: null,
-            rtcRegion: null,
-            videoQualityMode: null,
-            messageCount: null,
-            memberCount: null,
-            defaultAutoArchiveDuration: null,
-            permissions: [],
-            flags: null,
-            totalMessageSent: null,
-            available: null,
-            appliedTags: [],
-            defaultReactions: null,
-            defaultSortOrder: null,
-            defaultForumLayout: null,
-            threads: ThreadsManager(null, null,
-                ctx: EntityContext(
-                  datastore: _NoopDs(),
-                  wss: FakeWebsocketOrchestrator(),
-                  logger: FakeLogger(),
-                  runtimeState: RuntimeState(),
-                )),
-          ))),
-          guildPart: _NoopServerPart(),
-          messagePart: _NoopMessagePart(),
-        )))),
-        guildPart: _NoopServerPart(),
-        messagePart: _NoopMessagePart(),
-      );
-      final packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
-
+      final packet = MessageReactionRemoveEmojiPacket(dataStore: buildMockDs());
       expect(packet.packetType,
           equals(PacketType.messageReactionRemoveEmoji));
       expect(packet.packetType.name,
@@ -552,26 +177,15 @@ void main() {
       late MessageReactionRemoveEmojiPacket packet;
 
       setUp(() {
-        // Use a deferred dataStore so that the EntityContext used to build
-        // domain objects can reference the same dataStore that the packet uses.
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
+        final ds = MockDataStore();
+        final ctx = buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator());
         final message = _buildMessage(ctx);
         final channel = _buildServerTextChannel(ctx);
-        final guild = _buildServer(ctx);
+        final guild = buildMinimalGuild(_guildId, ctx);
 
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _FakeServerPart(guild),
-          messagePart: _FakeMessagePart(message),
-        );
+        when(() => ds.channel).thenReturn(FakeChannelPart(channel));
+        when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+        when(() => ds.message).thenReturn(_FakeMessagePart(message));
 
         packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
       });
@@ -655,23 +269,13 @@ void main() {
       late MessageReactionRemoveEmojiPacket packet;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
+        final ds = MockDataStore();
+        final ctx = buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator());
         final message = _buildMessage(ctx);
         final channel = _buildPrivateChannel(ctx);
 
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _NoopServerPart(),
-          messagePart: _FakeMessagePart(message),
-        );
+        when(() => ds.channel).thenReturn(FakeChannelPart(channel));
+        when(() => ds.message).thenReturn(_FakeMessagePart(message));
 
         packet = MessageReactionRemoveEmojiPacket(dataStore: ds);
       });
@@ -724,59 +328,4 @@ void main() {
       });
     });
   });
-}
-
-// ── No-op stubs used in packetType identity test ──────────────────────────────
-
-final class _NoopDs implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/ready_packet_test.dart
+++ b/packages/core/test/packets/ready_packet_test.dart
@@ -14,6 +14,7 @@ import '../helpers/fake_cache_provider.dart';
 import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 
 // ── No-op CommandInteractionManager stub ──────────────────────────────────────
 
@@ -89,7 +90,7 @@ void main() {
       marshaller = FakeMarshaller(logger: logger);
 
       ctx = EntityContext(
-        datastore: _NullDataStore(),
+        datastore: MockDataStore(),
         wss: wss,
         logger: logger,
         runtimeState: runtimeState,
@@ -209,12 +210,6 @@ void main() {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-final class _NullDataStore implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
 
 final class _CountingCommandManager implements CommandInteractionManagerContract {
   final void Function() onRegisterGlobal;

--- a/packages/core/test/packets/scheduled_event_packets_test.dart
+++ b/packages/core/test/packets/scheduled_event_packets_test.dart
@@ -1,15 +1,6 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
-import 'package:mineral/src/infrastructure/internals/marshaller/cache_key.dart';
-import 'package:mineral/src/infrastructure/internals/marshaller/serializer_bucket.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_scheduled_event_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_scheduled_event_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_scheduled_event_update_packet.dart';
@@ -17,11 +8,14 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_sch
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_scheduled_event_user_remove_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
+import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
@@ -30,202 +24,34 @@ const _eventId = '111222333444555666';
 const _userId = '999888777666555444';
 const _channelId = '777888999000111222';
 
-// ── Stub DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final UserPartContract _userPart;
-
-  _FakeDataStore({
-    required GuildPartContract guildPart,
-    UserPartContract? userPart,
-  })  : _guildPart = guildPart,
-        _userPart = userPart ?? _ThrowUserPart();
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  UserPartContract get user => _userPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError('client');
-}
-
-final class _ThrowUserPart implements UserPartContract {
-  @override
-  Future<User?> get(Object id, bool force) => throw UnimplementedError();
-}
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeUserPart implements UserPartContract {
-  final User _user;
-  _FakeUserPart(this._user);
-
-  @override
-  Future<User?> get(Object id, bool force) async => _user;
-}
-
-// ── Fake Marshaller ───────────────────────────────────────────────────────────
-
-final class _FakeMarshaller implements MarshallerContract {
-  @override
-  final LoggerContract logger = FakeLogger();
-
-  @override
-  final CacheProviderContract? cache;
-
-  @override
-  final CacheKey cacheKey = CacheKey();
-
-  @override
-  late final SerializerBucket serializers;
-
-  _FakeMarshaller({this.cache, EntityContext? entityContext}) {
-    serializers = SerializerBucket(
-        this,
-        entityContext ??
-            EntityContext(
-              datastore: _NullDataStore(),
-              wss: FakeWebsocketOrchestrator(),
-              logger: logger,
-              runtimeState: RuntimeState(),
-            ));
-  }
-}
-
-final class _NullDataStore implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
 // ── Domain object builders ────────────────────────────────────────────────────
 
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
+User _buildUser(MockDataStore ds) {
+  final ctx = buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator());
+  return User(
     ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
+    id: Snowflake.parse(_userId),
+    username: 'testuser',
+    discriminator: '0000',
+    avatar: null,
+    bot: false,
+    system: false,
+    mfaEnabled: false,
+    locale: null,
+    verified: false,
+    email: null,
+    flags: null,
+    premiumType: null,
+    publicFlags: null,
+    assets: UserAssets(
+      avatar: null,
+      avatarDecoration: null,
       banner: null,
-      discoverySplash: null,
     ),
+    createdAt: null,
+    presence: null,
   );
 }
-
-User _buildUser(EntityContext ctx) => User(
-      ctx: ctx,
-      id: Snowflake.parse(_userId),
-      username: 'testuser',
-      discriminator: '0000',
-      avatar: null,
-      bot: false,
-      system: false,
-      mfaEnabled: false,
-      locale: null,
-      verified: false,
-      email: null,
-      flags: null,
-      premiumType: null,
-      publicFlags: null,
-      assets: UserAssets(
-        avatar: null,
-        avatarDecoration: null,
-        banner: null,
-      ),
-      createdAt: null,
-      presence: null,
-    );
 
 // ── Scheduled event payload ───────────────────────────────────────────────────
 
@@ -297,30 +123,30 @@ void main() {
 
   group('PacketType identity', () {
     test('GuildScheduledEventCreatePacket has correct packetType', () {
-      final marshaller = _FakeMarshaller();
+      final marshaller = FakeMarshaller();
       final packet = GuildScheduledEventCreatePacket(
         marshaller: marshaller,
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildScheduledEventCreate));
       expect(packet.packetType.name, equals('GUILD_SCHEDULED_EVENT_CREATE'));
     });
 
     test('GuildScheduledEventUpdatePacket has correct packetType', () {
-      final marshaller = _FakeMarshaller();
+      final marshaller = FakeMarshaller();
       final packet = GuildScheduledEventUpdatePacket(
         marshaller: marshaller,
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildScheduledEventUpdate));
       expect(packet.packetType.name, equals('GUILD_SCHEDULED_EVENT_UPDATE'));
     });
 
     test('GuildScheduledEventDeletePacket has correct packetType', () {
-      final marshaller = _FakeMarshaller();
+      final marshaller = FakeMarshaller();
       final packet = GuildScheduledEventDeletePacket(
         marshaller: marshaller,
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildScheduledEventDelete));
       expect(packet.packetType.name, equals('GUILD_SCHEDULED_EVENT_DELETE'));
@@ -328,7 +154,7 @@ void main() {
 
     test('GuildScheduledEventUserAddPacket has correct packetType', () {
       final packet = GuildScheduledEventUserAddPacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildScheduledEventUserAdd));
       expect(packet.packetType.name, equals('GUILD_SCHEDULED_EVENT_USER_ADD'));
@@ -336,7 +162,7 @@ void main() {
 
     test('GuildScheduledEventUserRemovePacket has correct packetType', () {
       final packet = GuildScheduledEventUserRemovePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(
           packet.packetType, equals(PacketType.guildScheduledEventUserRemove));
@@ -348,29 +174,16 @@ void main() {
   // ── GUILD_SCHEDULED_EVENT_CREATE ───────────────────────────────────────────
 
   group('GuildScheduledEventCreatePacket', () {
-    late _FakeDataStore ds;
-    late _FakeMarshaller marshaller;
+    late MockDataStore ds;
+    late FakeMarshaller marshaller;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+      marshaller = FakeMarshaller(
+        entityContext: buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()),
       );
-      // We need a deferred setup since marshaller/guild depend on each other
-      late _FakeDataStore dsFinal;
-      marshaller = _FakeMarshaller(
-        entityContext: EntityContext(
-          datastore: _LazyDataStore(() => dsFinal),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        ),
-      );
-      final guild = _buildServer(ctx);
-      dsFinal = _FakeDataStore(guildPart: _FakeServerPart(guild));
-      ds = dsFinal;
     });
 
     test('dispatches Event.guildScheduledEventCreate', () async {
@@ -422,33 +235,19 @@ void main() {
   // ── GUILD_SCHEDULED_EVENT_UPDATE ───────────────────────────────────────────
 
   group('GuildScheduledEventUpdatePacket', () {
-    late _FakeDataStore ds;
-    late _FakeMarshaller marshaller;
+    late MockDataStore ds;
+    late FakeMarshaller marshaller;
     late FakeCacheProvider cache;
 
     setUp(() {
       cache = FakeCacheProvider();
-
-      late _FakeDataStore dsFinal;
-      marshaller = _FakeMarshaller(
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+      marshaller = FakeMarshaller(
         cache: cache,
-        entityContext: EntityContext(
-          datastore: _LazyDataStore(() => dsFinal),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        ),
+        entityContext: buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()),
       );
-
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      dsFinal = _FakeDataStore(guildPart: _FakeServerPart(guild));
-      ds = dsFinal;
     });
 
     test('dispatches Event.guildScheduledEventUpdate', () async {
@@ -520,28 +319,16 @@ void main() {
   // ── GUILD_SCHEDULED_EVENT_DELETE ───────────────────────────────────────────
 
   group('GuildScheduledEventDeletePacket', () {
-    late _FakeDataStore ds;
-    late _FakeMarshaller marshaller;
+    late MockDataStore ds;
+    late FakeMarshaller marshaller;
 
     setUp(() {
-      late _FakeDataStore dsFinal;
-      marshaller = _FakeMarshaller(
-        entityContext: EntityContext(
-          datastore: _LazyDataStore(() => dsFinal),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        ),
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+      marshaller = FakeMarshaller(
+        entityContext: buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()),
       );
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      dsFinal = _FakeDataStore(guildPart: _FakeServerPart(guild));
-      ds = dsFinal;
     });
 
     test('dispatches Event.guildScheduledEventDelete', () async {
@@ -586,22 +373,14 @@ void main() {
   // ── GUILD_SCHEDULED_EVENT_USER_ADD ─────────────────────────────────────────
 
   group('GuildScheduledEventUserAddPacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      late _FakeDataStore dsFinal;
-      final user = _buildUser(ctx);
-      dsFinal = _FakeDataStore(
-        guildPart: _FakeServerPart(_buildServer(ctx)),
-        userPart: _FakeUserPart(user),
-      );
-      ds = dsFinal;
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      final user = _buildUser(ds);
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+      when(() => ds.user).thenReturn(FakeUserPart(user));
     });
 
     test('dispatches Event.guildScheduledEventUserAdd', () async {
@@ -644,22 +423,14 @@ void main() {
   // ── GUILD_SCHEDULED_EVENT_USER_REMOVE ──────────────────────────────────────
 
   group('GuildScheduledEventUserRemovePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      late _FakeDataStore dsFinal;
-      final user = _buildUser(ctx);
-      dsFinal = _FakeDataStore(
-        guildPart: _FakeServerPart(_buildServer(ctx)),
-        userPart: _FakeUserPart(user),
-      );
-      ds = dsFinal;
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      final user = _buildUser(ds);
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+      when(() => ds.user).thenReturn(FakeUserPart(user));
     });
 
     test('dispatches Event.guildScheduledEventUserRemove', () async {
@@ -698,64 +469,4 @@ void main() {
       expect(args!.user.id, equals(Snowflake.parse(_userId)));
     });
   });
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-final class _DummyServerPart implements GuildPartContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  Future<Guild> get(Object id, bool force) => throw UnimplementedError();
-}
-
-/// A [DataStoreContract] that resolves lazily, used to break circular init deps.
-final class _LazyDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-  _LazyDataStore(this._resolve);
-
-  @override
-  GuildPartContract get guild => _resolve().guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/soundboard_packets_test.dart
+++ b/packages/core/test/packets/soundboard_packets_test.dart
@@ -1,12 +1,5 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_soundboard_sound_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_soundboard_sound_delete_packet.dart';
@@ -15,152 +8,18 @@ import 'package:mineral/src/infrastructure/internals/packets/listeners/guild_sou
 import 'package:mineral/src/infrastructure/internals/packets/listeners/soundboard_sounds_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
 const _guildId = '123456789012345678';
 const _soundId = '111222333444555666';
 const _soundId2 = '222333444555666777';
-
-// ── Minimal DataStoreContract stubs ──────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-
-  _FakeDataStore({required GuildPartContract guildPart})
-      : _guildPart = guildPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _DummyServerPart implements GuildPartContract {
-  @override
-  Future<Guild> get(Object id, bool force) => throw UnimplementedError();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _NullDataStore implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-// ── Domain object builder ─────────────────────────────────────────────────────
-
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
 
 // ── Payload builders ──────────────────────────────────────────────────────────
 
@@ -235,7 +94,7 @@ void main() {
   group('PacketType identity', () {
     test('GuildSoundboardSoundCreatePacket has correct packetType', () {
       final packet = GuildSoundboardSoundCreatePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildSoundboardSoundCreate));
       expect(packet.packetType.name, equals('GUILD_SOUNDBOARD_SOUND_CREATE'));
@@ -243,7 +102,7 @@ void main() {
 
     test('GuildSoundboardSoundUpdatePacket has correct packetType', () {
       final packet = GuildSoundboardSoundUpdatePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildSoundboardSoundUpdate));
       expect(packet.packetType.name, equals('GUILD_SOUNDBOARD_SOUND_UPDATE'));
@@ -251,7 +110,7 @@ void main() {
 
     test('GuildSoundboardSoundDeletePacket has correct packetType', () {
       final packet = GuildSoundboardSoundDeletePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.guildSoundboardSoundDelete));
       expect(packet.packetType.name, equals('GUILD_SOUNDBOARD_SOUND_DELETE'));
@@ -259,7 +118,7 @@ void main() {
 
     test('GuildSoundboardSoundsUpdatePacket has correct packetType', () {
       final packet = GuildSoundboardSoundsUpdatePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(
           packet.packetType, equals(PacketType.guildSoundboardSoundsUpdate));
@@ -269,7 +128,7 @@ void main() {
 
     test('SoundboardSoundsPacket has correct packetType', () {
       final packet = SoundboardSoundsPacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.soundboardSounds));
       expect(packet.packetType.name, equals('SOUNDBOARD_SOUNDS'));
@@ -279,17 +138,12 @@ void main() {
   // ── GUILD_SOUNDBOARD_SOUND_CREATE ─────────────────────────────────────────
 
   group('GuildSoundboardSoundCreatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildSoundboardSoundCreate', () async {
@@ -336,17 +190,12 @@ void main() {
   // ── GUILD_SOUNDBOARD_SOUND_UPDATE ─────────────────────────────────────────
 
   group('GuildSoundboardSoundUpdatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildSoundboardSoundUpdate', () async {
@@ -391,17 +240,12 @@ void main() {
   // ── GUILD_SOUNDBOARD_SOUND_DELETE ─────────────────────────────────────────
 
   group('GuildSoundboardSoundDeletePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildSoundboardSoundDelete', () async {
@@ -443,17 +287,12 @@ void main() {
   // ── GUILD_SOUNDBOARD_SOUNDS_UPDATE ────────────────────────────────────────
 
   group('GuildSoundboardSoundsUpdatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildSoundboardSoundsUpdate', () async {
@@ -497,17 +336,12 @@ void main() {
   // ── SOUNDBOARD_SOUNDS ─────────────────────────────────────────────────────
 
   group('SoundboardSoundsPacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildSoundboardSounds', () async {

--- a/packages/core/test/packets/stage_instance_packets_test.dart
+++ b/packages/core/test/packets/stage_instance_packets_test.dart
@@ -1,164 +1,23 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
-import 'package:mineral/src/api/guild/managers/threads_manager.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/stage_instance_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
 
 const _guildId = '123456789012345678';
 const _channelId = '111222333444555666';
 const _instanceId = '999888777666555444';
-
-// ── Minimal DataStoreContract stubs ──────────────────────────────────────────
-
-final class _FakeDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-
-  _FakeDataStore({required GuildPartContract guildPart})
-      : _guildPart = guildPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _DummyServerPart implements GuildPartContract {
-  @override
-  Future<Guild> get(Object id, bool force) => throw UnimplementedError();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _NullDataStore implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-// ── Domain object builder ─────────────────────────────────────────────────────
-
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
 
 // ── Stage instance payload ────────────────────────────────────────────────────
 
@@ -203,7 +62,7 @@ void main() {
   group('PacketType identity', () {
     test('StageInstanceCreatePacket has correct packetType', () {
       final packet = StageInstanceCreatePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.stageInstanceCreate));
       expect(packet.packetType.name, equals('STAGE_INSTANCE_CREATE'));
@@ -211,7 +70,7 @@ void main() {
 
     test('StageInstanceUpdatePacket has correct packetType', () {
       final packet = StageInstanceUpdatePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.stageInstanceUpdate));
       expect(packet.packetType.name, equals('STAGE_INSTANCE_UPDATE'));
@@ -219,7 +78,7 @@ void main() {
 
     test('StageInstanceDeletePacket has correct packetType', () {
       final packet = StageInstanceDeletePacket(
-        dataStore: _FakeDataStore(guildPart: _DummyServerPart()),
+        dataStore: buildMockDs(),
       );
       expect(packet.packetType, equals(PacketType.stageInstanceDelete));
       expect(packet.packetType.name, equals('STAGE_INSTANCE_DELETE'));
@@ -229,17 +88,12 @@ void main() {
   // ── STAGE_INSTANCE_CREATE ──────────────────────────────────────────────────
 
   group('StageInstanceCreatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildStageInstanceCreate', () async {
@@ -287,17 +141,12 @@ void main() {
   // ── STAGE_INSTANCE_UPDATE ──────────────────────────────────────────────────
 
   group('StageInstanceUpdatePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildStageInstanceUpdate', () async {
@@ -341,17 +190,12 @@ void main() {
   // ── STAGE_INSTANCE_DELETE ──────────────────────────────────────────────────
 
   group('StageInstanceDeletePacket', () {
-    late _FakeDataStore ds;
+    late MockDataStore ds;
 
     setUp(() {
-      final ctx = EntityContext(
-        datastore: _NullDataStore(),
-        wss: FakeWebsocketOrchestrator(),
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final guild = _buildServer(ctx);
-      ds = _FakeDataStore(guildPart: _FakeServerPart(guild));
+      ds = MockDataStore();
+      final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator()));
+      when(() => ds.guild).thenReturn(FakeGuildPart(guild));
     });
 
     test('dispatches Event.guildStageInstanceDelete', () async {

--- a/packages/core/test/packets/thread_packets_test.dart
+++ b/packages/core/test/packets/thread_packets_test.dart
@@ -2,24 +2,20 @@
 library;
 
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_create_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_delete_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/thread_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -70,33 +66,20 @@ void main() {
   late FakeCacheProvider cache;
   late FakeMarshaller marshaller;
   late Guild fakeGuild;
-  late _FakeGuildDataStore dataStore;
+  late MockDataStore dataStore;
 
   setUp(() {
     wss = FakeWebsocketOrchestrator();
     cache = FakeCacheProvider();
 
-    late _FakeGuildDataStore dsFinal;
+    dataStore = MockDataStore();
+    fakeGuild = buildMinimalGuild(_guildId, buildCtx(dataStore: dataStore, wss: wss));
+    when(() => dataStore.guild).thenReturn(FakeGuildPart(fakeGuild));
+
     marshaller = FakeMarshaller(
       cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
+      entityContext: buildCtx(dataStore: dataStore, wss: wss),
     );
-
-    final ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-    fakeGuild = buildMinimalGuild(_guildId, ctx);
-    dsFinal = _FakeGuildDataStore(FakeGuildPart(fakeGuild));
-    dataStore = dsFinal;
   });
 
   // ── THREAD_CREATE ──────────────────────────────────────────────────────────
@@ -184,13 +167,7 @@ void main() {
 
     test('before is null when no cache is configured', () async {
       // Use a marshaller WITHOUT cache so getOrFail? returns null.
-      final nocacheMarshallerCtx = EntityContext(
-        datastore: LazyDataStore(() => dataStore),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-      final noCache = FakeMarshaller(entityContext: nocacheMarshallerCtx);
+      final noCache = FakeMarshaller(entityContext: buildCtx(dataStore: dataStore, wss: wss));
 
       final packet =
           ThreadUpdatePacket(marshaller: noCache, dataStore: dataStore);
@@ -323,65 +300,3 @@ void main() {
   });
 }
 
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeGuildDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  _FakeGuildDataStore(this._guildPart);
-
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}

--- a/packages/core/test/packets/typing_presence_packets_test.dart
+++ b/packages/core/test/packets/typing_presence_packets_test.dart
@@ -4,21 +4,18 @@ library;
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/presence_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/typing_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_cache_provider.dart';
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_marshaller.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
 import 'helpers/packet_test_helpers.dart';
 
 // ── IDs ───────────────────────────────────────────────────────────────────────
@@ -35,76 +32,77 @@ ShardMessage<dynamic> _msg(String type, Map<String, dynamic> payload) =>
       payload: payload,
     );
 
+// ── Fake member part ──────────────────────────────────────────────────────────
+
+class _FakeMemberPart extends Mock implements MemberPartContract {
+  final Member _member;
+  _FakeMemberPart(this._member);
+
+  @override
+  Future<Member?> get(Object guildId, Object memberId, bool force) async =>
+      _member;
+}
+
+// ── Helper: build a wired MockDataStore with guild + member ───────────────────
+
+Future<MockDataStore> _buildDs(FakeWebsocketOrchestrator wss) async {
+  final ds = MockDataStore();
+  final cache = FakeCacheProvider();
+  final marshaller = FakeMarshaller(
+    cache: cache,
+    entityContext: buildCtx(dataStore: ds, wss: wss),
+  );
+
+  final guild = buildMinimalGuild(_guildId, buildCtx(dataStore: ds, wss: wss));
+  final member = await marshaller.serializers.member.serialize(
+    await marshaller.serializers.member.normalize({
+      'guild_id': _guildId,
+      'user': {
+        'id': _userId,
+        'username': 'TypingUser',
+        'discriminator': '0000',
+        'avatar': null,
+        'bot': false,
+        'global_name': null,
+        'public_flags': 0,
+      },
+      'nick': null,
+      'roles': <String>[],
+      'joined_at': '2024-01-01T00:00:00.000Z',
+      'deaf': false,
+      'mute': false,
+      'flags': 0,
+      'pending': false,
+    }),
+  );
+
+  when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+  when(() => ds.member).thenReturn(_FakeMemberPart(member));
+  return ds;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 void main() {
   late FakeWebsocketOrchestrator wss;
-  late FakeCacheProvider cache;
-  late FakeMarshaller marshaller;
-  late EntityContext ctx;
+  late MockDataStore ds;
 
   setUp(() async {
     wss = FakeWebsocketOrchestrator();
-    cache = FakeCacheProvider();
-
-    late _FakeMemberDataStore dsFinal;
-    marshaller = FakeMarshaller(
-      cache: cache,
-      entityContext: EntityContext(
-        datastore: LazyDataStore(() => dsFinal),
-        wss: wss,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      ),
-    );
-
-    ctx = EntityContext(
-      datastore: LazyDataStore(() => dsFinal),
-      wss: wss,
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-    final fakeGuild = buildMinimalGuild(_guildId, ctx);
-    final fakeMember = await marshaller.serializers.member.serialize(
-      await marshaller.serializers.member.normalize({
-        'guild_id': _guildId,
-        'user': {
-          'id': _userId,
-          'username': 'TypingUser',
-          'discriminator': '0000',
-          'avatar': null,
-          'bot': false,
-          'global_name': null,
-          'public_flags': 0,
-        },
-        'nick': null,
-        'roles': <String>[],
-        'joined_at': '2024-01-01T00:00:00.000Z',
-        'deaf': false,
-        'mute': false,
-        'flags': 0,
-        'pending': false,
-      }),
-    );
-
-    dsFinal = _FakeMemberDataStore(
-      guildPart: FakeGuildPart(fakeGuild),
-      memberPart: _FakeMemberPart(fakeMember),
-    );
+    ds = await _buildDs(wss);
   });
 
   // ── TYPING_START ───────────────────────────────────────────────────────────
 
   group('TypingPacket', () {
     test('packetType is PacketType.typingStart', () {
-      final packet = TypingPacket(ctx: ctx);
+      final packet = TypingPacket(ctx: buildCtx(dataStore: ds, wss: wss));
       expect(packet.packetType, equals(PacketType.typingStart));
       expect(packet.packetType.name, equals('TYPING_START'));
     });
 
     test('dispatches Event.typing', () async {
-      final packet = TypingPacket(ctx: ctx);
+      final packet = TypingPacket(ctx: buildCtx(dataStore: ds, wss: wss));
       Event? capturedEvent;
 
       void dispatch<T extends Object>(
@@ -127,7 +125,7 @@ void main() {
     });
 
     test('payload is TypingArgs with correct Typing object', () async {
-      final packet = TypingPacket(ctx: ctx);
+      final packet = TypingPacket(ctx: buildCtx(dataStore: ds, wss: wss));
       TypingArgs? args;
 
       void dispatch<T extends Object>(
@@ -156,7 +154,7 @@ void main() {
     });
 
     test('typing has no guild for DM typing', () async {
-      final packet = TypingPacket(ctx: ctx);
+      final packet = TypingPacket(ctx: buildCtx(dataStore: ds, wss: wss));
       TypingArgs? args;
 
       void dispatch<T extends Object>(
@@ -185,58 +183,11 @@ void main() {
   // ── PRESENCE_UPDATE ────────────────────────────────────────────────────────
 
   group('PresenceUpdatePacket', () {
-    late _FakeMemberDataStore presenceDs;
+    late MockDataStore presenceDs;
 
     setUp(() async {
       final wss2 = FakeWebsocketOrchestrator();
-      final cache2 = FakeCacheProvider();
-
-      late _FakeMemberDataStore dsFinal2;
-      final marshaller2 = FakeMarshaller(
-        cache: cache2,
-        entityContext: EntityContext(
-          datastore: LazyDataStore(() => dsFinal2),
-          wss: wss2,
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        ),
-      );
-
-      final ctx2 = EntityContext(
-        datastore: LazyDataStore(() => dsFinal2),
-        wss: wss2,
-        logger: FakeLogger(),
-        runtimeState: RuntimeState(),
-      );
-
-      final guild = buildMinimalGuild(_guildId, ctx2);
-      final member = await marshaller2.serializers.member.serialize(
-        await marshaller2.serializers.member.normalize({
-          'guild_id': _guildId,
-          'user': {
-            'id': _userId,
-            'username': 'PresenceUser',
-            'discriminator': '0000',
-            'avatar': null,
-            'bot': false,
-            'global_name': null,
-            'public_flags': 0,
-          },
-          'nick': null,
-          'roles': <String>[],
-          'joined_at': '2024-01-01T00:00:00.000Z',
-          'deaf': false,
-          'mute': false,
-          'flags': 0,
-          'pending': false,
-        }),
-      );
-
-      dsFinal2 = _FakeMemberDataStore(
-        guildPart: FakeGuildPart(guild),
-        memberPart: _FakeMemberPart(member),
-      );
-      presenceDs = dsFinal2;
+      presenceDs = await _buildDs(wss2);
     });
 
     test('packetType is PacketType.presenceUpdate', () {
@@ -306,86 +257,4 @@ void main() {
       expect(args!.presence, isNotNull);
     });
   });
-}
-
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-final class _FakeMemberPart implements MemberPartContract {
-  final Member _member;
-  _FakeMemberPart(this._member);
-
-  @override
-  Future<Member?> get(Object guildId, Object memberId, bool force) async =>
-      _member;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeMemberDataStore implements DataStoreContract {
-  final GuildPartContract _guildPart;
-  final MemberPartContract _memberPart;
-
-  _FakeMemberDataStore({
-    required GuildPartContract guildPart,
-    required MemberPartContract memberPart,
-  })  : _guildPart = guildPart,
-        _memberPart = memberPart;
-
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  MemberPartContract get member => _memberPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
 }

--- a/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
+++ b/packages/core/test/packets/voice_channel_effect_send_packet_test.dart
@@ -1,21 +1,19 @@
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
 import 'package:mineral/src/api/common/permissions.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/voice_channel_effect_send_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── Test IDs ─────────────────────────────────────────────────────────────────
 
@@ -25,299 +23,7 @@ const _userId = '345678901234567890';
 const _emojiId = '999888777666555444';
 const _soundId = '111222333444555666';
 
-// ── No-op stubs ───────────────────────────────────────────────────────────────
-
-final class _NoopDs implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Fake DataStore ────────────────────────────────────────────────────────────
-
-/// Delegates every accessor to a lazily-resolved [DataStoreContract].
-/// Breaks circular dependency: EntityContext → DataStoreContract → domain
-/// objects built with EntityContext.
-final class _DeferredDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-
-  _DeferredDataStore(this._resolve);
-
-  @override
-  ChannelPartContract get channel => _resolve().channel;
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  MemberPartContract get member => _resolve().member;
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-final class _FakeDataStore implements DataStoreContract {
-  final ChannelPartContract _channelPart;
-  final GuildPartContract _guildPart;
-  final MemberPartContract _memberPart;
-
-  _FakeDataStore({
-    required ChannelPartContract channelPart,
-    required GuildPartContract guildPart,
-    required MemberPartContract memberPart,
-  })  : _channelPart = channelPart,
-        _guildPart = guildPart,
-        _memberPart = memberPart;
-
-  @override
-  ChannelPartContract get channel => _channelPart;
-  @override
-  GuildPartContract get guild => _guildPart;
-  @override
-  MemberPartContract get member => _memberPart;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
-
-// ── Fake parts ────────────────────────────────────────────────────────────────
-
-final class _FakeChannelPart implements ChannelPartContract {
-  final Channel _channel;
-
-  _FakeChannelPart(this._channel);
-
-  @override
-  Future<T?> get<T extends Channel>(Object id, bool force) async {
-    if (_channel is T) {
-      // ignore: unnecessary_cast
-      return _channel as T;
-    }
-    return null;
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-final class _FakeMemberPart implements MemberPartContract {
-  final Member _member;
-
-  _FakeMemberPart(this._member);
-
-  @override
-  Future<Member?> get(Object guildId, Object id, bool force) async => _member;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
 // ── Domain object builders ────────────────────────────────────────────────────
-
-EntityContext _buildCtx(DataStoreContract dataStore) => EntityContext(
-      datastore: dataStore,
-      wss: FakeWebsocketOrchestrator(),
-      logger: FakeLogger(),
-      runtimeState: RuntimeState(),
-    );
-
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
 
 GuildVoiceChannel _buildVoiceChannel(EntityContext ctx) => GuildVoiceChannel(
       ChannelProperties(
@@ -392,6 +98,30 @@ Member _buildMember(EntityContext ctx) {
   );
 }
 
+// ── Helper: build a wired MockDataStore ───────────────────────────────────────
+
+MockDataStore _buildWiredDs() {
+  final ds = MockDataStore();
+  final ctx = buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator());
+  final guild = buildMinimalGuild(_guildId, ctx);
+  final channel = _buildVoiceChannel(ctx);
+  final member = _buildMember(ctx);
+  when(() => ds.guild).thenReturn(FakeGuildPart(guild));
+  when(() => ds.channel).thenReturn(FakeChannelPart(channel));
+  when(() => ds.member).thenReturn(_FakeMemberPart(member));
+  return ds;
+}
+
+// ── Fake member part ──────────────────────────────────────────────────────────
+
+class _FakeMemberPart extends Mock implements MemberPartContract {
+  final Member _member;
+  _FakeMemberPart(this._member);
+
+  @override
+  Future<Member?> get(Object guildId, Object id, bool force) async => _member;
+}
+
 // ── Shard message factories ───────────────────────────────────────────────────
 
 ShardMessage<dynamic> _shardMessage(Map<String, dynamic> payload) =>
@@ -414,24 +144,7 @@ void main() {
     // ── packetType identity ─────────────────────────────────────────────────
 
     test('packetType is voiceChannelEffectSend', () {
-      final ds = _FakeDataStore(
-        channelPart: _FakeChannelPart(
-          _buildVoiceChannel(
-            _buildCtx(_NoopDs()),
-          ),
-        ),
-        guildPart: _FakeServerPart(
-          _buildServer(
-            _buildCtx(_NoopDs()),
-          ),
-        ),
-        memberPart: _FakeMemberPart(
-          _buildMember(
-            _buildCtx(_NoopDs()),
-          ),
-        ),
-      );
-      final packet = VoiceChannelEffectSendPacket(dataStore: ds);
+      final packet = VoiceChannelEffectSendPacket(dataStore: _buildWiredDs());
 
       expect(packet.packetType, equals(PacketType.voiceChannelEffectSend));
       expect(packet.packetType.name, equals('VOICE_CHANNEL_EFFECT_SEND'));
@@ -441,29 +154,9 @@ void main() {
 
     group('emoji effect (animation_type set, no sound)', () {
       late VoiceChannelEffectSendPacket packet;
-      late EntityContext ctx;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
-        final guild = _buildServer(ctx);
-        final channel = _buildVoiceChannel(ctx);
-        final member = _buildMember(ctx);
-
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _FakeServerPart(guild),
-          memberPart: _FakeMemberPart(member),
-        );
-
-        packet = VoiceChannelEffectSendPacket(dataStore: ds);
+        packet = VoiceChannelEffectSendPacket(dataStore: _buildWiredDs());
       });
 
       test('dispatches Event.guildVoiceChannelEffectSend', () async {
@@ -585,26 +278,7 @@ void main() {
       late VoiceChannelEffectSendPacket packet;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
-        final guild = _buildServer(ctx);
-        final channel = _buildVoiceChannel(ctx);
-        final member = _buildMember(ctx);
-
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _FakeServerPart(guild),
-          memberPart: _FakeMemberPart(member),
-        );
-
-        packet = VoiceChannelEffectSendPacket(dataStore: ds);
+        packet = VoiceChannelEffectSendPacket(dataStore: _buildWiredDs());
       });
 
       test('dispatches Event.guildVoiceChannelEffectSend with sound payload',
@@ -643,26 +317,7 @@ void main() {
       late VoiceChannelEffectSendPacket packet;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
-
-        final guild = _buildServer(ctx);
-        final channel = _buildVoiceChannel(ctx);
-        final member = _buildMember(ctx);
-
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _FakeServerPart(guild),
-          memberPart: _FakeMemberPart(member),
-        );
-
-        packet = VoiceChannelEffectSendPacket(dataStore: ds);
+        packet = VoiceChannelEffectSendPacket(dataStore: _buildWiredDs());
       });
 
       test('all optional fields null when absent from payload', () async {

--- a/packages/core/test/packets/webhooks_update_packet_test.dart
+++ b/packages/core/test/packets/webhooks_update_packet_test.dart
@@ -1,264 +1,22 @@
 import 'package:mineral/api.dart';
-import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
-import 'package:mineral/services.dart';
-import 'package:mineral/src/api/guild/managers/rules_manager.dart';
 import 'package:mineral/src/api/guild/managers/threads_manager.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
-import 'package:mineral/src/domains/common/runtime_state.dart';
-import 'package:mineral/src/domains/services/datastore/request_bucket_contract.dart';
 import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/webhooks_update_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import '../helpers/fake_logger.dart';
 import '../helpers/fake_websocket_orchestrator.dart';
+import '../helpers/mocks.dart';
+import 'helpers/packet_test_helpers.dart';
 
 // ── Test IDs ──────────────────────────────────────────────────────────────────
 
 const _channelId = '111222333444555666';
 const _guildId = '123456789012345678';
-
-// ── Fake data store helpers ───────────────────────────────────────────────────
-
-/// Delegates every accessor to a lazily-resolved [DataStoreContract].
-final class _DeferredDataStore implements DataStoreContract {
-  final DataStoreContract Function() _resolve;
-
-  _DeferredDataStore(this._resolve);
-
-  @override
-  ChannelPartContract get channel => _resolve().channel;
-  @override
-  GuildPartContract get guild => _resolve().guild;
-  @override
-  MessagePartContract get message => _resolve().message;
-  @override
-  MemberPartContract get member => _resolve().member;
-  @override
-  UserPartContract get user => _resolve().user;
-  @override
-  RolePartContract get role => _resolve().role;
-  @override
-  InteractionPartContract get interaction => _resolve().interaction;
-  @override
-  StickerPartContract get sticker => _resolve().sticker;
-  @override
-  EmojiPartContract get emoji => _resolve().emoji;
-  @override
-  RulesPartContract get rules => _resolve().rules;
-  @override
-  ReactionPartContract get reaction => _resolve().reaction;
-  @override
-  ThreadPartContract get thread => _resolve().thread;
-  @override
-  InvitePartContract get invite => _resolve().invite;
-  @override
-  WebhookPartContract get webhook => _resolve().webhook;
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      _resolve().scheduledEvent;
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      _resolve().applicationEmoji;
-  @override
-  WelcomeScreenPartContract get welcomeScreen => _resolve().welcomeScreen;
-  @override
-  OnboardingPartContract get onboarding => _resolve().onboarding;
-  @override
-  TemplatePartContract get template => _resolve().template;
-  @override
-  StageInstancePartContract get stageInstance => _resolve().stageInstance;
-  @override
-  MonetizationPartContract get monetization => _resolve().monetization;
-  @override
-  SoundboardPartContract get soundboard => _resolve().soundboard;
-  @override
-  RequestBucketContract get requestBucket => _resolve().requestBucket;
-  @override
-  HttpClientContract get client => _resolve().client;
-}
-
-/// Minimal [DataStoreContract] that wires channel and guild parts.
-final class _FakeDataStore implements DataStoreContract {
-  final ChannelPartContract _channelPart;
-  final GuildPartContract _guildPart;
-
-  _FakeDataStore({
-    required ChannelPartContract channelPart,
-    required GuildPartContract guildPart,
-  })  : _channelPart = channelPart,
-        _guildPart = guildPart;
-
-  @override
-  ChannelPartContract get channel => _channelPart;
-  @override
-  GuildPartContract get guild => _guildPart;
-
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  MonetizationPartContract get monetization => throw UnimplementedError();
-  @override
-  SoundboardPartContract get soundboard => throw UnimplementedError();
-}
-
-/// [ChannelPartContract] that returns a pre-built [Channel].
-final class _FakeChannelPart implements ChannelPartContract {
-  final Channel? _channel;
-
-  _FakeChannelPart(this._channel);
-
-  @override
-  Future<T?> get<T extends Channel>(Object id, bool force) async {
-    if (_channel is T) {
-      // ignore: unnecessary_cast
-      return _channel as T;
-    }
-    return null;
-  }
-
-  @override
-  Future<Map<Snowflake, T>> fetch<T extends Channel>(
-          Object guildId, bool force) async =>
-      {};
-
-  @override
-  Future<T> create<T extends Channel>(
-          Object? guildId, ChannelBuilderContract builder,
-          {String? reason}) =>
-      throw UnimplementedError();
-
-  @override
-  Future<PrivateChannel?> createPrivateChannel(
-          Object id, String recipientId) async =>
-      null;
-
-  @override
-  Future<T?> update<T extends Channel>(
-          Object id, ChannelBuilderContract builder,
-          {Object? guildId, String? reason}) =>
-      throw UnimplementedError();
-
-  @override
-  Future<void> delete(Object id, String? reason) async {}
-}
-
-/// [GuildPartContract] that returns a pre-built [Guild].
-final class _FakeServerPart implements GuildPartContract {
-  final Guild _guild;
-
-  _FakeServerPart(this._guild);
-
-  @override
-  Future<Guild> get(Object id, bool force) async => _guild;
-
-  @override
-  Future<Guild> update(Object id, Map<String, dynamic> payload,
-          [String? reason]) =>
-      throw UnimplementedError();
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-// ── No-op stubs ───────────────────────────────────────────────────────────────
-
-final class _NoopDs implements DataStoreContract {
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-
-  @override
-  ChannelPartContract get channel => throw UnimplementedError();
-  @override
-  GuildPartContract get guild => throw UnimplementedError();
-  @override
-  MessagePartContract get message => throw UnimplementedError();
-  @override
-  MemberPartContract get member => throw UnimplementedError();
-  @override
-  UserPartContract get user => throw UnimplementedError();
-  @override
-  RolePartContract get role => throw UnimplementedError();
-  @override
-  InteractionPartContract get interaction => throw UnimplementedError();
-  @override
-  StickerPartContract get sticker => throw UnimplementedError();
-  @override
-  EmojiPartContract get emoji => throw UnimplementedError();
-  @override
-  RulesPartContract get rules => throw UnimplementedError();
-  @override
-  ReactionPartContract get reaction => throw UnimplementedError();
-  @override
-  ThreadPartContract get thread => throw UnimplementedError();
-  @override
-  InvitePartContract get invite => throw UnimplementedError();
-  @override
-  WebhookPartContract get webhook => throw UnimplementedError();
-  @override
-  GuildScheduledEventPartContract get scheduledEvent =>
-      throw UnimplementedError();
-  @override
-  ApplicationEmojiPartContract get applicationEmoji =>
-      throw UnimplementedError();
-  @override
-  WelcomeScreenPartContract get welcomeScreen => throw UnimplementedError();
-  @override
-  OnboardingPartContract get onboarding => throw UnimplementedError();
-  @override
-  TemplatePartContract get template => throw UnimplementedError();
-  @override
-  StageInstancePartContract get stageInstance => throw UnimplementedError();
-  @override
-  RequestBucketContract get requestBucket => throw UnimplementedError();
-  @override
-  HttpClientContract get client => throw UnimplementedError();
-}
 
 // ── Domain object builders ────────────────────────────────────────────────────
 
@@ -304,61 +62,6 @@ GuildTextChannel _buildServerTextChannel(EntityContext ctx) =>
       ),
     );
 
-Guild _buildServer(EntityContext ctx) {
-  final id = Snowflake.parse(_guildId);
-  return Guild(
-    ctx: ctx,
-    id: id,
-    name: 'Test Guild',
-    ownerId: Snowflake.parse('000000000000000001'),
-    description: null,
-    applicationId: null,
-    members: MemberManager(id, ctx: ctx),
-    settings: GuildSettings(
-      bitfieldPermission: null,
-      afkTimeout: null,
-      hasWidgetEnabled: false,
-      verificationLevel: VerificationLevel.none,
-      defaultMessageNotifications: DefaultMessageNotification.allMessages,
-      explicitContentFilter: ExplicitContentFilter.disabled,
-      features: [],
-      mfaLevel: MfaLevel.none,
-      systemChannelFlags: [],
-      vanityUrlCode: null,
-      subscription: GuildSubscription(
-        tier: PremiumTier.none,
-        subscriptionCount: null,
-        hasEnabledProgressBar: false,
-      ),
-      preferredLocale: 'en-US',
-      maxVideoChannelUsers: null,
-      nsfwLevel: NsfwLevel.none,
-      rulesManager: RulesManager(id, ctx: ctx),
-    ),
-    roles: RoleManager(id, ctx: ctx),
-    channels: ChannelManager(
-      id,
-      ctx: ctx,
-      afkChannelId: null,
-      systemChannelId: null,
-      rulesChannelId: null,
-      publicUpdatesChannelId: null,
-      safetyAlertsChannelId: null,
-    ),
-    threads: ThreadsManager(id, null, ctx: ctx),
-    assets: GuildAsset(
-      id,
-      ctx: ctx,
-      emojis: EmojiManager(id, ctx: ctx),
-      stickers: StickerManager(id, ctx: ctx),
-      icon: null,
-      splash: null,
-      banner: null,
-      discoverySplash: null,
-    ),
-  );
-}
-
 // ── Shard message factory ─────────────────────────────────────────────────────
 
 ShardMessage<dynamic> _buildShardMessage() => ShardMessage(
@@ -378,7 +81,7 @@ void main() {
     // ── packetType identity ─────────────────────────────────────────────────
 
     test('packetType is PacketType.webhooksUpdate', () {
-      final packet = WebhooksUpdatePacket(dataStore: _NoopDs());
+      final packet = WebhooksUpdatePacket(dataStore: buildMockDs());
       expect(packet.packetType, equals(PacketType.webhooksUpdate));
       expect(packet.packetType.name, equals('WEBHOOKS_UPDATE'));
     });
@@ -392,22 +95,14 @@ void main() {
       late GuildTextChannel channel;
 
       setUp(() {
-        late _FakeDataStore ds;
-
-        final ctx = EntityContext(
-          datastore: _DeferredDataStore(() => ds),
-          wss: FakeWebsocketOrchestrator(),
-          logger: FakeLogger(),
-          runtimeState: RuntimeState(),
-        );
+        final ds = MockDataStore();
+        final ctx = buildCtx(dataStore: ds, wss: FakeWebsocketOrchestrator());
 
         channel = _buildServerTextChannel(ctx);
-        guild = _buildServer(ctx);
+        guild = buildMinimalGuild(_guildId, ctx);
 
-        ds = _FakeDataStore(
-          channelPart: _FakeChannelPart(channel),
-          guildPart: _FakeServerPart(guild),
-        );
+        when(() => ds.channel).thenReturn(FakeChannelPart(channel));
+        when(() => ds.guild).thenReturn(FakeGuildPart(guild));
 
         packet = WebhooksUpdatePacket(dataStore: ds);
       });


### PR DESCRIPTION
## Summary
- **M16/M4**: added `MockDataStore extends Mock implements DataStoreContract` (mocktail `noSuchMethod`) in `helpers/mocks.dart`, plus a `buildMockDs({...})` factory. Migrated all 40+ inline `DataStoreContract` implementations across ~24 test files to it; removed the `LazyDataStore`/`GuildOnlyDataStore`/… helpers.
- **Result**: adding a new `DataStoreContract` part getter now requires **zero** test-fake changes (the churn we kept hitting).
- Left intact (deliberate): concrete `FakeDataStore` (real `RequestBucket` for parts tests) and `FakeMarshaller` (real serialization, ~30 consumers) — converting those to mocks would break behaviour-dependent tests; noted as the boundary of the Mocktail migration.

## Test plan
- [x] `dart analyze packages/core` — no issues
- [x] `dart test packages/core` — 1575/1575

Closes #452