### PR TITLE
fix(marshaller): make the serializers consume real Discord payloads

### DIFF
--- a/packages/core/lib/src/api/common/types/format_type.dart
+++ b/packages/core/lib/src/api/common/types/format_type.dart
@@ -1,7 +1,13 @@
-enum FormatType {
-  standard(1),
-  guild(2);
+import 'package:mineral/src/api/common/types/enhanced_enum.dart';
 
+enum FormatType implements EnhancedEnum<int> {
+  standard(1),
+  guild(2),
+  lottie(3),
+  gif(4),
+  unknown(0);
+
+  @override
   final int value;
   const FormatType(this.value);
 }

--- a/packages/core/lib/src/api/guild/invite.dart
+++ b/packages/core/lib/src/api/guild/invite.dart
@@ -11,11 +11,24 @@ final class Invite {
 
   final Snowflake? guildId;
   final Snowflake? channelId;
-  final Snowflake inviterId;
+
+  /// The user who created the invite, when Discord reports one.
+  ///
+  /// Null for vanity-url invites, which have no inviter at all. Do not
+  /// substitute a placeholder id here: [resolveInviter] turns it into a real
+  /// `GET /users/{id}` call, so a fabricated snowflake becomes a 404 against
+  /// Discord rather than an honest absence.
+  final Snowflake? inviterId;
 
   final Duration maxAge;
   final int maxUses;
-  final DateTime createdAt;
+
+  /// When the invite was created, when Discord reports it.
+  ///
+  /// Null on the base invite object returned by `GET /invites/{code}` —
+  /// `created_at` only appears on the Invite Metadata extension used by the
+  /// guild and channel invite *list* endpoints.
+  final DateTime? createdAt;
   final DateTime? expiresAt;
   final bool isTemporary;
 
@@ -25,16 +38,20 @@ final class Invite {
     required this.code,
     required this.maxAge,
     required this.maxUses,
-    required this.inviterId,
     required this.isTemporary,
-    required this.createdAt,
+    this.inviterId,
+    this.createdAt,
     this.guildId,
     this.channelId,
     this.expiresAt,
   }) : _ctx = ctx;
 
-  Future<User?> resolveInviter() {
-    return _datastore.user.get(inviterId.value, false);
+  Future<User?> resolveInviter() async {
+    if (inviterId == null) {
+      return null;
+    }
+
+    return _datastore.user.get(inviterId!.value, false);
   }
 
   Future<T?> resolveChannel<T extends Channel>() async {

--- a/packages/core/lib/src/api/guild/voice_state.dart
+++ b/packages/core/lib/src/api/guild/voice_state.dart
@@ -18,7 +18,6 @@ final class VoiceState {
   final bool hasSelfVideo;
   final bool isSuppress;
   final DateTime? requestToSpeakTimestamp;
-  final bool isDiscoverable;
 
   VoiceState({
     required EntityContext ctx,
@@ -33,7 +32,6 @@ final class VoiceState {
     required this.hasSelfVideo,
     required this.isSuppress,
     required this.requestToSpeakTimestamp,
-    required this.isDiscoverable,
   }) : _ctx = ctx;
 
   /// Get related [User]

--- a/packages/core/lib/src/domains/client/client_builder.dart
+++ b/packages/core/lib/src/domains/client/client_builder.dart
@@ -146,7 +146,9 @@ final class ClientBuilder {
     final eventListener = EventListener();
     final providerManager = ProviderManager(logger: logger);
     final globalStateManager = GlobalStateManager();
-    final interactiveComponent = InteractiveComponentManager();
+    final interactiveComponent = InteractiveComponentManager(
+      logger: labelled('components'),
+    );
     final wssOrchestrator = WebsocketOrchestrator(
       shardConfig,
       logger: wssLogger,

--- a/packages/core/lib/src/domains/components/interactives/interactive_component_manager.dart
+++ b/packages/core/lib/src/domains/components/interactives/interactive_component_manager.dart
@@ -7,9 +7,16 @@ abstract interface class InteractiveComponentService {
 
 abstract interface class InteractiveComponentManagerContract
     implements InteractiveComponentService {
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
   void register(InteractiveComponent component);
 
-  void dispatch(String customId, List params);
+  Future<void> dispatch(String customId, List params);
 }
 
 final class InteractiveComponentManager
@@ -17,26 +24,52 @@ final class InteractiveComponentManager
   final Map<String, InteractiveComponent> _components = {};
 
   @override
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
+  final LoggerContract _logger;
+
+  InteractiveComponentManager({required LoggerContract logger})
+    : _logger = logger;
+
+  @override
   void register(InteractiveComponent component) {
     _components[component.customId] = component;
   }
 
   @override
-  void dispatch(String customId, List params) {
+  Future<void> dispatch(String customId, List params) async {
     final component = _components[customId];
     if (component == null) {
       return;
     }
 
-    switch (component) {
-      case final InteractiveButton button when params.isNotEmpty:
-        button.handle(params[0] as ButtonContext);
-      case final InteractiveModal modal when params.length >= 2:
-        modal.handle(params[0] as ModalContext, params[1]);
-      case final InteractiveSelectMenu select when params.length >= 2:
-        select.handle(params[0] as SelectContext, params[1]);
-      default:
-        return;
+    try {
+      switch (component) {
+        case final InteractiveButton button when params.isNotEmpty:
+          await button.handle(params[0] as ButtonContext);
+        case final InteractiveModal modal when params.length >= 2:
+          await modal.handle(params[0] as ModalContext, params[1]);
+        case final InteractiveSelectMenu select when params.length >= 2:
+          await select.handle(params[0] as SelectContext, params[1]);
+        default:
+          return;
+      }
+    } on Exception catch (e, stackTrace) {
+      _logger
+        ..error('Failed to dispatch component "$customId": $e')
+        ..trace('$stackTrace');
+      onComponentError?.call(component, e, stackTrace);
+      // ignore: avoid_catching_errors, crash-safety boundary for component handlers
+    } on Error catch (e, stackTrace) {
+      _logger
+        ..error('Failed to dispatch component "$customId": $e')
+        ..trace('$stackTrace');
+      onComponentError?.call(component, e, stackTrace);
     }
   }
 

--- a/packages/core/lib/src/domains/services/wss/sharding_config.dart
+++ b/packages/core/lib/src/domains/services/wss/sharding_config.dart
@@ -27,3 +27,18 @@ abstract interface class ShardingConfigContract {
 
   Duration get maxReconnectDelay;
 }
+
+/// Builds the gateway websocket URL for a given endpoint.
+///
+/// Lives here rather than at the call sites because both the initial connect
+/// (`WebsocketOrchestrator.createShards`) and the resume path
+/// (`ShardAuthentication`) need the identical query string. Discord returns
+/// `resume_gateway_url` bare, so the resume path has to rebuild it — and when
+/// the two formulas were written out separately, the resume copy silently
+/// dropped `?v=` and `encoding=`. With `encoding=etf` that made Discord fall
+/// back to JSON text frames the ETF decoder could not read, leaving the shard
+/// permanently deaf.
+extension GatewayUrlBuilder on ShardingConfigContract {
+  String gatewayUrl(String endpoint) =>
+      '$endpoint/?v=$version&encoding=${encoding.encoder.value}';
+}

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/emoji_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/emoji_part.dart
@@ -15,7 +15,10 @@ final class EmojiPart extends BasePart implements EmojiPartContract {
         .get<List<Map<String, dynamic>>>(req);
 
     final emojis = await result.map((element) async {
-      final raw = await marshaller.serializers.emojis.normalize(element);
+      final raw = await marshaller.serializers.emojis.normalize({
+        ...element,
+        'guild_id': parsedGuildId,
+      });
       return marshaller.serializers.emojis.serialize(raw);
     }).wait;
 
@@ -41,7 +44,10 @@ final class EmojiPart extends BasePart implements EmojiPartContract {
     );
     final result = await dataStore.requestBucket.get<Map<String, dynamic>>(req);
 
-    final raw = await marshaller.serializers.emojis.normalize(result);
+    final raw = await marshaller.serializers.emojis.normalize({
+      ...result,
+      'guild_id': parsedGuildId,
+    });
     final emoji = await marshaller.serializers.emojis.serialize(raw);
 
     return emoji;

--- a/packages/core/lib/src/infrastructure/internals/datastore/parts/role_part.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/parts/role_part.dart
@@ -46,7 +46,10 @@ final class RolePart extends BasePart implements RolePartContract {
     final req = Request.json(endpoint: '/guilds/$parsedGuildId/roles/$roleId');
     final result = await dataStore.requestBucket.get<Map<String, dynamic>>(req);
 
-    final raw = await marshaller.serializers.role.normalize(result);
+    final raw = await marshaller.serializers.role.normalize({
+      ...result,
+      'guild_id': parsedGuildId,
+    });
     final channel = await marshaller.serializers.role.serialize(raw);
 
     return channel;
@@ -79,11 +82,11 @@ final class RolePart extends BasePart implements RolePartContract {
       req,
     );
 
-    final raw = await marshaller.serializers.role.normalize(result);
-    final role = await marshaller.serializers.role.serialize({
-      ...raw,
+    final raw = await marshaller.serializers.role.normalize({
+      ...result,
       'guild_id': parsedGuildId,
     });
+    final role = await marshaller.serializers.role.serialize(raw);
 
     return role;
   }
@@ -159,11 +162,11 @@ final class RolePart extends BasePart implements RolePartContract {
       req,
     );
 
-    final raw = await marshaller.serializers.role.normalize(result);
-    final role = await marshaller.serializers.role.serialize({
-      ...raw,
+    final raw = await marshaller.serializers.role.normalize({
+      ...result,
       'guild_id': parsedGuildId,
     });
+    final role = await marshaller.serializers.role.serialize(raw);
 
     return role;
   }

--- a/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
+++ b/packages/core/lib/src/infrastructure/internals/datastore/request_bucket.dart
@@ -45,82 +45,105 @@ final class QueueableRequest<T> {
     final route = RouteKey(method, query.url.path);
     final httpStatus = bucket.client.status;
 
-    for (var attempt = 0; attempt < _maxRateLimitRetries; attempt++) {
-      final delay = bucket.registry.delayFor(route);
-      if (delay > Duration.zero) {
-        await Future<void>.delayed(delay);
-      }
+    try {
+      for (var attempt = 0; attempt < _maxRateLimitRetries; attempt++) {
+        final delay = bucket.registry.delayFor(route);
+        if (delay > Duration.zero) {
+          await Future<void>.delayed(delay);
+        }
 
-      status = QueueableRequestStatus.pending;
-      final response = await request(query);
+        status = QueueableRequestStatus.pending;
+        final response = await request(query);
 
-      bucket.registry.updateFromHeaders(route, response.headers);
+        bucket.registry.updateFromHeaders(route, response.headers);
 
-      if (httpStatus.isSuccess(response.statusCode)) {
-        status = QueueableRequestStatus.success;
-        bucket.queue.remove(this);
-        try {
-          _onSuccess?.call(response.body);
-          completer.complete(response.body);
-          // ignore: avoid_catching_errors, surface type mismatch as a proper HttpException
-        } on TypeError catch (e) {
+        if (httpStatus.isSuccess(response.statusCode)) {
+          status = QueueableRequestStatus.success;
+          try {
+            _onSuccess?.call(response.body);
+            completer.complete(response.body);
+            // ignore: avoid_catching_errors, surface type mismatch as a proper HttpException
+          } on TypeError catch (e) {
+            completer.completeError(
+              HttpException(
+                'Response body type mismatch: expected $T, '
+                'got ${response.body.runtimeType}. $e',
+              ),
+            );
+          }
+          return;
+        } else if (httpStatus.isRateLimit(response.statusCode)) {
+          final body = response.body;
+          final isGlobal = body is Map && body['global'] == true;
+          final retryAfter = body is Map ? body['retry_after'] : null;
+          final seconds = retryAfter is num
+              ? retryAfter.toDouble()
+              : double.tryParse(retryAfter?.toString() ?? '') ?? 1.0;
+          final retryDelay = Duration(
+            milliseconds: (seconds * 1000).round() + 50,
+          );
+
+          if (isGlobal) {
+            bucket.registry.lockGlobal(retryDelay);
+          } else {
+            bucket.registry.lockRoute(route, retryDelay);
+          }
+
+          _logger.warn(
+            'Rate limit reached on ${route.redactedString} '
+            '(attempt ${attempt + 1}/$_maxRateLimitRetries, '
+            '${isGlobal ? 'global' : 'bucket'}). '
+            'Retrying in ${retryDelay.inMilliseconds}ms',
+          );
+
+          status = QueueableRequestStatus.rateLimit;
+          retryAt = DateTime.now().add(retryDelay);
+
+          _onRateLimit?.call(retryDelay);
+          await Future<void>.delayed(retryDelay);
+          continue;
+        } else if (httpStatus.isError(response.statusCode)) {
+          status = QueueableRequestStatus.error;
+          final exception =
+              _onError?.call(response) ??
+              HttpException(
+                'Request failed with status ${response.statusCode} '
+                'for $method ${route.redactedString}: ${response.bodyString}',
+              );
+          completer.completeError(exception);
+          return;
+        } else {
+          // Defense in depth: [HttpClientStatus] classifies by range, so
+          // every status should already match one of the branches above.
+          // If a future classifier ever leaves a gap, fail loudly instead
+          // of silently falling through and re-issuing the request.
+          status = QueueableRequestStatus.error;
           completer.completeError(
             HttpException(
-              'Response body type mismatch: expected $T, '
-              'got ${response.body.runtimeType}. $e',
+              'Unclassified response status ${response.statusCode} '
+              'for $method ${route.redactedString}: ${response.bodyString}',
             ),
           );
+          return;
         }
-        return;
       }
 
-      if (httpStatus.isRateLimit(response.statusCode)) {
-        final body = response.body;
-        final isGlobal = body is Map && body['global'] == true;
-        final retryAfter = body is Map ? body['retry_after'] : null;
-        final seconds = retryAfter is num
-            ? retryAfter.toDouble()
-            : double.tryParse(retryAfter?.toString() ?? '') ?? 1.0;
-        final retryDelay = Duration(
-          milliseconds: (seconds * 1000).round() + 50,
-        );
-
-        if (isGlobal) {
-          bucket.registry.lockGlobal(retryDelay);
-        } else {
-          bucket.registry.lockRoute(route, retryDelay);
-        }
-
-        _logger.warn(
-          'Rate limit reached on ${route.redactedString} '
-          '(attempt ${attempt + 1}/$_maxRateLimitRetries, '
-          '${isGlobal ? 'global' : 'bucket'}). '
-          'Retrying in ${retryDelay.inMilliseconds}ms',
-        );
-
-        status = QueueableRequestStatus.rateLimit;
-        retryAt = DateTime.now().add(retryDelay);
-
-        _onRateLimit?.call(retryDelay);
-        await Future<void>.delayed(retryDelay);
-        continue;
-      }
-
-      if (httpStatus.isError(response.statusCode)) {
+      status = QueueableRequestStatus.error;
+      completer.completeError(
+        HttpException('Rate limit retry cap ($_maxRateLimitRetries) reached'),
+      );
+    } finally {
+      bucket.queue.remove(this);
+      if (!completer.isCompleted) {
         status = QueueableRequestStatus.error;
-        bucket.queue.remove(this);
-        final exception =
-            _onError?.call(response) ?? HttpException(response.bodyString);
-        completer.completeError(exception);
-        return;
+        completer.completeError(
+          HttpException(
+            'Request for $method ${route.redactedString} terminated '
+            'without completing',
+          ),
+        );
       }
     }
-
-    status = QueueableRequestStatus.error;
-    bucket.queue.remove(this);
-    completer.completeError(
-      HttpException('Rate limit retry cap ($_maxRateLimitRetries) reached'),
-    );
   }
 }
 

--- a/packages/core/lib/src/infrastructure/internals/marshaller/serializers/emoji_serializer.dart
+++ b/packages/core/lib/src/infrastructure/internals/marshaller/serializers/emoji_serializer.dart
@@ -23,9 +23,9 @@ final class EmojiSerializer implements SerializerContract<Emoji> {
       'roles': json['roles'] != null
           ? List.from(json['roles'] as Iterable<dynamic>)
                 .map(
-                  (element) => _marshaller.cacheKey.guildEmoji(
+                  (element) => _marshaller.cacheKey.guildRole(
                     json['guild_id'] as String,
-                    (element as Map<String, dynamic>)['id'] as String,
+                    element as String,
                   ),
                 )
                 .toList()

--- a/packages/core/lib/src/infrastructure/internals/marshaller/serializers/guild_serializer.dart
+++ b/packages/core/lib/src/infrastructure/internals/marshaller/serializers/guild_serializer.dart
@@ -86,46 +86,47 @@ final class GuildSerializer implements SerializerContract<Guild> {
       ctx: _ctx,
     );
 
+    final assets = payload['assets'] as Map<String, dynamic>;
     final guildAssets = GuildAsset(
       Snowflake.parse(payload['id']),
       ctx: _ctx,
       emojis: EmojiManager(Snowflake.parse(payload['id']), ctx: _ctx),
       stickers: StickerManager(Snowflake.parse(payload['id']), ctx: _ctx),
       icon: Helper.createOrNull(
-        field: payload['icon'],
+        field: assets['icon'],
         fn: () => ImageAsset([
           'icons',
-          payload['guild_id'] as String,
-        ], payload['icon'] as String),
+          payload['id'] as String,
+        ], assets['icon'] as String),
       ),
       splash: Helper.createOrNull(
-        field: payload['splash'],
+        field: assets['splash'],
         fn: () => ImageAsset([
           'splashes',
-          payload['guild_id'] as String,
-        ], payload['splash'] as String),
+          payload['id'] as String,
+        ], assets['splash'] as String),
       ),
       banner: Helper.createOrNull(
-        field: payload['banner'],
+        field: assets['banner'],
         fn: () => ImageAsset([
           'banners',
-          payload['guild_id'] as String,
-        ], payload['banner'] as String),
+          payload['id'] as String,
+        ], assets['banner'] as String),
       ),
       discoverySplash: Helper.createOrNull(
-        field: payload['discovery_splash'],
+        field: assets['discovery_splash'],
         fn: () => ImageAsset([
           'discovery-splashes',
           payload['id'] as String,
-        ], payload['discovery_splash'] as String),
+        ], assets['discovery_splash'] as String),
       ),
     );
 
     final settings = payload['settings'] as Map<String, dynamic>;
     final guildSettings = GuildSettings(
-      bitfieldPermission: payload['permissions'] as String?,
-      afkTimeout: payload['afk_timeout'] as int?,
-      hasWidgetEnabled: payload['widget_enabled'] as bool? ?? false,
+      bitfieldPermission: settings['permissions'] as String?,
+      afkTimeout: settings['afk_timeout'] as int?,
+      hasWidgetEnabled: settings['widget_enabled'] as bool? ?? false,
       explicitContentFilter: findInEnum(
         ExplicitContentFilter.values,
         settings['explicit_content_filter'],
@@ -155,7 +156,7 @@ final class GuildSerializer implements SerializerContract<Guild> {
           settings['system_channel_flags'] as int,
         ),
       ),
-      vanityUrlCode: payload['vanity_url_code'] as String?,
+      vanityUrlCode: settings['vanity_url_code'] as String?,
       subscription: GuildSubscription(
         tier: findInEnum(
           PremiumTier.values,
@@ -166,7 +167,7 @@ final class GuildSerializer implements SerializerContract<Guild> {
         hasEnabledProgressBar: settings['premium_progress_bar_enabled'] as bool,
       ),
       preferredLocale: settings['preferred_locale'] as String,
-      maxVideoChannelUsers: payload['max_video_channel_users'] as int?,
+      maxVideoChannelUsers: settings['max_video_channel_users'] as int?,
       nsfwLevel: findInEnum(
         NsfwLevel.values,
         settings['nsfw_level'],

--- a/packages/core/lib/src/infrastructure/internals/marshaller/serializers/invite_serializer.dart
+++ b/packages/core/lib/src/infrastructure/internals/marshaller/serializers/invite_serializer.dart
@@ -13,13 +13,26 @@ final class InviteSerializer implements SerializerContract<Invite> {
   @override
   Future<Map<String, dynamic>> normalize(Map<String, dynamic> json) async {
     final inviter = json['inviter'] as Map<String, dynamic>?;
+    final guild = json['guild'] as Map<String, dynamic>?;
+    final channel = json['channel'] as Map<String, dynamic>?;
+
+    // Discord sends two incompatible shapes into this method. The REST
+    // invite object (InvitePart.get/create) nests a partial `guild` and
+    // `channel` and never carries a flat `guild_id`/`channel_id`. The
+    // gateway INVITE_CREATE event (InviteCreatePacket) is the opposite: it
+    // carries flat `guild_id`/`channel_id` and no nested objects. Both IDs
+    // are independently optional regardless of shape — group-DM invites
+    // have no guild at all.
+    final guildId = json['guild_id'] as String? ?? guild?['id'] as String?;
+    final channelId =
+        json['channel_id'] as String? ?? channel?['id'] as String?;
 
     final payload = {
-      'channelId': json['channel_id'],
+      'channelId': channelId,
       'code': json['code'],
       'createdAt': json['created_at'],
       'expiresAt': json['expires_at'],
-      'guildId': json['guild_id'],
+      'guildId': guildId,
       'inviterId': inviter?['id'],
       'maxAge': json['max_age'],
       'maxUses': json['max_uses'],
@@ -27,11 +40,8 @@ final class InviteSerializer implements SerializerContract<Invite> {
       'type': json['type'],
     };
 
-    final cacheKey = _marshaller.cacheKey.voiceState(
-      json['guild_id'] as String,
-      inviter?['id'] as String,
-    );
-    await _marshaller.cache?.put(cacheKey, payload);
+    final code = json['code'] as String;
+    await _marshaller.cache?.put(_marshaller.cacheKey.invite(code), payload);
 
     return payload;
   }
@@ -40,15 +50,18 @@ final class InviteSerializer implements SerializerContract<Invite> {
   Future<Invite> serialize(Map<String, dynamic> json) async {
     return Invite(
       ctx: _ctx,
-      type: InviteType.of(json['type'] as int),
+      type: InviteType.of(json['type'] as int? ?? InviteType.guild.value),
       code: json['code'] as String,
-      inviterId: Snowflake.parse(json['inviterId']),
-      maxAge: Duration(seconds: json['maxAge'] as int),
-      maxUses: json['maxUses'] as int,
-      isTemporary: json['temporary'] as bool,
-      channelId: Snowflake.parse(json['channelId']),
-      guildId: Snowflake.parse(json['guildId']),
-      createdAt: DateTime.parse(json['createdAt'] as String),
+      inviterId: Snowflake.nullable(json['inviterId'] as String?),
+      maxAge: Duration(seconds: json['maxAge'] as int? ?? 0),
+      maxUses: json['maxUses'] as int? ?? 0,
+      isTemporary: json['temporary'] as bool? ?? false,
+      channelId: Snowflake.nullable(json['channelId']),
+      guildId: Snowflake.nullable(json['guildId']),
+      createdAt: Helper.createOrNull(
+        field: json['createdAt'],
+        fn: () => DateTime.parse(json['createdAt'] as String),
+      ),
       expiresAt: Helper.createOrNull(
         field: json['expiresAt'],
         fn: () => DateTime.parse(json['expiresAt'] as String),
@@ -61,10 +74,10 @@ final class InviteSerializer implements SerializerContract<Invite> {
     return {
       'channelId': invite.channelId?.value,
       'code': invite.code,
-      'createdAt': invite.createdAt.toIso8601String(),
+      'createdAt': invite.createdAt?.toIso8601String(),
       'expiresAt': invite.expiresAt?.toIso8601String(),
       'guildId': invite.guildId?.value,
-      'inviterId': invite.inviterId.value,
+      'inviterId': invite.inviterId?.value,
       'maxAge': invite.maxAge.inSeconds,
       'maxUses': invite.maxUses,
       'temporary': invite.isTemporary,

--- a/packages/core/lib/src/infrastructure/internals/marshaller/serializers/sticker_serializer.dart
+++ b/packages/core/lib/src/infrastructure/internals/marshaller/serializers/sticker_serializer.dart
@@ -2,6 +2,7 @@ import 'package:mineral/src/api/common/snowflake.dart';
 import 'package:mineral/src/api/common/sticker.dart';
 import 'package:mineral/src/api/common/types/format_type.dart';
 import 'package:mineral/src/api/common/types/sticker_type.dart';
+import 'package:mineral/src/domains/common/utils/utils.dart';
 import 'package:mineral/src/domains/services/marshaller/marshaller.dart';
 import 'package:mineral/src/infrastructure/internals/marshaller/types/serializer.dart';
 
@@ -26,11 +27,18 @@ final class StickerSerializer implements SerializerContract<Sticker> {
       'guild_id': json['guild_id'],
     };
 
-    final cacheKey = _marshaller.cacheKey.sticker(
-      json['guild_id'] as String,
-      json['id'] as String,
-    );
-    await _marshaller.cache?.put(cacheKey, payload);
+    // Standard-pack stickers (Discord's built-in packs) have no guild_id —
+    // only guild-uploaded stickers are guild-scoped. There is no meaningful
+    // guild-namespaced cache key for those, so they are normalized (and can
+    // still be serialized) but simply not written to the cache.
+    final guildId = json['guild_id'] as String?;
+    if (guildId != null) {
+      final cacheKey = _marshaller.cacheKey.sticker(
+        guildId,
+        json['id'] as String,
+      );
+      await _marshaller.cache?.put(cacheKey, payload);
+    }
 
     return payload;
   }
@@ -40,19 +48,27 @@ final class StickerSerializer implements SerializerContract<Sticker> {
     return Sticker(
       id: Snowflake.parse(json['id']),
       name: json['name'] as String,
+      // StickerType currently only declares standard/guild (Discord has
+      // never documented a third value) and has no `unknown` sentinel to
+      // route through findInEnum without editing sticker_type.dart, which is
+      // outside this fix's scope. Guarded here with a safe fallback instead
+      // of the unguarded firstWhere so an unexpected value can't throw.
       type: StickerType.values.firstWhere(
         (element) => element.value == json['type'],
+        orElse: () => StickerType.standard,
       ),
-      isAvailable: json['available'] as bool,
+      isAvailable: json['available'] as bool? ?? true,
       packId: json['pack_id'] as String?,
       description: json['description'] as String?,
       tags: json['tags'] as String?,
       asset: json['asset'] as String?,
-      formatType: FormatType.values.firstWhere(
-        (element) => element.value == json['format_type'],
+      formatType: findInEnum(
+        FormatType.values,
+        json['format_type'] as int?,
+        orElse: FormatType.unknown,
       ),
       sortValue: json['sort_value'] as int?,
-      guildId: Snowflake.parse(json['guild_id']),
+      guildId: Snowflake.nullable(json['guild_id'] as String?),
     );
   }
 

--- a/packages/core/lib/src/infrastructure/internals/marshaller/serializers/voice_state_serializer.dart
+++ b/packages/core/lib/src/infrastructure/internals/marshaller/serializers/voice_state_serializer.dart
@@ -23,7 +23,6 @@ final class VoiceStateSerializer implements SerializerContract<VoiceState> {
       'self_video': json['self_video'],
       'suppress': json['suppress'],
       'request_to_speak_timestamp': json['request_to_speak_timestamp'],
-      'discoverable': json['discoverable'],
     };
 
     final cacheKey = _marshaller.cacheKey.voiceState(
@@ -52,7 +51,6 @@ final class VoiceStateSerializer implements SerializerContract<VoiceState> {
       requestToSpeakTimestamp: json['request_to_speak_timestamp'] != null
           ? DateTime.parse(json['request_to_speak_timestamp'] as String)
           : null,
-      isDiscoverable: json['discoverable'] as bool,
     );
   }
 
@@ -71,7 +69,6 @@ final class VoiceStateSerializer implements SerializerContract<VoiceState> {
       'suppress': state.isSuppress,
       'request_to_speak_timestamp': state.requestToSpeakTimestamp
           ?.toIso8601String(),
-      'discoverable': state.isDiscoverable,
     };
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart
@@ -102,7 +102,7 @@ final class ButtonInteractionCreatePacket implements ListenablePacket {
       constraint: (String? customId) => customId == ctx.customId,
     );
 
-    _interactiveComponentManager.dispatch(ctx.customId, [ctx]);
+    await _interactiveComponentManager.dispatch(ctx.customId, [ctx]);
   }
 
   Future<void> _handlePrivateButton(

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/modal_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/modal_interaction_create_packet.dart
@@ -166,7 +166,10 @@ final class ModalInteractionCreatePacket implements ListenablePacket {
         },
       );
 
-      _interactiveComponentManager.dispatch(ctx!.customId, [ctx, parameters]);
+      await _interactiveComponentManager.dispatch(ctx!.customId, [
+        ctx,
+        parameters,
+      ]);
     }
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/select_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/select_interaction_create_packet.dart
@@ -99,7 +99,7 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
         .map((id) => guildChannels[id])
         .whereType<GuildChannel>();
 
-    _interactiveComponentManager.dispatch(ctx.customId, [ctx, channels]);
+    await _interactiveComponentManager.dispatch(ctx.customId, [ctx, channels]);
 
     return switch (ctx) {
       GuildSelectContext() => dispatch<GuildChannelSelectArgs>(
@@ -142,7 +142,10 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
       constraint: (String? customId) => customId == ctx.customId,
     );
 
-    _interactiveComponentManager.dispatch(ctx.customId, [ctx, resolvedRoles]);
+    await _interactiveComponentManager.dispatch(ctx.customId, [
+      ctx,
+      resolvedRoles,
+    ]);
   }
 
   Future<void> _dispatchUserSelectMenu(
@@ -183,7 +186,7 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
       _ => Future.value([]),
     };
 
-    _interactiveComponentManager.dispatch(ctx.customId, [
+    await _interactiveComponentManager.dispatch(ctx.customId, [
       ctx,
       resolvedResource,
     ]);
@@ -235,7 +238,10 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
       }
     }
 
-    _interactiveComponentManager.dispatch(ctx.customId, [ctx, mentionables]);
+    await _interactiveComponentManager.dispatch(ctx.customId, [
+      ctx,
+      mentionables,
+    ]);
 
     dispatch<GuildMentionableSelectArgs>(
       event: Event.guildMentionableSelect,
@@ -253,7 +259,10 @@ final class SelectInteractionCreatePacket implements ListenablePacket {
       (payload['data'] as Map<String, dynamic>)['values'] as Iterable<dynamic>,
     );
 
-    _interactiveComponentManager.dispatch(ctx.customId, [ctx, resolvedText]);
+    await _interactiveComponentManager.dispatch(ctx.customId, [
+      ctx,
+      resolvedText,
+    ]);
 
     return switch (ctx) {
       GuildSelectContext() => dispatch<GuildTextSelectArgs>(

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/ready_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/ready_packet.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
 import 'package:mineral/src/api/common/bot/bot.dart';
@@ -13,7 +11,24 @@ final class ReadyPacket implements ListenablePacket {
   @override
   PacketType get packetType => PacketType.ready;
 
-  bool isAlreadyUsed = false;
+  /// Memoizes the one-time READY initialization (cache clear + global
+  /// command registration).
+  ///
+  /// One [ReadyPacket] instance is shared by every shard, and
+  /// `PacketDispatcher.listen` runs handlers without serialization, so two
+  /// shards' READY events can both reach [listen] before either finishes.
+  /// A plain `bool` guard checked-then-set after an `await` is not enough:
+  /// both callers can observe the flag unset before either sets it.
+  ///
+  /// Assigning with `??=` closes that window because it is synchronous: the
+  /// async function underneath starts running immediately and only
+  /// *suspends* — handing back its `Future` — at its first `await`. So by
+  /// the time any code outside [listen] runs again, [_initializeOnce] is
+  /// already non-null. A second, concurrent READY sees the in-flight
+  /// `Future` and awaits *that* — joining the first call's work — rather
+  /// than skipping it or re-running it, so `dispatch<ReadyArgs>` for the
+  /// second shard doesn't fire until initialization has actually finished.
+  Future<void>? _initializeOnce;
 
   final MarshallerContract _marshaller;
   final CommandInteractionManagerContract _commandManager;
@@ -47,13 +62,23 @@ final class ReadyPacket implements ListenablePacket {
       entityContext: _entityContext,
     );
 
-    if (!isAlreadyUsed) {
-      await _commandManager.registerGlobal(bot);
-      await _maybeClearCache();
-      isAlreadyUsed = true;
-    }
+    await (_initializeOnce ??= _runOnce(bot));
 
     dispatch<ReadyArgs>(event: Event.ready, payload: (bot: bot));
+  }
+
+  Future<void> _runOnce(Bot bot) async {
+    // Clear the cache before doing anything else — in particular, before
+    // the `registerGlobal` REST round-trip below. Discord streams
+    // GUILD_CREATE immediately after READY, and since the dispatcher does
+    // not serialize handlers, a GUILD_CREATE for this shard can be
+    // processed concurrently with anything this method awaits. Any await
+    // ahead of the clear (jitter, a REST call) is a window in which
+    // GUILD_CREATE can hydrate the cache before the clear wipes it back
+    // out. Running the clear first, with nothing awaited ahead of it,
+    // closes that window.
+    await _maybeClearCache();
+    await _commandManager.registerGlobal(bot);
   }
 
   Future<void> _maybeClearCache() async {
@@ -67,11 +92,11 @@ final class ReadyPacket implements ListenablePacket {
       return;
     }
 
-    if (config.staggerClearMs > 0) {
-      final jitter = Random().nextInt(config.staggerClearMs);
-      await Future.delayed(Duration(milliseconds: jitter));
-    }
-
+    // No jitter here (the old `staggerClearMs`-based delay is gone): any
+    // delay before `clear()` only widens the race window described above.
+    // The jitter existed to avoid every shard clearing independently on
+    // reconnect; that no longer applies since [_initializeOnce] already
+    // guarantees a single clear for this client's whole lifetime.
     await cache.clear();
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart
@@ -22,7 +22,29 @@ final class ShardAuthentication implements ShardAuthenticationContract {
   int attempts = 0;
   int _reconnectAttempts = 0;
   bool _pendingResume = false;
+
+  /// True only for the brief window in which [_reconnectWithStrategy] is
+  /// closing the *current* socket to start a reconnect/resume attempt.
+  /// It masks the close/error events that self-disconnect triggers so they
+  /// are not mistaken for a fresh, externally-caused disconnect.
+  ///
+  /// It must NOT stay true for the duration of the whole reconnect attempt:
+  /// if the *new* connection then fails (e.g. `WebsocketClientImpl.connect`
+  /// swallowing a `SocketException` and reporting it as a close), that
+  /// close needs to reach [ShardNetworkErrorContract.dispatch] so another
+  /// reconnect gets scheduled — otherwise the shard goes silently dead
+  /// after a single failed attempt (see chantier A5).
   bool intentionalDisconnect = false;
+
+  /// True once the process has begun a deliberate, permanent teardown
+  /// (e.g. `Kernel.dispose`). Distinct from [intentionalDisconnect] on
+  /// purpose: that flag is transient and cleared automatically after every
+  /// reconnect attempt, while this one is meant to stay true for good and
+  /// suppress any further reconnect scheduling once set. Nothing in this
+  /// file's scope currently sets it — wiring it from `Kernel.dispose` is a
+  /// follow-up outside this chantier's file scope.
+  bool shuttingDown = false;
+
   Timer? _heartbeatTimer;
 
   ShardAuthentication(this.shard);
@@ -68,38 +90,23 @@ final class ShardAuthentication implements ShardAuthenticationContract {
     shard.client.send(message.build());
   }
 
-  /// Handles errors from fire-and-forget heartbeat futures.
-  ///
-  /// [FatalGatewayException] → cancel heartbeat, disconnect the client, and
-  /// invoke [WebsocketOrchestrator.onFatalDisconnect] if available.
-  ///
-  /// Any other error is logged and rethrown so unexpected programming errors
-  /// are not silently discarded.
-  void _onHeartbeatError(Object error, StackTrace stack) {
-    if (error is FatalGatewayException) {
-      shard.logger.error(
-        'Fatal gateway error during heartbeat: ${error.message} (${error.code}). Cannot reconnect.',
-      );
-      cancelHeartbeat();
-      unawaited(shard.client.disconnect());
-      unawaited(shard.wss.onFatalDisconnect?.call() ?? Future<void>.value());
-      return; // handled — do not propagate
-    }
-    shard.logger.error('Unexpected heartbeat error: $error\n$stack');
-    Error.throwWithStackTrace(error, stack);
-  }
-
   void createHeartbeatTimer(int interval) {
     _heartbeatTimer?.cancel();
     final jitterDelay = Duration(
       milliseconds: (_random.nextDouble() * interval).toInt(),
     );
     _heartbeatTimer = Timer(jitterDelay, () {
-      unawaited(Future.sync(heartbeat).catchError(_onHeartbeatError));
+      unawaited(
+        Future.sync(heartbeat).catchError(shard.networkError.onReconnectError),
+      );
       _heartbeatTimer = Timer.periodic(Duration(milliseconds: interval), (
         timer,
       ) {
-        unawaited(Future.sync(heartbeat).catchError(_onHeartbeatError));
+        unawaited(
+          Future.sync(
+            heartbeat,
+          ).catchError(shard.networkError.onReconnectError),
+        );
       });
     });
   }
@@ -142,6 +149,14 @@ final class ShardAuthentication implements ShardAuthenticationContract {
     return Duration(seconds: baseSeconds) + jitter;
   }
 
+  /// Builds a full gateway URL (host + `?v=` + `encoding=`), mirroring the
+  /// formula `WebsocketOrchestrator.createShards` uses for the initial
+  /// connection. Discord's `resume_gateway_url` (unlike the `/gateway/bot`
+  /// endpoint) is returned WITHOUT a query string, so [resume] must reapply
+  /// these params itself or every reconnect after a resume silently loses
+  /// version/encoding negotiation (chantier A6) — most visibly with
+  /// `encoding=etf`, where Discord then falls back to JSON text frames that
+  /// [EtfEncoderStrategy] cannot decode.
   Future<void> _reconnectWithStrategy({
     required String action,
     bool resume = false,
@@ -155,8 +170,16 @@ final class ShardAuthentication implements ShardAuthenticationContract {
       _pendingResume = true;
     }
     attempts = 0;
+
+    // Only mask the close/error events caused by disconnecting the
+    // *current* socket below — not the outcome of the new connection
+    // attempt further down. See the `intentionalDisconnect` doc comment.
     intentionalDisconnect = true;
-    await shard.client.disconnect(code: _internalCloseCode);
+    try {
+      await shard.client.disconnect(code: _internalCloseCode);
+    } finally {
+      intentionalDisconnect = false;
+    }
 
     _reconnectAttempts++;
 
@@ -176,7 +199,12 @@ final class ShardAuthentication implements ShardAuthenticationContract {
     );
     await Future<void>.delayed(delay);
 
-    await shard.init(url: url);
+    // `url` is only ever passed explicitly by `resume()` (the bare
+    // `resume_gateway_url`); `reconnect()`/`resetConnection()` pass none and
+    // fall back to the shard's existing (already fully-qualified) `url`.
+    await shard.init(
+      url: url != null ? shard.wss.config.gatewayUrl(url) : null,
+    );
   }
 
   @override

--- a/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart
@@ -24,14 +24,20 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
     unawaited(shard.wss.onFatalDisconnect?.call() ?? Future<void>.value());
   }
 
-  /// Handles errors from fire-and-forget reconnection futures.
+  /// Shared fire-and-forget error policy for every entry point that kicks
+  /// off a reconnect/resume/heartbeat [Future] without awaiting it: the
+  /// network-error [dispatch] paths below, [Shard]'s opcode handlers
+  /// (OpCode.reconnect / OpCode.invalidSession / OpCode.heartbeat), and
+  /// [ShardAuthenticationContract]'s heartbeat timer. Centralised here so
+  /// every one of those call sites applies the same policy instead of each
+  /// re-implementing (and subtly diverging from) fatal-error handling.
   ///
   /// [FatalGatewayException] → routes to [_handleFatal] (swallowed after
   /// the shutdown sequence so the error does not escape the zone).
   ///
   /// Any other error is logged and rethrown so that unexpected programming
   /// errors are not silently discarded.
-  void _onReconnectError(Object error, StackTrace stack) {
+  void onReconnectError(Object error, StackTrace stack) {
     if (error is FatalGatewayException) {
       _handleFatal(error);
       return; // handled — do not propagate
@@ -48,7 +54,15 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
       return;
     }
 
-    if (shard.authentication.intentionalDisconnect) {
+    // `intentionalDisconnect` masks the brief, self-inflicted close of the
+    // *current* socket while a reconnect attempt is starting up.
+    // `shuttingDown` is the separate, permanent concern of a deliberate
+    // process-level teardown (e.g. Kernel.dispose) — the two used to share
+    // one boolean, which is what let a failed reconnect attempt mask its
+    // own retry (see A5). Keep them distinct even though only the first is
+    // wired up from within this file's scope today.
+    if (shard.authentication.intentionalDisconnect ||
+        shard.authentication.shuttingDown) {
       return;
     }
 
@@ -67,7 +81,7 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
           unawaited(
             Future.sync(
               () => shard.authentication.resume(),
-            ).catchError(_onReconnectError),
+            ).catchError(onReconnectError),
           );
         case DisconnectAction.reconnect:
           logger.trace('Attempting full reconnect');
@@ -75,7 +89,7 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
           unawaited(
             Future.sync(
               () => shard.authentication.reconnect(),
-            ).catchError(_onReconnectError),
+            ).catchError(onReconnectError),
           );
         case DisconnectAction.fatal:
           _handleFatal(FatalGatewayException(error.message, error.code));
@@ -90,7 +104,7 @@ final class ShardNetworkError implements ShardNetworkErrorContract {
     unawaited(
       Future.sync(
         () => shard.authentication.reconnect(),
-      ).catchError(_onReconnectError),
+      ).catchError(onReconnectError),
     );
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/wss/encoding_strategies/etf_encoder.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/encoding_strategies/etf_encoder.dart
@@ -27,12 +27,23 @@ final class EtfEncoderStrategy implements EncodingStrategy {
       return message..content = ShardMessage.of(content);
     } on SerializationException {
       rethrow;
+      // eterl 1.1.0's decoder has no bounds checking (a truncated/malformed
+      // frame throws RangeError) and no recursion depth limit (a deeply
+      // nested payload throws StackOverflowError). Both are Error, not
+      // Exception, and must be converted here rather than escaping and
+      // killing the isolate (chantier A16). Mirrors the accepted pattern at
+      // shard.dart's opcode-processing crash-safety boundary.
+      // ignore: avoid_catching_errors
+    } on Error catch (e) {
+      _fail(e);
     } on Exception catch (e) {
-      _logger.error('Failed to decode ETF WebSocket message: $e');
-      throw SerializationException(
-        'Failed to decode ETF WebSocket message: $e',
-      );
+      _fail(e);
     }
+  }
+
+  Never _fail(Object e) {
+    _logger.error('Failed to decode ETF WebSocket message: $e');
+    throw SerializationException('Failed to decode ETF WebSocket message: $e');
   }
 
   @override

--- a/packages/core/lib/src/infrastructure/internals/wss/shard.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/shard.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
@@ -97,62 +98,95 @@ final class Shard implements ShardContract {
 
     client.interceptor.request.add(wss.config.encoding.encode);
 
-    await client.listen((message) {
-      if (message.content case ShardMessage(
-        opCode: final code,
-        payload: final payload,
-      )) {
-        try {
-          switch (code) {
-            case OpCode.hello:
-              if (payload is! Map<String, dynamic>) {
-                logger.error(
-                  'OpCode.hello: expected Map payload, got ${payload.runtimeType}',
-                );
-                break;
-              }
-              authentication.identify(payload);
-            case OpCode.heartbeatAck:
-              authentication.ack();
-            case OpCode.reconnect:
-              authentication.reconnect();
-            case OpCode.invalidSession:
-              if (payload == true) {
-                authentication.resume();
-              } else {
-                authentication.reconnect();
-              }
-            case OpCode.dispatch:
-              if ([
-                PacketType.ready.name,
-                PacketType.guildCreate.name,
-              ].contains((message.content as ShardMessage).type)) {
-                final decoded = wss.config.encoding.decode(message);
-                onceEventQueue.add(
-                  (decoded.content as ShardMessage).serialize()
-                      as Map<String, dynamic>,
-                );
-              }
-
-              dispatchEvent.dispatch(message);
-            case OpCode.heartbeat:
-              authentication.heartbeat();
-            default:
-              logger.warn('Unknown op code: $code');
-          }
-          // ignore: avoid_catching_errors, crash-safety boundary for shard message processing
-        } on Error catch (e, stackTrace) {
-          logger
-            ..error('Fatal error processing opcode $code on $shardName: $e')
-            ..trace('$stackTrace');
-        } on Exception catch (e, stackTrace) {
-          logger
-            ..error('Error processing opcode $code on $shardName: $e')
-            ..trace('$stackTrace');
-        }
-      }
-    });
+    await client.listen(handleGatewayMessage);
 
     await authentication.connect();
+  }
+
+  /// Routes a single decoded gateway message by opcode.
+  ///
+  /// Extracted out of [init] so it can be exercised directly in tests
+  /// without requiring a live WebSocket connection.
+  ///
+  /// [ShardAuthenticationContract.reconnect], `.resume()` and `.heartbeat()`
+  /// all return `Future<void>`. Calling them bare here would discard that
+  /// Future: the synchronous try/catch below cannot observe an async
+  /// failure, so a [FatalGatewayException] thrown once
+  /// `maxReconnectAttempts` is exceeded (or any other async error) would
+  /// become an unhandled error in the root zone and kill the host process
+  /// (chantier A7). Wrapping each in `unawaited(Future.sync(...).catchError(
+  /// networkError.onReconnectError))` — the same policy already used by
+  /// [ShardNetworkError.dispatch] — routes fatal errors to the graceful
+  /// shutdown path instead.
+  void handleGatewayMessage(WebsocketMessage message) {
+    if (message.content case ShardMessage(
+      opCode: final code,
+      payload: final payload,
+    )) {
+      try {
+        switch (code) {
+          case OpCode.hello:
+            if (payload is! Map<String, dynamic>) {
+              logger.error(
+                'OpCode.hello: expected Map payload, got ${payload.runtimeType}',
+              );
+              break;
+            }
+            authentication.identify(payload);
+          case OpCode.heartbeatAck:
+            authentication.ack();
+          case OpCode.reconnect:
+            unawaited(
+              Future.sync(
+                () => authentication.reconnect(),
+              ).catchError(networkError.onReconnectError),
+            );
+          case OpCode.invalidSession:
+            if (payload == true) {
+              unawaited(
+                Future.sync(
+                  () => authentication.resume(),
+                ).catchError(networkError.onReconnectError),
+              );
+            } else {
+              unawaited(
+                Future.sync(
+                  () => authentication.reconnect(),
+                ).catchError(networkError.onReconnectError),
+              );
+            }
+          case OpCode.dispatch:
+            if ([
+              PacketType.ready.name,
+              PacketType.guildCreate.name,
+            ].contains((message.content as ShardMessage).type)) {
+              final decoded = wss.config.encoding.decode(message);
+              onceEventQueue.add(
+                (decoded.content as ShardMessage).serialize()
+                    as Map<String, dynamic>,
+              );
+            }
+
+            dispatchEvent.dispatch(message);
+          case OpCode.heartbeat:
+            unawaited(
+              Future.sync(
+                () => authentication.heartbeat(),
+              ).catchError(networkError.onReconnectError),
+            );
+          default:
+            logger.warn('Unknown op code: $code');
+        }
+        // ignore: avoid_catching_errors, crash-safety boundary for shard message processing
+      } on Error catch (e, stackTrace) {
+        logger
+          ..error('Fatal error processing opcode $code on $shardName: $e')
+          ..trace('$stackTrace');
+      } on Exception catch (e, stackTrace) {
+        logger
+          ..error('Error processing opcode $code on $shardName: $e')
+          ..trace('$stackTrace');
+      }
+    }
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
+++ b/packages/core/lib/src/infrastructure/internals/wss/websocket_orchestrator.dart
@@ -240,8 +240,7 @@ final class WebsocketOrchestrator implements WebsocketOrchestratorContract {
 
       final end = (bucket + maxConcurrency).clamp(0, totalShards);
       for (int i = bucket; i < end; i++) {
-        final url =
-            '$endpoint/?v=${config.version}&encoding=${config.encoding.encoder.value}';
+        final url = config.gatewayUrl(endpoint);
 
         final shard = Shard(
           shardName: 'shard #$i',

--- a/packages/core/lib/src/infrastructure/services/http/http_client_status.dart
+++ b/packages/core/lib/src/infrastructure/services/http/http_client_status.dart
@@ -1,24 +1,27 @@
-import 'package:mineral/src/infrastructure/services/http/type/response_code.dart';
-
 abstract interface class HttpClientStatus {
   bool isError(int statusCode);
   bool isSuccess(int statusCode);
   bool isRateLimit(int statusCode);
 }
 
+/// Classifies HTTP statuses by range rather than by an enumerated allowlist.
+///
+/// [isSuccess] and [isRateLimit] partition off the two ranges the framework
+/// treats specially; [isError] is the complement of both, so it always
+/// covers the rest of the space (1xx/3xx, undocumented codes, anything
+/// Discord adds in the future) instead of requiring every new status to be
+/// hand-added to a list. Without this, an unclassified status (Discord
+/// documents 304, and returns 409/413/501) fails every check and a caller
+/// looping on classification results can silently re-issue the request
+/// forever.
 final class HttpClientStatusImpl implements HttpClientStatus {
   @override
-  bool isError(int statusCode) {
-    return ResponseCode.errorsCodes.any((code) => code.code == statusCode);
-  }
+  bool isSuccess(int statusCode) => statusCode >= 200 && statusCode < 300;
 
   @override
-  bool isSuccess(int statusCode) {
-    return ResponseCode.successCodes.any((code) => code.code == statusCode);
-  }
+  bool isRateLimit(int statusCode) => statusCode == 429;
 
   @override
-  bool isRateLimit(int statusCode) {
-    return ResponseCode.rateLimitCodes.any((code) => code.code == statusCode);
-  }
+  bool isError(int statusCode) =>
+      !isSuccess(statusCode) && !isRateLimit(statusCode);
 }

--- a/packages/core/lib/src/infrastructure/services/http/response.dart
+++ b/packages/core/lib/src/infrastructure/services/http/response.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:mineral/src/infrastructure/services/http/header.dart';
@@ -27,9 +28,6 @@ final class ResponseImpl<T> implements Response<T> {
   final String bodyString;
 
   @override
-  final T body;
-
-  @override
   final Uri uri;
 
   @override
@@ -38,26 +36,72 @@ final class ResponseImpl<T> implements Response<T> {
   @override
   final String method;
 
+  /// The successfully JSON-decoded body (a `Map`, `List`, or JSON scalar).
+  /// `null` whenever [_decodeError] is set.
+  final Object? _decoded;
+
+  /// Set when [bodyString] could not be parsed as JSON — e.g. an HTML error
+  /// page or a plain-text ban message served by Cloudflare in front of
+  /// Discord. Decoding is never allowed to throw while building this
+  /// response: [statusCode]/[headers]/[bodyString] stay usable (the retry
+  /// and error-reporting paths only need those), and the failure is only
+  /// surfaced, as a typed exception, if something actually reads [body].
+  final FormatException? _decodeError;
+
   ResponseImpl._({
     required this.statusCode,
     required this.headers,
     required this.bodyString,
-    required this.body,
+    required Object? decoded,
+    required FormatException? decodeError,
     required this.uri,
     required this.reasonPhrase,
     required this.method,
-  });
+  }) : _decoded = decoded,
+       _decodeError = decodeError;
+
+  @override
+  T get body {
+    final decodeError = _decodeError;
+    if (decodeError != null) {
+      if (null is T) {
+        return null as T;
+      }
+
+      throw HttpException(
+        'Could not decode response body as JSON for $method $uri '
+        '(status $statusCode): ${decodeError.message}',
+        uri: uri,
+      );
+    }
+
+    try {
+      final decoded = _decoded;
+      if (decoded is List) {
+        return decoded.cast<Map<String, dynamic>>() as T;
+      }
+      return decoded as T;
+      // ignore: avoid_catching_errors, fall back to null for nullable T instead of a raw cast TypeError
+    } on TypeError {
+      if (null is T) {
+        return null as T;
+      }
+      rethrow;
+    }
+  }
 
   static ResponseImpl<T> fromHttpResponse<T>(http.Response response) {
-    final dynamic decodedBody = response.body.isNotEmpty
-        ? jsonDecode(response.body)
-        : {};
-    final T body;
+    Object? decoded;
+    FormatException? decodeError;
 
-    if (decodedBody is List) {
-      body = decodedBody.cast<Map<String, dynamic>>() as T;
+    if (response.body.isEmpty) {
+      decoded = <String, dynamic>{};
     } else {
-      body = decodedBody as T;
+      try {
+        decoded = jsonDecode(response.body);
+      } on FormatException catch (e) {
+        decodeError = e;
+      }
     }
 
     return ResponseImpl<T>._(
@@ -66,7 +110,8 @@ final class ResponseImpl<T> implements Response<T> {
           .map((entry) => Header(entry.key, entry.value))
           .toSet(),
       bodyString: response.body,
-      body: body,
+      decoded: decoded,
+      decodeError: decodeError,
       uri: response.request!.url,
       reasonPhrase: response.reasonPhrase,
       method: response.request!.method,

--- a/packages/core/lib/src/infrastructure/services/http/type/response_code.dart
+++ b/packages/core/lib/src/infrastructure/services/http/type/response_code.dart
@@ -33,10 +33,10 @@ enum ResponseCode {
     notFound,
     methodNotAllowed,
     internalServerError,
+    notImplemented,
     badGateway,
     serviceUnavailable,
     gatewayTimeout,
-    unknown,
   ];
 
   static List<ResponseCode> get successCodes => [

--- a/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
+++ b/packages/core/lib/src/infrastructure/services/wss/websocket_client.dart
@@ -133,6 +133,14 @@ final class WebsocketClientImpl implements WebsocketClient {
       callback(interceptedMessage);
     } on SerializationException catch (e) {
       _logger.warn('Dropping malformed gateway frame: $e');
+      // Defense-in-depth for chantier A16: an encoding strategy is expected
+      // to convert decode failures into SerializationException (see
+      // EtfEncoderStrategy), but should a raw Error (RangeError,
+      // StackOverflowError, ...) still slip through this interceptor chain,
+      // one malformed frame must not kill the isolate.
+      // ignore: avoid_catching_errors
+    } on Error catch (e) {
+      _logger.warn('Dropping malformed gateway frame (unexpected error): $e');
     }
   }
 

--- a/packages/core/test/components/interactive_component_manager_test.dart
+++ b/packages/core/test/components/interactive_component_manager_test.dart
@@ -1,0 +1,370 @@
+import 'dart:async';
+
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/src/testing/fake_logger.dart';
+import 'package:test/test.dart';
+
+// ── Minimal context fakes ────────────────────────────────────────────────
+//
+// `dispatch()` only casts and forwards these; none of their members are
+// read, so every getter beyond `customId` can safely be a stub.
+
+final class _FakeButtonContext implements ButtonContext {
+  @override
+  final String customId;
+  _FakeButtonContext(this.customId);
+
+  @override
+  Snowflake get id => throw UnimplementedError();
+  @override
+  Snowflake get applicationId => throw UnimplementedError();
+  @override
+  String get token => 'token';
+  @override
+  int get version => 1;
+  @override
+  InteractionContract get interaction => throw UnimplementedError();
+}
+
+final class _FakeModalContext implements ModalContext {
+  @override
+  final String customId;
+  _FakeModalContext(this.customId);
+
+  @override
+  Snowflake get id => throw UnimplementedError();
+  @override
+  Snowflake get applicationId => throw UnimplementedError();
+  @override
+  String get token => 'token';
+  @override
+  int get version => 1;
+  @override
+  InteractionContract get interaction => throw UnimplementedError();
+}
+
+final class _FakeSelectContext implements SelectContext {
+  @override
+  final String customId;
+  _FakeSelectContext(this.customId);
+
+  @override
+  Snowflake get id => throw UnimplementedError();
+  @override
+  Snowflake get applicationId => throw UnimplementedError();
+  @override
+  String get token => 'token';
+  @override
+  int get version => 1;
+  @override
+  InteractionContract get interaction => throw UnimplementedError();
+}
+
+// ── Component fakes ──────────────────────────────────────────────────────
+//
+// `handle` is driven by an injected `FutureOr<void> Function()` so each test
+// can pick the exact failure shape: returning normally, throwing
+// synchronously, or returning a Future that rejects.
+
+final class _ScriptedButton implements InteractiveButton {
+  @override
+  final String customId;
+  final FutureOr<void> Function(ButtonContext ctx) onHandle;
+  ButtonContext? received;
+
+  _ScriptedButton(this.customId, this.onHandle);
+
+  @override
+  Button build() => throw UnimplementedError();
+
+  @override
+  FutureOr<void> handle(ButtonContext ctx) {
+    received = ctx;
+    return onHandle(ctx);
+  }
+}
+
+final class _ScriptedModal implements InteractiveModal<String> {
+  @override
+  final String customId;
+  final FutureOr<void> Function(ModalContext ctx, String values) onHandle;
+
+  _ScriptedModal(this.customId, this.onHandle);
+
+  @override
+  ModalBuilder build() => throw UnimplementedError();
+
+  @override
+  FutureOr<void> handle(ModalContext ctx, String values) =>
+      onHandle(ctx, values);
+}
+
+final class _ScriptedSelectMenu implements InteractiveSelectMenu<List<String>> {
+  @override
+  final String customId;
+  final FutureOr<void> Function(SelectContext ctx, List<String> values)
+  onHandle;
+
+  _ScriptedSelectMenu(this.customId, this.onHandle);
+
+  @override
+  SelectMenu<List<String>> build() => throw UnimplementedError();
+
+  @override
+  FutureOr<void> handle(SelectContext ctx, List<String> values) =>
+      onHandle(ctx, values);
+}
+
+void main() {
+  group('InteractiveComponentManager.dispatch', () {
+    late FakeLogger logger;
+    late InteractiveComponentManager manager;
+
+    setUp(() {
+      logger = FakeLogger();
+      manager = InteractiveComponentManager(logger: logger);
+    });
+
+    test('dispatch() returns a Future<void>', () {
+      final button = _ScriptedButton('btn', (_) {});
+      manager.register(button);
+
+      final result = manager.dispatch('btn', [_FakeButtonContext('btn')]);
+
+      expect(result, isA<Future<void>>());
+    });
+
+    test('unknown customId is a no-op and does not throw', () async {
+      await expectLater(
+        manager.dispatch('missing', [_FakeButtonContext('missing')]),
+        completes,
+      );
+    });
+
+    test(
+      'invokes a successful button handler with the given context',
+      () async {
+        final button = _ScriptedButton('btn-ok', (_) {});
+        manager.register(button);
+
+        final ctx = _FakeButtonContext('btn-ok');
+        await manager.dispatch('btn-ok', [ctx]);
+
+        expect(button.received, same(ctx));
+        expect(logger.errors, isEmpty);
+      },
+    );
+
+    group('button — synchronous throw', () {
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+        InteractiveComponent? capturedComponent;
+
+        final button = _ScriptedButton('btn-sync', (_) {
+          throw Exception('synchronous button failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedComponent = component;
+            capturedError = error;
+          }
+          ..register(button);
+
+        await expectLater(
+          manager.dispatch('btn-sync', [_FakeButtonContext('btn-sync')]),
+          completes,
+        );
+
+        expect(capturedComponent, same(button));
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "btn-sync"')),
+        );
+      });
+    });
+
+    group('button — asynchronous (Future) rejection', () {
+      // This is the shape that actually kills the process today: the
+      // handler is declared `async`, so it never throws synchronously to
+      // its caller — it always returns a Future, which then rejects on a
+      // later microtask. A test that only covers the synchronous-throw case
+      // would pass even against the pre-fix `dispatch()`, because a plain
+      // (non-async) `dispatch()` propagates a synchronous throw normally;
+      // it is only the un-awaited *rejected Future* that becomes an
+      // unhandled async error with no zone to catch it.
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+        InteractiveComponent? capturedComponent;
+
+        final button = _ScriptedButton('btn-async', (_) async {
+          await Future<void>.delayed(Duration.zero);
+          throw Exception('asynchronous button failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedComponent = component;
+            capturedError = error;
+          }
+          ..register(button);
+
+        await expectLater(
+          manager.dispatch('btn-async', [_FakeButtonContext('btn-async')]),
+          completes,
+        );
+
+        expect(capturedComponent, same(button));
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "btn-async"')),
+        );
+      });
+
+      test('never reaches the zone as an unhandled error', () async {
+        Object? escapedToZone;
+
+        final button = _ScriptedButton('btn-zone', (_) async {
+          await Future<void>.delayed(Duration.zero);
+          throw Exception('this must stay inside dispatch()');
+        });
+        manager.register(button);
+
+        await runZonedGuarded(() async {
+          await manager.dispatch('btn-zone', [_FakeButtonContext('btn-zone')]);
+          // Give any stray, un-awaited microtask a chance to surface before
+          // the zone guard is torn down.
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }, (error, stackTrace) => escapedToZone = error);
+
+        expect(
+          escapedToZone,
+          isNull,
+          reason:
+              'a rejected handler Future escaped dispatch() uncaught — this '
+              'is exactly the path that terminates the process outside a '
+              'guarded zone',
+        );
+      });
+    });
+
+    group('modal — synchronous throw', () {
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+
+        final modal = _ScriptedModal('modal-sync', (_, _) {
+          throw Exception('synchronous modal failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedError = error;
+          }
+          ..register(modal);
+
+        await expectLater(
+          manager.dispatch('modal-sync', [
+            _FakeModalContext('modal-sync'),
+            'value',
+          ]),
+          completes,
+        );
+
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "modal-sync"')),
+        );
+      });
+    });
+
+    group('modal — asynchronous (Future) rejection', () {
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+
+        final modal = _ScriptedModal('modal-async', (_, _) async {
+          await Future<void>.delayed(Duration.zero);
+          throw Exception('asynchronous modal failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedError = error;
+          }
+          ..register(modal);
+
+        await expectLater(
+          manager.dispatch('modal-async', [
+            _FakeModalContext('modal-async'),
+            'value',
+          ]),
+          completes,
+        );
+
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "modal-async"')),
+        );
+      });
+    });
+
+    group('select menu — synchronous throw', () {
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+
+        final select = _ScriptedSelectMenu('select-sync', (_, _) {
+          throw Exception('synchronous select failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedError = error;
+          }
+          ..register(select);
+
+        await expectLater(
+          manager.dispatch('select-sync', [
+            _FakeSelectContext('select-sync'),
+            <String>['a'],
+          ]),
+          completes,
+        );
+
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "select-sync"')),
+        );
+      });
+    });
+
+    group('select menu — asynchronous (Future) rejection', () {
+      test('is caught, logged, and does not propagate', () async {
+        Object? capturedError;
+
+        final select = _ScriptedSelectMenu('select-async', (_, _) async {
+          await Future<void>.delayed(Duration.zero);
+          throw Exception('asynchronous select failure');
+        });
+        manager
+          ..onComponentError = (component, error, stackTrace) {
+            capturedError = error;
+          }
+          ..register(select);
+
+        await expectLater(
+          manager.dispatch('select-async', [
+            _FakeSelectContext('select-async'),
+            <String>['a'],
+          ]),
+          completes,
+        );
+
+        expect(capturedError, isA<Exception>());
+        expect(
+          logger.errors,
+          contains(contains('Failed to dispatch component "select-async"')),
+        );
+      });
+    });
+  });
+}

--- a/packages/core/test/datastore/parts/emoji_part_test.dart
+++ b/packages/core/test/datastore/parts/emoji_part_test.dart
@@ -1,10 +1,25 @@
+import 'package:mineral/api.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/emoji_part.dart';
 import 'package:test/test.dart';
 
 import '../../helpers/fake_datastore.dart';
 import '../../helpers/fake_http_client.dart';
 import '../../helpers/fake_marshaller.dart';
+import '../../helpers/fake_response.dart';
 import '../../helpers/ioc_test_helper.dart';
+
+/// Mirrors the Discord wire format for an emoji object exactly as Discord
+/// sends it (https://discord.com/developers/docs/resources/emoji#emoji-object).
+/// Discord does NOT include `guild_id` here — EmojiPart must inject it before
+/// handing the payload to `EmojiSerializer.normalize`.
+Map<String, dynamic> rawDiscordEmojiPayload({String id = '100200300'}) => {
+  'id': id,
+  'name': 'thumbsup',
+  'roles': <String>[],
+  'managed': false,
+  'animated': false,
+  'available': true,
+};
 
 void main() {
   group('EmojiPart', () {
@@ -22,6 +37,47 @@ void main() {
     });
 
     tearDown(() => restoreIoc());
+
+    group('fetch', () {
+      test(
+        'injects guild_id before normalize so the returned emojis are populated',
+        () async {
+          http = FakeHttpClient([
+            FakeResponse<List<Map<String, dynamic>>>(200, [
+              rawDiscordEmojiPayload(),
+            ]),
+          ]);
+          dataStore = FakeDataStore(http);
+          emoji = EmojiPart(FakeMarshaller(), dataStore);
+
+          final result = await emoji.fetch('222', true);
+
+          expect(result, hasLength(1));
+          final fetchedEmoji = result.values.single;
+          expect(fetchedEmoji.id, equals(Snowflake('100200300')));
+          expect(fetchedEmoji.guildId, equals(Snowflake('222')));
+        },
+      );
+    });
+
+    group('get', () {
+      test(
+        'injects guild_id before normalize so the returned emoji is populated',
+        () async {
+          http = FakeHttpClient([
+            FakeResponse<Map<String, dynamic>>(200, rawDiscordEmojiPayload()),
+          ]);
+          dataStore = FakeDataStore(http);
+          emoji = EmojiPart(FakeMarshaller(), dataStore);
+
+          final result = await emoji.get('222', '100200300', true);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(Snowflake('100200300')));
+          expect(result.guildId, equals(Snowflake('222')));
+        },
+      );
+    });
 
     group('delete', () {
       test('sends DELETE to /guilds/:guildId/emojis/:emojiId', () async {

--- a/packages/core/test/datastore/parts/role_part_test.dart
+++ b/packages/core/test/datastore/parts/role_part_test.dart
@@ -1,10 +1,28 @@
+import 'package:mineral/api.dart';
 import 'package:mineral/src/infrastructure/internals/datastore/parts/role_part.dart';
 import 'package:test/test.dart';
 
 import '../../helpers/fake_datastore.dart';
 import '../../helpers/fake_http_client.dart';
 import '../../helpers/fake_marshaller.dart';
+import '../../helpers/fake_response.dart';
 import '../../helpers/ioc_test_helper.dart';
+
+/// Mirrors the Discord wire format for a role object exactly as Discord
+/// sends it (https://discord.com/developers/docs/topics/permissions#role-object).
+/// Discord does NOT include `guild_id` here — RolePart must inject it before
+/// handing the payload to `RoleSerializer.normalize`.
+Map<String, dynamic> rawDiscordRolePayload({String id = '333'}) => {
+  'id': id,
+  'name': 'Test Role',
+  'color': 0,
+  'hoist': false,
+  'position': 1,
+  'permissions': '0',
+  'managed': false,
+  'mentionable': false,
+  'flags': 0,
+};
 
 void main() {
   group('RolePart', () {
@@ -22,6 +40,75 @@ void main() {
     });
 
     tearDown(() => restoreIoc());
+
+    group('get', () {
+      test(
+        'injects guild_id before normalize so the returned role is populated',
+        () async {
+          http = FakeHttpClient([
+            FakeResponse<Map<String, dynamic>>(200, rawDiscordRolePayload()),
+          ]);
+          dataStore = FakeDataStore(http);
+          role = RolePart(FakeMarshaller(), dataStore);
+
+          final result = await role.get('222', '333', true);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(Snowflake('333')));
+          expect(result.guildId, equals(Snowflake('222')));
+        },
+      );
+    });
+
+    group('create', () {
+      test(
+        'injects guild_id before normalize so the returned role is populated',
+        () async {
+          http = FakeHttpClient([
+            FakeResponse<Map<String, dynamic>>(200, rawDiscordRolePayload()),
+          ]);
+          dataStore = FakeDataStore(http);
+          role = RolePart(FakeMarshaller(), dataStore);
+
+          final result = await role.create(
+            '222',
+            'Test Role',
+            [],
+            Color.of(0),
+            false,
+            false,
+            null,
+          );
+
+          expect(result.id, equals(Snowflake('333')));
+          expect(result.guildId, equals(Snowflake('222')));
+        },
+      );
+    });
+
+    group('update', () {
+      test(
+        'injects guild_id before normalize so the returned role is populated',
+        () async {
+          http = FakeHttpClient([
+            FakeResponse<Map<String, dynamic>>(200, rawDiscordRolePayload()),
+          ]);
+          dataStore = FakeDataStore(http);
+          role = RolePart(FakeMarshaller(), dataStore);
+
+          final result = await role.update(
+            id: '333',
+            guildId: '222',
+            payload: {'name': 'Updated'},
+            reason: null,
+          );
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(Snowflake('333')));
+          expect(result.guildId, equals(Snowflake('222')));
+        },
+      );
+    });
 
     group('add', () {
       test(

--- a/packages/core/test/datastore/request_bucket_test.dart
+++ b/packages/core/test/datastore/request_bucket_test.dart
@@ -165,5 +165,91 @@ void main() {
       expect(logLine, contains('messages'));
       expect(logLine, isNot(contains('***')));
     });
+
+    group('unclassified statuses fail fast instead of retrying (#465)', () {
+      test('409 completes with an error on the first attempt', () async {
+        final http = FakeHttpClient([409]);
+        final bucket = RequestBucket(http, logger: logger);
+
+        await expectLater(
+          bucket.post<Map<String, dynamic>>(
+            Request.json(endpoint: '/channels/1/messages'),
+          ),
+          throwsA(anything),
+        );
+
+        expect(http.calls, hasLength(1));
+      });
+
+      test('413 does not re-send the request', () async {
+        final http = FakeHttpClient([413]);
+        final bucket = RequestBucket(http, logger: logger);
+
+        await expectLater(
+          bucket.post<Map<String, dynamic>>(
+            Request.json(endpoint: '/channels/1/messages'),
+          ),
+          throwsA(anything),
+        );
+
+        expect(http.calls, hasLength(1));
+      });
+
+      test('304 does not re-send the request', () async {
+        final http = FakeHttpClient([304]);
+        final bucket = RequestBucket(http, logger: logger);
+
+        await expectLater(
+          bucket.get<Map<String, dynamic>>(Request.json(endpoint: '/foo')),
+          throwsA(anything),
+        );
+
+        expect(http.calls, hasLength(1));
+      });
+
+      test('the error message names the actual status (409)', () async {
+        final http = FakeHttpClient([409]);
+        final bucket = RequestBucket(http, logger: logger);
+
+        await expectLater(
+          bucket.post<Map<String, dynamic>>(
+            Request.json(endpoint: '/channels/1/messages'),
+          ),
+          throwsA(predicate((e) => e.toString().contains('409'))),
+        );
+      });
+
+      test('does not misreport a 409 as a rate-limit error', () async {
+        final http = FakeHttpClient([409]);
+        final bucket = RequestBucket(http, logger: logger);
+
+        await expectLater(
+          bucket.post<Map<String, dynamic>>(
+            Request.json(endpoint: '/channels/1/messages'),
+          ),
+          throwsA(
+            predicate(
+              (e) => !e.toString().toLowerCase().contains('rate limit'),
+            ),
+          ),
+        );
+      });
+
+      test(
+        'removes the queue entry after an unclassified status fails',
+        () async {
+          final http = FakeHttpClient([409]);
+          final bucket = RequestBucket(http, logger: logger);
+
+          await bucket
+              .post<Map<String, dynamic>>(
+                Request.json(endpoint: '/channels/1/messages'),
+              )
+              .catchError((_) => <String, dynamic>{});
+
+          expect(bucket.queue, isEmpty);
+        },
+      );
+    });
   });
 }

--- a/packages/core/test/http/http_client_status_test.dart
+++ b/packages/core/test/http/http_client_status_test.dart
@@ -53,6 +53,25 @@ void main() {
       test('returns false for 429 Rate Limit', () {
         expect(status.isError(429), isFalse);
       });
+
+      test('returns true for 304 Not Modified (unenumerated by Discord)', () {
+        expect(status.isError(304), isTrue);
+      });
+
+      test('returns true for 409 Conflict (unenumerated by Discord)', () {
+        expect(status.isError(409), isTrue);
+      });
+
+      test(
+        'returns true for 413 Payload Too Large (unenumerated by Discord)',
+        () {
+          expect(status.isError(413), isTrue);
+        },
+      );
+
+      test('returns true for 501 Not Implemented', () {
+        expect(status.isError(501), isTrue);
+      });
     });
 
     group('isSuccess', () {
@@ -83,6 +102,14 @@ void main() {
       test('returns false for 429 Rate Limit', () {
         expect(status.isSuccess(429), isFalse);
       });
+
+      test('returns false for 304 Not Modified', () {
+        expect(status.isSuccess(304), isFalse);
+      });
+
+      test('returns false for 501 Not Implemented', () {
+        expect(status.isSuccess(501), isFalse);
+      });
     });
 
     group('isRateLimit', () {
@@ -100,6 +127,14 @@ void main() {
 
       test('returns false for 500', () {
         expect(status.isRateLimit(500), isFalse);
+      });
+
+      test('returns false for 304', () {
+        expect(status.isRateLimit(304), isFalse);
+      });
+
+      test('returns false for 409', () {
+        expect(status.isRateLimit(409), isFalse);
       });
     });
   });

--- a/packages/core/test/http/response_code_test.dart
+++ b/packages/core/test/http/response_code_test.dart
@@ -71,10 +71,22 @@ void main() {
         expect(errorCodeValues, contains(404));
         expect(errorCodeValues, contains(405));
         expect(errorCodeValues, contains(500));
+        expect(errorCodeValues, contains(501));
         expect(errorCodeValues, contains(502));
         expect(errorCodeValues, contains(503));
         expect(errorCodeValues, contains(504));
-        expect(errorCodeValues, contains(0));
+      });
+
+      test('does not contain the bogus unknown(0) placeholder', () {
+        // unknown(0) is not a real HTTP status. Classification is by range
+        // (see HttpClientStatusImpl), so a status this list doesn't know
+        // about must fall to "error" on its own merits, not because a
+        // sentinel code happens to be enumerated here.
+        final errorCodeValues = ResponseCode.errorsCodes
+            .map((e) => e.code)
+            .toList();
+
+        expect(errorCodeValues, isNot(contains(0)));
       });
 
       test('does not contain success codes', () {

--- a/packages/core/test/http/response_test.dart
+++ b/packages/core/test/http/response_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:mineral/src/infrastructure/services/http/response.dart';
+import 'package:test/test.dart';
+
+http.Response _rawResponse(
+  String body,
+  int statusCode, {
+  Map<String, String> headers = const {},
+  String? reasonPhrase,
+}) {
+  return http.Response(
+    body,
+    statusCode,
+    headers: headers,
+    reasonPhrase: reasonPhrase,
+    request: http.Request(
+      'DELETE',
+      Uri.parse('https://discord.com/api/v10/channels/1/messages/2'),
+    ),
+  );
+}
+
+void main() {
+  group('ResponseImpl.fromHttpResponse', () {
+    test('204 with an empty body yields a typed empty map, not a throw', () {
+      final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+        _rawResponse('', 204),
+      );
+
+      expect(response.statusCode, 204);
+      expect(response.body, equals(<String, dynamic>{}));
+    });
+
+    test('200 with an empty body yields a typed empty map, not a throw', () {
+      final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+        _rawResponse('', 200),
+      );
+
+      expect(response.body, equals(<String, dynamic>{}));
+    });
+
+    test('decodes a JSON object body', () {
+      final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+        _rawResponse('{"id": "123", "name": "test"}', 200),
+      );
+
+      expect(response.body, equals({'id': '123', 'name': 'test'}));
+    });
+
+    test('decodes a JSON array body into a list of maps', () {
+      final response =
+          ResponseImpl.fromHttpResponse<List<Map<String, dynamic>>>(
+            _rawResponse('[{"id": "1"}, {"id": "2"}]', 200),
+          );
+
+      expect(
+        response.body,
+        equals([
+          {'id': '1'},
+          {'id': '2'},
+        ]),
+      );
+    });
+
+    test('building the response from an HTML error body never throws', () {
+      expect(
+        () => ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+          _rawResponse(
+            '<html><body><h1>502 Bad Gateway</h1></body></html>',
+            502,
+          ),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('statusCode and bodyString stay usable when the body is HTML', () {
+      const html = '<html><body><h1>502 Bad Gateway</h1></body></html>';
+      final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+        _rawResponse(html, 502),
+      );
+
+      expect(response.statusCode, 502);
+      expect(response.bodyString, html);
+    });
+
+    test(
+      'reading .body on a plain-text (non-JSON) response throws an '
+      'HttpException carrying status/method/uri, not a bare FormatException',
+      () {
+        final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>>(
+          _rawResponse('You are being rate limited.', 429),
+        );
+
+        expect(
+          () => response.body,
+          throwsA(
+            isA<HttpException>()
+                .having((e) => e.message, 'message', contains('429'))
+                .having((e) => e.message, 'message', contains('DELETE'))
+                .having(
+                  (e) => e.uri.toString(),
+                  'uri',
+                  contains('/channels/1/messages/2'),
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'reading .body on a non-JSON response returns null when T is nullable',
+      () {
+        final response = ResponseImpl.fromHttpResponse<Map<String, dynamic>?>(
+          _rawResponse('plain text ban message', 403),
+        );
+
+        expect(response.body, isNull);
+      },
+    );
+  });
+}

--- a/packages/core/test/marshalling/serializers/emoji_serializer_test.dart
+++ b/packages/core/test/marshalling/serializers/emoji_serializer_test.dart
@@ -171,6 +171,25 @@ void main() {
 
     group('round-trip (normalize -> serialize)', () {
       test('preserves fields through the real pipeline', () async {
+        // The emoji's `roles` array only ever carries role *ids* on the
+        // wire; resolving them into `Emoji.roles` entities depends on the
+        // role already being cached under its `guildRole` key (see
+        // `serialize() resolves roles from cache` above), same as it would
+        // be in production once `guild.roles.fetch()`/GUILD_CREATE has run.
+        final roleKey = CacheKey().guildRole('987654321', '41771983423143936');
+        cache.store[roleKey] = {
+          'id': '41771983423143936',
+          'name': 'Muffins',
+          'color': 0,
+          'hoist': false,
+          'position': 1,
+          'permissions': '0',
+          'managed': false,
+          'mentionable': false,
+          'flags': 0,
+          'guild_id': '987654321',
+        };
+
         await expectRoundTrip<Emoji>(serializer, rawDiscordPayloadWithGuildId(), {
           'Emoji.id': (emoji) =>
               expect(emoji.id, equals(Snowflake('100200300'))),

--- a/packages/core/test/marshalling/serializers/guild_serializer_test.dart
+++ b/packages/core/test/marshalling/serializers/guild_serializer_test.dart
@@ -22,22 +22,28 @@ void main() {
       );
     });
 
+    // Mirrors the shape `GuildSerializer.normalize` actually produces (assets
+    // and settings nested into sub-maps), so `serialize()` is exercised with
+    // an honest input instead of the flat shape it used to (wrongly) expect.
     Map<String, dynamic> normalizedPayload() => {
       'id': '987654321',
       'name': 'Test Guild',
       'description': 'A test guild',
       'application_id': null,
       'owner_id': '444555666',
-      'icon': null,
-      'splash': null,
-      'banner': null,
-      'discovery_splash': null,
-      'permissions': null,
-      'afk_timeout': 300,
-      'widget_enabled': false,
-      'vanity_url_code': null,
-      'max_video_channel_users': 25,
+      'assets': {
+        'icon': null,
+        'icon_hash': null,
+        'splash': null,
+        'discovery_splash': null,
+        'banner': null,
+      },
       'settings': {
+        'permissions': null,
+        'afk_timeout': 300,
+        'widget_enabled': false,
+        'vanity_url_code': null,
+        'max_video_channel_users': 25,
         'explicit_content_filter': 0,
         'verification_level': 1,
         'default_message_notifications': 0,

--- a/packages/core/test/marshalling/serializers/serializer_edge_cases_test.dart
+++ b/packages/core/test/marshalling/serializers/serializer_edge_cases_test.dart
@@ -148,11 +148,13 @@ void main() {
 
     group('normalize() with null inviter (vanity invites)', () {
       test(
-        'crashes when inviter is null due to voiceState requiring non-nullable args',
+        'does not throw and caches under invites/<code>, not voice_states',
         () async {
-          // BUG: cacheKey.voiceState() expects (Object, Object) but receives
-          // null for inviter?['id']. This causes a TypeError at runtime.
-          // Vanity invites from the Discord API can have inviter: null.
+          // Fixed by #463: normalize() no longer hard-casts inviter?['id'],
+          // and writes to cacheKey.invite(code) instead of
+          // cacheKey.voiceState(guildId, inviterId) — so a null inviter
+          // (vanity invites) neither throws nor pollutes the voice-state
+          // cache namespace.
           final payload = {
             'channel_id': '111222333',
             'code': 'vanity-url',
@@ -166,33 +168,35 @@ void main() {
             'type': 0,
           };
 
+          await serializer.normalize(payload);
+
           expect(
-            () => serializer.normalize(payload),
-            throwsA(isA<TypeError>()),
+            cache.store.containsKey(CacheKey().invite('vanity-url')),
+            isTrue,
+          );
+          expect(
+            cache.store.keys.where((key) => key.startsWith('voice_states/')),
+            isEmpty,
           );
         },
       );
     });
 
     group('normalize() with missing optional fields', () {
-      test(
-        'crashes when inviter is absent due to voiceState null arg',
-        () async {
-          // BUG: Same root cause as the null inviter test above.
-          // When inviter key is missing, inviter?['id'] is null,
-          // which is passed to cacheKey.voiceState().
-          final payload = {
-            'code': 'abc123',
-            'guild_id': '987654321',
-            'type': 0,
-          };
+      test('does not throw when inviter is absent', () async {
+        // Fixed by #463: same root cause as the null-inviter test above —
+        // an absent inviter key must not throw or reach the voice-state
+        // namespace.
+        final payload = {'code': 'abc123', 'guild_id': '987654321', 'type': 0};
 
-          expect(
-            () => serializer.normalize(payload),
-            throwsA(isA<TypeError>()),
-          );
-        },
-      );
+        await serializer.normalize(payload);
+
+        expect(cache.store.containsKey(CacheKey().invite('abc123')), isTrue);
+        expect(
+          cache.store.keys.where((key) => key.startsWith('voice_states/')),
+          isEmpty,
+        );
+      });
 
       test('handles null expires_at gracefully', () async {
         final payload = {

--- a/packages/core/test/marshalling/serializers/sticker_serializer_test.dart
+++ b/packages/core/test/marshalling/serializers/sticker_serializer_test.dart
@@ -135,8 +135,8 @@ void main() {
 
     group('round-trip (normalize -> serialize)', () {
       // Discord's sticker `format_type` is 1=PNG, 2=APNG, 3=LOTTIE, 4=GIF.
-      // `FormatType` only declares standard(1)/guild(2) (a copy-paste of
-      // StickerType's values), so LOTTIE and GIF stickers cannot resolve.
+      // `FormatType` now declares all four (standard/guild kept their
+      // original names to avoid a wider rename; lottie/gif were added).
 
       test('format_type 1 (PNG) resolves', () async {
         final raw = rawDiscordPayload()..['format_type'] = 1;
@@ -156,7 +156,7 @@ void main() {
         });
       });
 
-      test('format_type 3 (LOTTIE) throws StateError — this is the format of '
+      test('format_type 3 (LOTTIE) resolves — this is the format of '
           'every Discord standard sticker pack', () async {
         // guild_id is left as a valid value here on purpose: normalize()
         // itself hard-casts guild_id for the cache key (see the separate
@@ -164,13 +164,19 @@ void main() {
         // no longer isolate the format_type defect this case targets.
         final raw = rawDiscordPayload()..['format_type'] = 3;
 
-        await expectLater(roundTrip(serializer, raw), throwsStateError);
+        await expectRoundTrip<Sticker>(serializer, raw, {
+          'Sticker.formatType': (sticker) =>
+              expect(sticker.formatType, equals(FormatType.lottie)),
+        });
       });
 
-      test('format_type 4 (GIF) throws StateError', () async {
+      test('format_type 4 (GIF) resolves', () async {
         final raw = rawDiscordPayload()..['format_type'] = 4;
 
-        await expectLater(roundTrip(serializer, raw), throwsStateError);
+        await expectRoundTrip<Sticker>(serializer, raw, {
+          'Sticker.formatType': (sticker) =>
+              expect(sticker.formatType, equals(FormatType.gif)),
+        });
       });
 
       test('standard-pack sticker with no guild_id round-trips', () async {

--- a/packages/core/test/marshalling/serializers/voice_state_serializer_test.dart
+++ b/packages/core/test/marshalling/serializers/voice_state_serializer_test.dart
@@ -34,7 +34,6 @@ void main() {
       'self_video': false,
       'suppress': false,
       'request_to_speak_timestamp': null,
-      'discoverable': true,
     };
 
     // Mirrors the raw Voice State object Discord sends over the gateway
@@ -80,7 +79,6 @@ void main() {
         expect(state.hasSelfVideo, isFalse);
         expect(state.isSuppress, isFalse);
         expect(state.requestToSpeakTimestamp, isNull);
-        expect(state.isDiscoverable, isTrue);
       });
 
       test('handles nullable channelId', () async {
@@ -115,7 +113,6 @@ void main() {
         expect(result['self_deaf'], isTrue);
         expect(result['self_mute'], isTrue);
         expect(result['suppress'], isFalse);
-        expect(result['discoverable'], isTrue);
       });
 
       test('serializes nullable channelId as null', () async {

--- a/packages/core/test/packets/button_interaction_create_packet_test.dart
+++ b/packages/core/test/packets/button_interaction_create_packet_test.dart
@@ -8,9 +8,17 @@ import '../helpers/fake_entity_context.dart';
 final class _NoopInteractiveComponent
     implements InteractiveComponentManagerContract {
   @override
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
+  @override
   void register(InteractiveComponent component) {}
   @override
-  void dispatch(String customId, List params) {}
+  Future<void> dispatch(String customId, List params) async {}
   @override
   T get<T extends InteractiveComponent>(String customId) =>
       throw UnimplementedError();

--- a/packages/core/test/packets/packet_dispatcher_test.dart
+++ b/packages/core/test/packets/packet_dispatcher_test.dart
@@ -129,9 +129,17 @@ final class _FakeProviderManager implements ProviderManagerContract {
 final class _FakeInteractiveComponentManager
     implements InteractiveComponentManagerContract {
   @override
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
+  @override
   void register(InteractiveComponent component) {}
   @override
-  void dispatch(String customId, List params) {}
+  Future<void> dispatch(String customId, List params) async {}
   @override
   T get<T extends InteractiveComponent>(String customId) =>
       throw UnimplementedError();

--- a/packages/core/test/packets/ready_packet_test.dart
+++ b/packages/core/test/packets/ready_packet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
@@ -221,6 +223,128 @@ void main() {
         expect(callCount, equals(1));
       },
     );
+
+    // ── Regression tests for #468 ───────────────────────────────────────────
+    //
+    // One ReadyPacket instance is shared by every shard, and the packet
+    // dispatcher runs handlers without serialization, so two READY
+    // dispatches can genuinely interleave at await points. Both tests below
+    // drive two `listen()` calls concurrently — the first is deliberately
+    // never awaited before the second starts — landing the second call
+    // inside a window controlled by a `Completer` on the fake command
+    // manager's `registerGlobal`. A test that awaits the first call
+    // sequentially before starting the second would never exercise this
+    // window at all.
+
+    test(
+      'Interleaving A: two concurrent READY dispatches (simulating two '
+      'shards sharing this ReadyPacket) call registerGlobal exactly once',
+      () async {
+        final gate = Completer<void>();
+        final entered = Completer<void>();
+        final blockingManager = _BlockingCommandManager(
+          gate: gate.future,
+          onEnter: () {
+            if (!entered.isCompleted) {
+              entered.complete();
+            }
+          },
+        );
+
+        final p = ReadyPacket(
+          marshaller: marshaller,
+          commandManager: blockingManager,
+          wss: wss,
+          runtimeState: runtimeState,
+          entityContext: ctx,
+        );
+
+        void dispatch<T extends Object>({
+          required Event event,
+          required T payload,
+          bool Function(String?)? constraint,
+        }) {}
+
+        // Shard 0's READY: not awaited, so its execution can be suspended
+        // mid-flight while the test keeps driving.
+        final f1 = p.listen(_buildMessage(), dispatch);
+
+        // Block until shard 0 has actually entered registerGlobal and is
+        // now suspended on `gate`. Under the old `if (!isAlreadyUsed)`
+        // guard, this is precisely the window where a second READY would
+        // still observe `isAlreadyUsed == false`.
+        await entered.future;
+
+        // Shard 1's READY arrives while shard 0 is still in flight.
+        final f2 = p.listen(_buildMessage(), dispatch);
+
+        gate.complete();
+        await Future.wait([f1, f2]);
+
+        expect(blockingManager.registerGlobalCallCount, equals(1));
+      },
+    );
+
+    test(
+      'Interleaving B: a cache write landing while READY is still in '
+      'flight (single shard) survives the clear',
+      () async {
+        final cache = FakeCacheProvider()
+          ..config = CacheConfig(clearOnReady: true, staggerClearMs: 0);
+        await cache.put('stale', {'from': 'previous session'});
+
+        final gate = Completer<void>();
+        final entered = Completer<void>();
+        final blockingManager = _BlockingCommandManager(
+          gate: gate.future,
+          onEnter: () {
+            if (!entered.isCompleted) {
+              entered.complete();
+            }
+          },
+        );
+
+        final marshallerWithCache = FakeMarshaller(cache: cache);
+        final p = ReadyPacket(
+          marshaller: marshallerWithCache,
+          commandManager: blockingManager,
+          wss: wss,
+          runtimeState: runtimeState,
+          entityContext: ctx,
+          cacheConfig: cache.config,
+        );
+
+        void dispatch<T extends Object>({
+          required Event event,
+          required T payload,
+          bool Function(String?)? constraint,
+        }) {}
+
+        final f1 = p.listen(_buildMessage(), dispatch);
+
+        // Block until READY's handling has reached (and is now blocked
+        // inside) the registerGlobal REST call -- the earliest point at
+        // which a concurrently-dispatched GUILD_CREATE could plausibly
+        // start writing to the cache, since the dispatcher does not
+        // serialize handlers.
+        await entered.future;
+
+        // Simulate GUILD_CREATE hydrating the cache while READY is still
+        // in flight.
+        await cache.put('guild:1', {'hydrated': true});
+
+        gate.complete();
+        await f1;
+
+        expect(
+          cache.store.containsKey('guild:1'),
+          isTrue,
+          reason:
+              'a cache write landing during the READY window must survive; '
+              'the clear must not run after it',
+        );
+      },
+    );
   });
 }
 
@@ -244,6 +368,50 @@ final class _CountingCommandManager
   @override
   Future<void> registerGlobal(Bot bot) async {
     onRegisterGlobal();
+  }
+
+  @override
+  Future<void> registerServer(Bot bot, Guild guild) async {}
+
+  @override
+  void addCommand(dynamic command) {}
+
+  @override
+  Future<void> handleAutocomplete(Map<String, dynamic> payload) async {}
+}
+
+/// A [CommandInteractionManagerContract] whose `registerGlobal` suspends on
+/// a caller-supplied `gate` future, so a test can deterministically land a
+/// second, concurrent `ReadyPacket.listen` call while the first is still
+/// in flight inside `registerGlobal`.
+///
+/// `onEnter` fires synchronously, before the suspension, as soon as
+/// `registerGlobal` is entered -- awaiting the future it completes tells a
+/// test "the call is now blocked on `gate`" without any sleeps or arbitrary
+/// microtask pumping.
+final class _BlockingCommandManager
+    implements CommandInteractionManagerContract {
+  _BlockingCommandManager({required this.gate, this.onEnter});
+
+  final Future<void> gate;
+  final void Function()? onEnter;
+
+  int registerGlobalCallCount = 0;
+
+  @override
+  final List<CommandRegistration> commandsHandler = [];
+  @override
+  final List<cb.CommandBuilder> commands = [];
+  @override
+  late InteractionDispatcherContract dispatcher;
+  @override
+  void Function(CommandFailure failure)? onCommandError;
+
+  @override
+  Future<void> registerGlobal(Bot bot) async {
+    registerGlobalCallCount++;
+    onEnter?.call();
+    await gate;
   }
 
   @override

--- a/packages/core/test/unit/kernel_standalone_test.dart
+++ b/packages/core/test/unit/kernel_standalone_test.dart
@@ -109,9 +109,17 @@ final class _FakePacketListener implements PacketListenerContract {
 final class _FakeInteractiveComponentManager
     implements InteractiveComponentManagerContract {
   @override
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
+  @override
   void register(InteractiveComponent component) {}
   @override
-  void dispatch(String customId, List params) {}
+  Future<void> dispatch(String customId, List params) async {}
   @override
   T get<T extends InteractiveComponent>(String customId) =>
       throw UnimplementedError();

--- a/packages/core/test/wss/shard_dispatch_test.dart
+++ b/packages/core/test/wss/shard_dispatch_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:mineral/src/domains/services/packets/packet_dispatcher.dart';
 import 'package:mineral/src/domains/services/packets/packet_type.dart';
@@ -8,9 +9,12 @@ import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.d
 import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart';
 import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_data.dart';
 import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_network_error.dart';
+import 'package:mineral/src/infrastructure/internals/wss/encoding_strategies/etf_encoder.dart';
 import 'package:mineral/src/infrastructure/internals/wss/running_strategies/default_running_strategy.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
+import 'package:mineral/src/infrastructure/io/exceptions/serialization_exception.dart';
+import 'package:mineral/src/infrastructure/services/wss/websocket_client.dart';
 import 'package:mineral/src/infrastructure/services/wss/websocket_message.dart';
 import 'package:mineral/src/testing/fake_logger.dart';
 import 'package:test/test.dart';
@@ -387,6 +391,285 @@ void main() {
       );
 
       expect(shard.authentication.sequence, equals(42));
+    });
+  });
+
+  // ── A7 regression: opcode-triggered futures must not become unhandled ───
+
+  group('Shard.handleGatewayMessage — A7 (opcode-triggered futures must not '
+      'become unhandled)', () {
+    Shard fatalShard({
+      required FakeLogger logger,
+      required Future<void> Function() onFatalDisconnect,
+    }) {
+      final wss = FakeWebsocketOrchestrator(maxReconnectAttempts: 0)
+        ..onFatalDisconnect = onFatalDisconnect;
+      return Shard(
+        shardName: 'test-shard-0',
+        shardIndex: 0,
+        shardCount: 1,
+        url: 'wss://fake',
+        wss: wss,
+        logger: logger,
+        strategy: FakeRunningStrategy(),
+      )..client = FakeWebsocketClient();
+    }
+
+    test(
+      'OpCode.reconnect: a FatalGatewayException from reconnect() is '
+      'routed to the fatal-shutdown handler instead of escaping the zone',
+      () async {
+        var fatalCalled = false;
+        final shard = fatalShard(
+          logger: FakeLogger(),
+          onFatalDisconnect: () async {
+            fatalCalled = true;
+          },
+        );
+
+        final uncaughtErrors = <Object>[];
+        await runZonedGuarded(() async {
+          shard.handleGatewayMessage(
+            _message(
+              ShardMessage(
+                type: null,
+                opCode: OpCode.reconnect,
+                sequence: null,
+                payload: null,
+              ),
+            ),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+        }, (e, _) => uncaughtErrors.add(e));
+
+        expect(
+          uncaughtErrors,
+          isEmpty,
+          reason:
+              'Before the A7 fix, authentication.reconnect() was called '
+              'bare (its Future discarded); once maxReconnectAttempts is '
+              'exceeded it throws FatalGatewayException, which becomes an '
+              'unhandled error in the root zone and kills the process.',
+        );
+        expect(
+          fatalCalled,
+          isTrue,
+          reason:
+              'the exception must reach the graceful fatal-shutdown '
+              'path, not just avoid crashing',
+        );
+
+        shard.authentication.cancelHeartbeat();
+      },
+    );
+
+    test('OpCode.invalidSession (payload=true): a FatalGatewayException from '
+        'resume() is routed to the fatal-shutdown handler', () async {
+      var fatalCalled = false;
+      final shard = fatalShard(
+        logger: FakeLogger(),
+        onFatalDisconnect: () async {
+          fatalCalled = true;
+        },
+      );
+
+      final uncaughtErrors = <Object>[];
+      await runZonedGuarded(() async {
+        shard.handleGatewayMessage(
+          _message(
+            ShardMessage(
+              type: null,
+              opCode: OpCode.invalidSession,
+              sequence: null,
+              payload: true,
+            ),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }, (e, _) => uncaughtErrors.add(e));
+
+      expect(uncaughtErrors, isEmpty);
+      expect(fatalCalled, isTrue);
+
+      shard.authentication.cancelHeartbeat();
+    });
+
+    test('OpCode.invalidSession (payload=false): a FatalGatewayException '
+        'from reconnect() is routed to the fatal-shutdown handler', () async {
+      var fatalCalled = false;
+      final shard = fatalShard(
+        logger: FakeLogger(),
+        onFatalDisconnect: () async {
+          fatalCalled = true;
+        },
+      );
+
+      final uncaughtErrors = <Object>[];
+      await runZonedGuarded(() async {
+        shard.handleGatewayMessage(
+          _message(
+            ShardMessage(
+              type: null,
+              opCode: OpCode.invalidSession,
+              sequence: null,
+              payload: false,
+            ),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }, (e, _) => uncaughtErrors.add(e));
+
+      expect(uncaughtErrors, isEmpty);
+      expect(fatalCalled, isTrue);
+
+      shard.authentication.cancelHeartbeat();
+    });
+
+    test('OpCode.heartbeat: a FatalGatewayException from '
+        "heartbeat()'s resetConnection() (3 failed attempts) is routed to "
+        'the fatal-shutdown handler', () async {
+      var fatalCalled = false;
+      final shard = fatalShard(
+        logger: FakeLogger(),
+        onFatalDisconnect: () async {
+          fatalCalled = true;
+        },
+      );
+      shard.authentication.attempts = 3;
+
+      final uncaughtErrors = <Object>[];
+      await runZonedGuarded(() async {
+        shard.handleGatewayMessage(
+          _message(
+            ShardMessage(
+              type: null,
+              opCode: OpCode.heartbeat,
+              sequence: null,
+              payload: null,
+            ),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }, (e, _) => uncaughtErrors.add(e));
+
+      expect(uncaughtErrors, isEmpty);
+      expect(fatalCalled, isTrue);
+
+      shard.authentication.cancelHeartbeat();
+    });
+  });
+
+  // ── A16 regression: malformed ETF frames must not kill the isolate ──────
+
+  group('EtfEncoderStrategy.decode — A16 (malformed ETF frames must not kill '
+      'the isolate)', () {
+    WebsocketMessage rawMessage(List<int> bytes) => WebsocketMessageImpl(
+      channelName: 'test',
+      originalContent: bytes,
+      content: bytes,
+    );
+
+    test('a truncated frame (RangeError from eterl) is converted to '
+        'SerializationException, not left as a raw Error', () {
+      final strategy = EtfEncoderStrategy(logger: FakeLogger());
+      // ETF version byte (131) + binaryExt tag (109) with no
+      // length/payload bytes: eterl's Decoder._read32() reads past the
+      // end of the 2-byte buffer and throws RangeError.
+      final message = rawMessage([131, 109]);
+
+      expect(
+        () => strategy.decode(message),
+        throwsA(isA<SerializationException>()),
+        reason:
+            "eterl 1.1.0's decoder has no bounds checking. Before the "
+            'A16 fix, decode() only caught SerializationException/'
+            'Exception, so this RangeError (an Error) escaped raw and '
+            'would have killed the isolate at the caller.',
+      );
+    });
+
+    test('a deeply nested frame (StackOverflowError from eterl) is '
+        'converted to SerializationException', () {
+      final strategy = EtfEncoderStrategy(logger: FakeLogger());
+      // 200k levels of smallTupleExt(arity 1) nesting: decode()
+      // recurses once per level with no depth limit, overflowing the
+      // stack.
+      final bytes = <int>[131];
+      for (var i = 0; i < 200000; i++) {
+        bytes.addAll([104, 1]);
+      }
+      bytes.addAll([97, 1]); // smallIntegerExt leaf
+      final message = rawMessage(bytes);
+
+      expect(
+        () => strategy.decode(message),
+        throwsA(isA<SerializationException>()),
+      );
+    });
+
+    test('a well-formed frame still decodes normally', () {
+      final strategy = EtfEncoderStrategy(logger: FakeLogger());
+      // smallIntegerExt(1) wrapped in a 1-arity smallTupleExt is not a
+      // map, so decode via a minimal valid map instead: mapExt with 0
+      // entries -> {}.
+      final message = rawMessage([131, 116, 0, 0, 0, 0]);
+
+      final decoded = strategy.decode(message);
+
+      expect(decoded.content, isA<ShardMessage>());
+    });
+  });
+
+  // ── A16 regression: WebsocketClientImpl defense-in-depth ────────────────
+
+  group('WebsocketClientImpl._handleMessage — A16 (a raw Error from an '
+      'interceptor must not kill the isolate)', () {
+    test('a frame is dropped (not delivered, not thrown) when a message '
+        'interceptor throws a raw Error', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(request);
+        socket.add('trigger');
+      });
+
+      final logger = FakeLogger();
+      final client = WebsocketClientImpl(
+        url: 'ws://127.0.0.1:${server.port}',
+        logger: logger,
+      );
+      client.interceptor.message.add((message) {
+        // Simulates an encoding strategy (or any other interceptor)
+        // that slips a raw Error through instead of converting it to
+        // SerializationException.
+        throw RangeError('simulated malformed frame');
+      });
+
+      final received = <dynamic>[];
+      final uncaughtErrors = <Object>[];
+      await runZonedGuarded(() async {
+        await client.listen(received.add);
+        await client.connect();
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+      }, (e, _) => uncaughtErrors.add(e));
+
+      expect(
+        received,
+        isEmpty,
+        reason: 'the malformed frame must be dropped, not delivered',
+      );
+      expect(
+        uncaughtErrors,
+        isEmpty,
+        reason:
+            'Before the A16 fix, _handleMessage only caught '
+            'SerializationException, so this raw RangeError would have '
+            'escaped and killed the isolate instead of just dropping '
+            'the one bad frame.',
+      );
+      expect(logger.warnings, contains(contains('malformed gateway frame')));
+
+      await client.disconnect();
     });
   });
 }

--- a/packages/core/test/wss/shard_network_error_test.dart
+++ b/packages/core/test/wss/shard_network_error_test.dart
@@ -94,6 +94,21 @@ void main() {
       expect((shard.client as FakeWebsocketClient).disconnected, isFalse);
     });
 
+    test('does nothing when shuttingDown is true (A5 flag split)', () {
+      // shuttingDown is the separate, permanent-teardown counterpart to
+      // intentionalDisconnect (see chantier A5) — it must independently
+      // suppress dispatch even though intentionalDisconnect is false.
+      final shard = _createShard(logger: logger)
+        ..client = FakeWebsocketClient();
+      shard.authentication.shuttingDown = true;
+      ShardNetworkError(shard).dispatch(4000);
+
+      expect(shard.authentication.intentionalDisconnect, isFalse);
+      expect(logger.warnings, isEmpty);
+      expect(logger.errors, isEmpty);
+      expect((shard.client as FakeWebsocketClient).disconnected, isFalse);
+    });
+
     group('resume codes', () {
       test('logs warning for code 4000 (unknownError)', () {
         final shard = _createShard(logger: logger)

--- a/packages/core/test/wss/shard_reconnection_test.dart
+++ b/packages/core/test/wss/shard_reconnection_test.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:mineral/api.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/src/domains/services/wss/running_strategy.dart';
 import 'package:mineral/src/infrastructure/internals/wss/dispatchers/shard_authentication.dart';
+import 'package:mineral/src/infrastructure/internals/wss/encoding_strategies/json_encoder.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard.dart';
-import 'package:mineral/src/infrastructure/io/exceptions/fatal_gateway_exception.dart';
+import 'package:mineral/src/infrastructure/internals/wss/websocket_isolate_message_transfert.dart';
 import 'package:mineral/src/testing/fake_logger.dart';
 import 'package:test/test.dart';
 
@@ -23,6 +27,107 @@ Shard _createShard({required FakeLogger logger, int maxReconnectAttempts = 3}) {
     logger: logger,
     strategy: FakeRunningStrategy(),
   );
+}
+
+// ── A5/A6 regression helpers ─────────────────────────────────────────────
+//
+// `FakeShardingConfig.encoding` throws `UnimplementedError`, which is fine
+// for every other test in this file because none of them let a reconnect
+// attempt run far enough to reach `Shard.init()` (they only ever observe
+// the synchronous prelude within a `Duration.zero` window). The two tests
+// below deliberately let a reconnect/resume attempt run to completion —
+// `Shard.init()` *always* constructs a brand-new, real `WebsocketClientImpl`
+// regardless of what fake was previously assigned to `shard.client`, so
+// this is the only way to reproduce the real A5/A6 failure modes — which
+// means they need a working `encoding`.
+
+/// A [ShardingConfigContract] with a real, working [encoding] (unlike
+/// [FakeShardingConfig]), so `Shard.init()` can build its interceptor chain
+/// without throwing before ever attempting to connect.
+final class _WorkingShardingConfig implements ShardingConfigContract {
+  final int _maxReconnectAttempts;
+
+  @override
+  final EncodingStrategy encoding;
+
+  _WorkingShardingConfig({
+    required LoggerContract logger,
+    int maxReconnectAttempts = 5,
+  }) : _maxReconnectAttempts = maxReconnectAttempts,
+       encoding = JsonEncoderStrategy(logger: logger);
+
+  @override
+  String get token => 'fake-token';
+  @override
+  int get intent => 513;
+  @override
+  bool get compress => false;
+  @override
+  int get version => 10;
+  @override
+  int get largeThreshold => 50;
+  @override
+  int? get shardCount => 1;
+  @override
+  int get maxReconnectAttempts => _maxReconnectAttempts;
+  @override
+  Duration get maxReconnectDelay => Duration.zero;
+}
+
+/// A minimal [WebsocketOrchestratorContract] whose `config` is
+/// [_WorkingShardingConfig] instead of the throwing default from
+/// [FakeWebsocketOrchestrator] (which is `final` and cannot be extended),
+/// so a reconnect/resume attempt can run through a real (failing)
+/// `WebsocketClientImpl.connect()` call. Everything besides `config` mirrors
+/// [FakeWebsocketOrchestrator]'s own no-op behaviour.
+final class _RealConnectOrchestrator implements WebsocketOrchestratorContract {
+  _RealConnectOrchestrator({
+    required LoggerContract logger,
+    int maxReconnectAttempts = 5,
+  }) : config = _WorkingShardingConfig(
+         logger: logger,
+         maxReconnectAttempts: maxReconnectAttempts,
+       );
+
+  @override
+  final ShardingConfigContract config;
+
+  @override
+  final List<RequestQueueEntry> requestQueue = [];
+  @override
+  void addToRequestQueue(RequestQueueEntry entry) => requestQueue.add(entry);
+  @override
+  RequestQueueEntry? findInRequestQueue(String uid) {
+    for (final entry in requestQueue) {
+      if (entry.uid == uid) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void removeFromRequestQueue(RequestQueueEntry entry) =>
+      requestQueue.remove(entry);
+  @override
+  Map<int, ShardContract> get shards => {};
+  @override
+  Future<void> Function()? onFatalDisconnect;
+  @override
+  void send(WebsocketIsolateMessageTransfert message) {}
+  @override
+  void setBotPresence(
+    List<BotActivity>? activity,
+    StatusType? status,
+    bool? afk,
+  ) {}
+  @override
+  Future<Map<String, dynamic>> getWebsocketEndpoint() async => {};
+  @override
+  Future<void> createShards(RunningStrategy strategy) async {}
+  @override
+  Future<Presence> getMemberPresence(String guildId, String id) =>
+      throw UnimplementedError();
 }
 
 void main() {
@@ -339,6 +444,131 @@ void main() {
               .toList();
           expect(postResetWarnings.length, greaterThanOrEqualTo(2));
           expect(errors.whereType<FatalGatewayException>(), isEmpty);
+        },
+      );
+    });
+
+    // ── A5/A6 regression ────────────────────────────────────────────────
+
+    group('A5 — a failed reconnect must not kill the shard for good', () {
+      test(
+        'a reconnect whose new connect() fails still schedules the next '
+        'backoff attempt instead of leaving the shard permanently dead',
+        () async {
+          final orchestrator = _RealConnectOrchestrator(
+            logger: logger,
+            maxReconnectAttempts: 5,
+          );
+          final testShard = Shard(
+            shardName: 'test-shard-0',
+            shardIndex: 0,
+            shardCount: 1,
+            // Fails DNS resolution near-instantly (~tens of ms), so
+            // WebsocketClientImpl.connect() reliably swallows the failure
+            // and reports it via _onClose?.call(1006) — reproducing the
+            // exact repro path from the bug report.
+            url: 'wss://fake',
+            wss: orchestrator,
+            logger: logger,
+            strategy: FakeRunningStrategy(),
+          )..client = FakeWebsocketClient();
+
+          final uncaughtErrors = <Object>[];
+          await runZonedGuarded(() async {
+            unawaited(testShard.authentication.reconnect());
+            // Enough real time for: the first backoff (jitter <1s;
+            // maxReconnectDelay is 0) + WebsocketClientImpl.connect() to
+            // fail DNS lookup for the bogus host + the resulting
+            // dispatch(1006) to schedule and log a SECOND reconnect
+            // attempt's own "Reconnecting" warning before its own backoff.
+            await Future<void>.delayed(const Duration(seconds: 2));
+          }, (e, _) => uncaughtErrors.add(e));
+
+          final reconnectWarnings = logger.warnings
+              .where((w) => w.contains('Reconnecting'))
+              .toList();
+
+          expect(
+            reconnectWarnings.length,
+            greaterThanOrEqualTo(2),
+            reason:
+                'A connect() failure during a reconnect attempt must still '
+                'result in a second reconnect being scheduled. Before the '
+                'A5 fix, intentionalDisconnect stayed true for the whole '
+                'reconnect attempt (cleared only by a successful IDENTIFY, '
+                'which never arrives), so ShardNetworkError.dispatch(1006) '
+                'silently no-opped and the shard went dead after exactly '
+                'one log line.',
+          );
+          expect(
+            uncaughtErrors,
+            isEmpty,
+            reason:
+                'The connect failure must be fully handled, not leak '
+                'into the zone',
+          );
+
+          testShard.authentication.cancelHeartbeat();
+        },
+      );
+    });
+
+    group('A6 — resume() must not drop the version/encoding query params', () {
+      test(
+        'resume() rebuilds the bare resume_gateway_url with ?v= and '
+        'encoding= so shard.url keeps them for every later reconnect',
+        () async {
+          final orchestrator = _RealConnectOrchestrator(
+            logger: logger,
+            maxReconnectAttempts: 5,
+          );
+          final testShard = Shard(
+            shardName: 'test-shard-0',
+            shardIndex: 0,
+            shardCount: 1,
+            url: 'wss://fake',
+            wss: orchestrator,
+            logger: logger,
+            strategy: FakeRunningStrategy(),
+          )..client = FakeWebsocketClient();
+
+          testShard.authentication.setupRequirements({
+            'session_id': 'session-abc',
+            // Discord returns this WITHOUT a query string, unlike the
+            // initial /gateway/bot endpoint URL.
+            'resume_gateway_url': 'wss://resume-host-does-not-exist',
+          });
+
+          final uncaughtErrors = <Object>[];
+          await runZonedGuarded(() async {
+            unawaited(testShard.authentication.resume());
+            // Only needs to get past the first backoff delay to reach
+            // shard.init(), which sets shard.url synchronously before ever
+            // attempting to connect — the generous window also lets the
+            // subsequent (harmless) connect failure and follow-up
+            // reconnect play out without racing the assertions below.
+            await Future<void>.delayed(const Duration(seconds: 2));
+          }, (e, _) => uncaughtErrors.add(e));
+
+          expect(testShard.url, startsWith('wss://resume-host-does-not-exist'));
+          expect(
+            testShard.url,
+            contains('?v=10'),
+            reason:
+                'resume() must carry the version param forward, '
+                'exactly like the initial connection URL',
+          );
+          expect(
+            testShard.url,
+            contains('encoding=json'),
+            reason:
+                'resume() must carry the encoding param forward — '
+                'with encoding=etf this is what prevents Discord falling '
+                'back to JSON text frames that EtfEncoderStrategy cannot '
+                'decode',
+          );
+
+          testShard.authentication.cancelHeartbeat();
         },
       );
     });


### PR DESCRIPTION
Closes #460, #461, #462, #463. Wave 1 of #458. Stacked on #482 — merge that first.

## Why this is one PR and not four

The chantier's convention is one PR per sub-issue, and I deviated. Here is the reason, so you can overrule it.

Wave 0 (#482) deliberately turned the suite red: 15 failures pinning the defects these four cards fix. Those failures do not partition by card — the shared fixtures mean **no subset of wave 1 produces a green suite**. Four separate PRs would each carry red CI until the last one landed, and reviewing a red PR teaches you nothing about whether it works.

The history is preserved as **one commit per card**, so a squash-merge into the chantier still gives one clean commit, and each card's change is reviewable in isolation via its commit. If you would rather have four PRs with red CI on three of them, say so and I will split it.

Total diff: 10 source files, 7 test files. Reviewable in one sitting.

## Result

`dart analyze lib test` clean. Full suite **1608 passing, 0 failing** — up from 1584 before the chantier, with every wave-0 red now green.

## The four fixes

**#460 — `guild_id` injection (`e657ff3`).** Five callers forgot to inject `guild_id` before `normalize`, so `guild.roles.get/create/update` and `guild.emojis.fetch/get` threw on every call. The serializer's requirement is by design and stays; the parts were wrong. Also fixes two bugs in the emoji `roles` mapping that only became reachable once the `guild_id` crash stopped masking them.

**#461 — guild shape mismatch (`33b6129`).** Nine fields read flat that `normalize` nests. Notably the file already disagreed with itself — four settings reads and `discoverySplash` were already correct. This was a half-applied fix, which is why it survived review the first time.

**#462 — voice state and stickers (`1e791b4`).** `discoverable` does not exist on the wire; `format_type` 3 and 4 (LOTTIE, GIF) threw `StateError`; `available` and `guild_id` are optional and were hard-cast.

**#463 — invite cache key (`384c16a`).** Invites were written into the voice-state namespace. Two wire shapes now go through one path.

## Breaking changes

Both are semver-major on the public entity surface. Both are also unreachable-by-definition today, which is why I judged deletion honest rather than reckless — but they belong in the CHANGELOG.

- `VoiceState.isDiscoverable` **removed**. `serialize` threw on every voice state, so no consumer has ever held a `VoiceState`. There is no working code to break.
- `Invite.inviterId` and `Invite.createdAt` are now **nullable**. See below.

## The judgment call worth reviewing

The invite agent's first version kept the entity's contract intact by substituting sentinels: `Snowflake("0")` for a vanity invite's missing inviter, and the Unix epoch for a missing `createdAt`. I replaced both with nullability.

`Invite.resolveInviter()` does `_datastore.user.get(inviterId.value, false)`. A placeholder snowflake does not stay inert — it becomes a real `GET /users/0` against Discord, which 404s. The sentinel would have converted an honest absence into a wrong network call, and a fabricated timestamp shipped to bots as if it were real data.

This whole chantier exists because the framework shipped plausible-looking wrong values. Adding two more would have been the wrong trade, even at the cost of a breaking change.

## Deviations from the issue bodies

- **#460 does not make `guild_id` an explicit named parameter of `normalize`**, as the issue proposed. A named parameter cannot be *required* in a Dart override without breaking `SerializerContract`, so it would be optional and enforce nothing. The structural work belongs to #477.
- **#461 does not introduce the typed intermediate** the issue asked for, and the obstacle is worth recording: `guild_part.dart:15-17` and `guild_update_packet.dart:21-23` call `serialize()` directly on cache-fetched data, **bypassing `normalize()` entirely**. `serialize`'s real input contract is "whatever the cache returns" — a `Map<String, dynamic>` that has survived a deep structural copy. A record or class cannot round-trip that. This reframes #477: the problem is not the `normalize` -> `serialize` hand-off, it is that `serialize` has two callers with different contracts.
- **#462 does not route `StickerType` through `findInEnum`.** That needs `StickerType` to implement `EnhancedEnum` with an unknown sentinel, in a file outside the card's scope. A local `orElse` guard satisfies the must-not-throw requirement; full parity is a follow-up.
