### PR TITLE
fix: revive private buttons, give CommandBuilder an interface, cover the composition root

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -21,6 +21,17 @@ such.
   They duplicated the bit values of `createPublicThreads`/`createPrivateThreads`,
   which made every permission bitfield round-trip carry into the adjacent bit.
   Discord itself renamed these; the `create*` members are the current names.
+- **`CommandBuilder` now declares members.** It was an empty marker interface;
+  it now requires `name`, `context`, `toJson()`, `reduceHandlers()` and
+  `declaration`. Downstream code that implements it must supply them. This is
+  what removes five duplicated type-switches from the command manager and makes
+  a new builder type a compile-time concern rather than a runtime throw.
+- **`CommandDefinitionBuilder.context<T>()` renamed to `configure<T>()`.** It
+  collided with the interface's `context` getter. The renamed method had no
+  usages anywhere in the repository and no tests; the `context` getter is the
+  established convention across the other builders.
+- **`CommandDeclarationBuilder.reduceHandlers(String)` is now no-arg.** Every
+  call site passed the receiver's own `name`.
 - **`EnvPlaceholder()` no longer exposes anything without an explicit
   allowlist.** It previously copied the entire process environment — bot token
   included — into a public substitution table. Pass
@@ -42,6 +53,14 @@ such.
   `StateError` (`FormatType` declared only two of Discord's four values).
 - Emoji `roles` were read as objects; Discord sends bare snowflake strings, and
   the ids were mapped to the wrong cache-key namespace.
+- Button clicks in direct messages dispatched nothing at all — not the
+  component handler, not even `Event.privateButtonClick`. The private handler
+  matched `ButtonType` against the button's `custom_id` instead of its `type`,
+  so the lookup failed for every realistic id and the method returned early.
+  Behind that sat two further defects: the interactive component manager was
+  never called, and the author was read from `payload['member']`, which Discord
+  omits in a DM. All three are fixed together; fixing only the first would have
+  turned a silent no-op into a null-cast crash.
 
 ### Fixed — resilience
 
@@ -94,6 +113,15 @@ such.
 - `package:mineral/api.dart` no longer re-exports the whole of `env_guard`.
   Seventeen files' worth of generic names (`Schema`, `Rule`, `Property`,
   `Validator`, `Loader`, ...) are no longer part of mineral's public namespace.
+
+### Internal
+
+- `ClientBuilder.build()`'s wiring is extracted into a pure `composeApp`
+  function so the composition root can be tested. `build()` stays synchronous
+  and its behaviour is unchanged. Both hand-closed construction cycles and
+  `packetListener.init()` now have tests; deleting either line fails exactly one
+  of them. `composeApp` and `AppComposition` are hidden from the public barrel —
+  they exist for testability and expose internal types.
 
 ### Testing
 

--- a/packages/core/lib/api.dart
+++ b/packages/core/lib/api.dart
@@ -177,7 +177,13 @@ export 'package:mineral/src/api/private/channels/private_group_channel.dart';
 export 'package:mineral/src/api/private/user.dart';
 export 'package:mineral/src/api/private/user_assets.dart';
 export 'package:mineral/src/domains/client/client.dart';
-export 'package:mineral/src/domains/client/client_builder.dart';
+// `composeApp`/`AppComposition` are hidden deliberately. They exist to make the
+// composition root testable, not to be called by bots, and `AppComposition`
+// exposes `Kernel` and the concrete `PacketListener` — internal types no barrel
+// exports, so a consumer could hold the record but not name its members.
+// `ClientBuilder` remains the public entry point.
+export 'package:mineral/src/domains/client/client_builder.dart'
+    hide AppComposition, composeApp;
 export 'package:mineral/src/domains/commands/command_context.dart';
 export 'package:mineral/src/domains/commands/command_handler.dart';
 export 'package:mineral/src/domains/commands/command_options.dart';

--- a/packages/core/lib/src/api/common/commands/builder/command_declaration_builder.dart
+++ b/packages/core/lib/src/api/common/commands/builder/command_declaration_builder.dart
@@ -19,10 +19,12 @@ import 'package:mineral/src/infrastructure/io/exceptions/missing_property_except
 final class CommandDeclarationBuilder implements CommandBuilder {
   final CommandHelper _helper = CommandHelper();
 
+  @override
   String? name;
   Map<String, String>? _nameLocalizations;
   String? _description;
   Map<String, String>? _descriptionLocalizations;
+  @override
   CommandContextType context = CommandContextType.guild;
   List<ApplicationIntegrationType>? integrationTypes;
   List<InteractionContextType>? interactionContexts;
@@ -122,6 +124,7 @@ final class CommandDeclarationBuilder implements CommandBuilder {
     return this;
   }
 
+  @override
   Map<String, dynamic> toJson() {
     if (name == null) {
       throw MissingPropertyException('Command name is required');
@@ -152,7 +155,8 @@ final class CommandDeclarationBuilder implements CommandBuilder {
     };
   }
 
-  List<CommandRegistration> reduceHandlers(String commandName) {
+  @override
+  List<CommandRegistration> reduceHandlers() {
     if (subCommands.isEmpty && groups.isEmpty) {
       return [
         CommandRegistration(
@@ -168,7 +172,7 @@ final class CommandDeclarationBuilder implements CommandBuilder {
     for (final subCommand in subCommands) {
       if (subCommand.handle case null) {
         throw MissingMethodException(
-          'Command "$commandName.${subCommand.name}" has no handler',
+          'Command "$name.${subCommand.name}" has no handler',
         );
       }
 
@@ -195,4 +199,7 @@ final class CommandDeclarationBuilder implements CommandBuilder {
 
     return registrations;
   }
+
+  @override
+  CommandDeclarationBuilder? get declaration => this;
 }

--- a/packages/core/lib/src/api/common/commands/builder/command_definition_builder.dart
+++ b/packages/core/lib/src/api/common/commands/builder/command_definition_builder.dart
@@ -7,11 +7,13 @@ import 'package:mineral/src/api/common/commands/builder/command_declaration_buil
 import 'package:mineral/src/api/common/commands/builder/sub_command_builder.dart';
 import 'package:mineral/src/api/common/commands/builder/translation.dart';
 import 'package:mineral/src/api/common/commands/command_choice_option.dart';
+import 'package:mineral/src/api/common/commands/command_context_type.dart';
 import 'package:mineral/src/api/common/commands/command_option.dart';
 import 'package:mineral/src/api/common/lang.dart';
 import 'package:mineral/src/domains/commands/command_builder.dart';
 import 'package:mineral/src/domains/commands/command_context.dart';
 import 'package:mineral/src/domains/commands/command_handler.dart';
+import 'package:mineral/src/domains/commands/command_registration.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/invalid_command_exception.dart';
 import 'package:yaml/yaml.dart';
 
@@ -318,7 +320,13 @@ final class CommandDefinitionBuilder implements CommandBuilder {
     }
   }
 
-  void context<T>(String key, Function(T) fn) {
+  /// Looks up the builder declared under [key] (a root command, sub-command,
+  /// or group sub-command key from the loaded definition) and hands it to
+  /// [fn] for further, programmatic configuration.
+  ///
+  /// Named `configure` — not `context` — because [CommandBuilder] already
+  /// reserves `context` for [CommandContextType] (see #478).
+  void configure<T>(String key, Function(T) fn) {
     final command = _commandMapper.entries.firstWhere(
       (element) => element.key == key,
     );
@@ -359,4 +367,19 @@ final class CommandDefinitionBuilder implements CommandBuilder {
     _declareGroups(payload);
     _declareSubCommands(payload);
   }
+
+  @override
+  String? get name => command.name;
+
+  @override
+  CommandContextType get context => command.context;
+
+  @override
+  Map<String, dynamic> toJson() => command.toJson();
+
+  @override
+  List<CommandRegistration> reduceHandlers() => command.reduceHandlers();
+
+  @override
+  CommandDeclarationBuilder? get declaration => command;
 }

--- a/packages/core/lib/src/api/common/commands/builder/message_command_builder.dart
+++ b/packages/core/lib/src/api/common/commands/builder/message_command_builder.dart
@@ -1,4 +1,5 @@
 import 'package:mineral/src/api/common/commands/application_integration_type.dart';
+import 'package:mineral/src/api/common/commands/builder/command_declaration_builder.dart';
 import 'package:mineral/src/api/common/commands/builder/translation.dart';
 import 'package:mineral/src/api/common/commands/command_context_type.dart';
 import 'package:mineral/src/api/common/commands/command_helper.dart';
@@ -6,15 +7,19 @@ import 'package:mineral/src/api/common/commands/command_kind.dart';
 import 'package:mineral/src/api/common/commands/interaction_context_type.dart';
 import 'package:mineral/src/domains/commands/command_builder.dart';
 import 'package:mineral/src/domains/commands/command_handler.dart';
+import 'package:mineral/src/domains/commands/command_registration.dart';
 import 'package:mineral/src/domains/commands/contexts/message_command_context.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/command_name_exception.dart';
+import 'package:mineral/src/infrastructure/io/exceptions/invalid_command_exception.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/missing_property_exception.dart';
 
 final class MessageCommandBuilder implements CommandBuilder {
   final CommandHelper _helper = CommandHelper();
 
+  @override
   String? name;
   Map<String, String>? _nameLocalizations;
+  @override
   CommandContextType context = CommandContextType.guild;
   List<ApplicationIntegrationType>? integrationTypes;
   List<InteractionContextType>? interactionContexts;
@@ -60,6 +65,7 @@ final class MessageCommandBuilder implements CommandBuilder {
     return this;
   }
 
+  @override
   Map<String, dynamic> toJson() {
     if (name == null) {
       throw MissingPropertyException('Message command name is required');
@@ -75,4 +81,23 @@ final class MessageCommandBuilder implements CommandBuilder {
         'contexts': interactionContexts!.map((e) => e.value).toList(),
     };
   }
+
+  @override
+  List<CommandRegistration> reduceHandlers() {
+    final commandHandler = handle;
+    if (commandHandler == null) {
+      throw InvalidCommandException('Message command "$name" has no handler');
+    }
+
+    return [
+      CommandRegistration(
+        name: '$name',
+        handler: commandHandler,
+        declaredOptions: const [],
+      ),
+    ];
+  }
+
+  @override
+  CommandDeclarationBuilder? get declaration => null;
 }

--- a/packages/core/lib/src/api/common/commands/builder/user_command_builder.dart
+++ b/packages/core/lib/src/api/common/commands/builder/user_command_builder.dart
@@ -1,4 +1,5 @@
 import 'package:mineral/src/api/common/commands/application_integration_type.dart';
+import 'package:mineral/src/api/common/commands/builder/command_declaration_builder.dart';
 import 'package:mineral/src/api/common/commands/builder/translation.dart';
 import 'package:mineral/src/api/common/commands/command_context_type.dart';
 import 'package:mineral/src/api/common/commands/command_helper.dart';
@@ -6,15 +7,19 @@ import 'package:mineral/src/api/common/commands/command_kind.dart';
 import 'package:mineral/src/api/common/commands/interaction_context_type.dart';
 import 'package:mineral/src/domains/commands/command_builder.dart';
 import 'package:mineral/src/domains/commands/command_handler.dart';
+import 'package:mineral/src/domains/commands/command_registration.dart';
 import 'package:mineral/src/domains/commands/contexts/user_command_context.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/command_name_exception.dart';
+import 'package:mineral/src/infrastructure/io/exceptions/invalid_command_exception.dart';
 import 'package:mineral/src/infrastructure/io/exceptions/missing_property_exception.dart';
 
 final class UserCommandBuilder implements CommandBuilder {
   final CommandHelper _helper = CommandHelper();
 
+  @override
   String? name;
   Map<String, String>? _nameLocalizations;
+  @override
   CommandContextType context = CommandContextType.guild;
   List<ApplicationIntegrationType>? integrationTypes;
   List<InteractionContextType>? interactionContexts;
@@ -60,6 +65,7 @@ final class UserCommandBuilder implements CommandBuilder {
     return this;
   }
 
+  @override
   Map<String, dynamic> toJson() {
     if (name == null) {
       throw MissingPropertyException('User command name is required');
@@ -75,4 +81,23 @@ final class UserCommandBuilder implements CommandBuilder {
         'contexts': interactionContexts!.map((e) => e.value).toList(),
     };
   }
+
+  @override
+  List<CommandRegistration> reduceHandlers() {
+    final commandHandler = handle;
+    if (commandHandler == null) {
+      throw InvalidCommandException('User command "$name" has no handler');
+    }
+
+    return [
+      CommandRegistration(
+        name: '$name',
+        handler: commandHandler,
+        declaredOptions: const [],
+      ),
+    ];
+  }
+
+  @override
+  CommandDeclarationBuilder? get declaration => null;
 }

--- a/packages/core/lib/src/domains/client/client_builder.dart
+++ b/packages/core/lib/src/domains/client/client_builder.dart
@@ -13,6 +13,197 @@ import 'package:mineral/src/infrastructure/internals/packets/packet_listener.dar
 import 'package:mineral/src/infrastructure/internals/wss/sharding_config.dart';
 import 'package:mineral/src/infrastructure/internals/wss/websocket_orchestrator.dart';
 
+/// Composition output of [composeApp]: the application graph every
+/// downstream bot is built from. Mirrors the shape of [DataLayerComposition]
+/// in `marshaller.dart` — the fields most callers need direct access to are
+/// exposed individually even though most are also reachable through
+/// [appState], because [composeApp] is the only sanctioned place where the
+/// graph's two genuine construction cycles are closed:
+/// [WebsocketOrchestrator.onFatalDisconnect] <-> [Kernel], and
+/// [PacketListener.kernel] / [PacketListener.init] <-> [Kernel]. Outside this
+/// function the graph appears fully wired and immutable.
+typedef AppComposition = ({
+  Kernel kernel,
+  PacketListener packetListener,
+  WebsocketOrchestratorContract wss,
+  DataStoreContract dataStore,
+  MarshallerContract marshaller,
+  AppState appState,
+});
+
+/// Builds the full application graph — every module [ClientBuilder.build]
+/// constructs, wired together — from an explicitly-passed [env] instead of
+/// the process-global one. This is what makes the composition root testable:
+/// a test can call [composeApp] directly with an [Env] it controls and
+/// inspect the returned graph, without touching process globals.
+///
+/// [composeApp] never reads or writes the global `ioc` container; mirroring
+/// bindings into it for end-user DX is [ClientBuilder.build]'s job, once it
+/// has a finished [AppComposition] in hand.
+AppComposition composeApp({
+  required Env env,
+  LoggerContract? logger,
+  CacheProviderContract? cache,
+  CacheConfig? cacheConfig,
+  String? token,
+  int? intent,
+  int? discordRestHttpVersion,
+  int? discordWssVersion,
+  WebsocketEncoder wssEncoder = WebsocketEncoder.json,
+}) {
+  final resolvedCacheConfig = cacheConfig ?? CacheConfig.defaults();
+
+  final logLevel = env.get(AppEnv.logLevel);
+  final dartEnv = env.get<DartEnv>(AppEnv.dartEnv);
+
+  final resolvedLogger = logger ?? Logger(logLevel as LogLevel, dartEnv.value);
+
+  // Dedicated subsystem loggers so output is prefixed with a meaningful
+  // label (`[websocket]`, `[http]`, `[datastore]`, `[marshaller]`) instead
+  // of the default `[mineral]`. Only applies when the caller hasn't
+  // overridden the logger — custom loggers are used as-is to respect their
+  // own labelling conventions.
+  LoggerContract labelled(String label) =>
+      logger ?? Logger(logLevel as LogLevel, dartEnv.value, label: label);
+
+  final wssLogger = labelled('websocket');
+  final httpLogger = labelled('http');
+  final dataStoreLogger = labelled('datastore');
+  final marshallerLogger = labelled('marshaller');
+
+  final resolvedToken = env.get<String>(AppEnv.token, defaultValue: token);
+  final resolvedIntent = env.get<int>(AppEnv.intent, defaultValue: intent);
+
+  final httpVersion = env.get<int>(
+    AppEnv.discordRestHttpVersion,
+    defaultValue: discordRestHttpVersion,
+  );
+
+  final shardVersion = env.get<int>(
+    AppEnv.discordWssVersion,
+    defaultValue: discordWssVersion,
+  );
+
+  final wsEncodingStrategy = env.get(
+    AppEnv.discordWssEncoding,
+    defaultValue: wssEncoder,
+  );
+
+  final http = ResilientHttpClient(
+    HttpClient(
+      config: HttpClientConfigImpl(
+        uri: Uri.parse('https://discord.com/api/v$httpVersion'),
+        headers: {
+          Header.userAgent('Mineral'),
+          Header.contentType('application/json'),
+        },
+      ),
+    ),
+  );
+
+  final shardConfig = ShardingConfig(
+    token: resolvedToken,
+    intent: resolvedIntent,
+    version: shardVersion,
+    encoding: wsEncodingStrategy.strategy(logger: wssLogger),
+  );
+
+  final eventListener = EventListener();
+  final providerManager = ProviderManager(logger: resolvedLogger);
+  final globalStateManager = GlobalStateManager();
+  final interactiveComponent = InteractiveComponentManager(
+    logger: labelled('components'),
+  );
+  final wssOrchestrator = WebsocketOrchestrator(
+    shardConfig,
+    logger: wssLogger,
+    httpClient: http,
+  );
+
+  final runtimeState = RuntimeState();
+
+  final dataLayer = composeDataLayer(
+    marshallerLogger: marshallerLogger,
+    dataStoreLogger: dataStoreLogger,
+    httpLogger: httpLogger,
+    cache: cache,
+    httpClient: http,
+    wss: wssOrchestrator,
+    runtimeState: runtimeState,
+  );
+  final marshaller = dataLayer.marshaller;
+  final dataStore = dataLayer.dataStore;
+  final entityContext = dataLayer.entityContext;
+  final commandManager = CommandInteractionManager(
+    dataStore: dataStore,
+    marshaller: marshaller,
+    ctx: entityContext,
+  );
+
+  // PacketListener is constructed here — after all its dependencies are
+  // available but before Kernel, because Kernel takes PacketListener as a
+  // required argument. The only field that cannot be passed here is `kernel`
+  // itself (genuine cycle), which is wired via the setter below.
+  final packetListener = PacketListener(
+    marshaller: marshaller,
+    dataStore: dataStore,
+    interactiveComponent: interactiveComponent,
+    commandManager: commandManager,
+    entityContext: entityContext,
+    runtimeState: runtimeState,
+    cacheConfig: resolvedCacheConfig,
+  );
+
+  final kernel = Kernel(
+    logger: resolvedLogger,
+    httpClient: http,
+    packetListener: packetListener,
+    providerManager: providerManager,
+    eventListener: eventListener,
+    globalState: globalStateManager,
+    interactiveComponent: interactiveComponent,
+    wss: wssOrchestrator,
+    runtimeState: runtimeState,
+  );
+
+  // Close the cycle: the orchestrator was built before the kernel, so its
+  // fatal-disconnect hook is wired here once the kernel exists.
+  wssOrchestrator.onFatalDisconnect = kernel.dispose;
+
+  final appState = AppState(
+    logger: resolvedLogger,
+    httpClient: http,
+    cache: cache,
+    cacheConfig: resolvedCacheConfig,
+    marshaller: marshaller,
+    dataStore: dataStore,
+    wss: wssOrchestrator,
+    packetListener: packetListener,
+    eventListener: eventListener,
+    providerManager: providerManager,
+    globalState: globalStateManager,
+    interactiveComponent: interactiveComponent,
+    commandManager: commandManager,
+    kernel: kernel,
+  );
+
+  // Wire the one field that could not be passed at construction time (cycle).
+  packetListener
+    ..kernel = appState.kernel
+    ..init();
+
+  eventListener.kernel = appState.kernel;
+
+  return (
+    kernel: kernel,
+    packetListener: packetListener,
+    wss: wssOrchestrator,
+    dataStore: dataStore,
+    marshaller: marshaller,
+    appState: appState,
+  );
+}
+
 final class ClientBuilder {
   LoggerContract? _logger;
   CacheProviderContract? _cache;
@@ -87,145 +278,24 @@ final class ClientBuilder {
   Client build() {
     _validateEnvironment();
 
-    final logLevel = env.get(AppEnv.logLevel);
-    final dartEnv = env.get<DartEnv>(AppEnv.dartEnv);
-
-    final logger = _logger ?? Logger(logLevel as LogLevel, dartEnv.value);
-    ioc.bind<LoggerContract>(() => logger);
-
-    // Dedicated subsystem loggers so output is prefixed with a meaningful
-    // label (`[websocket]`, `[http]`, `[datastore]`, `[marshaller]`) instead
-    // of the default `[mineral]`. Only applies when the user hasn't
-    // overridden the logger via `setLogger` — custom loggers are used as-is
-    // to respect their own labelling conventions.
-    LoggerContract labelled(String label) =>
-        _logger ?? Logger(logLevel as LogLevel, dartEnv.value, label: label);
-
-    final wssLogger = labelled('websocket');
-    final httpLogger = labelled('http');
-    final dataStoreLogger = labelled('datastore');
-    final marshallerLogger = labelled('marshaller');
-
-    final token = env.get<String>(AppEnv.token, defaultValue: _token);
-    final intent = env.get<int>(AppEnv.intent, defaultValue: _intent);
-
-    final httpVersion = env.get<int>(
-      AppEnv.discordRestHttpVersion,
-      defaultValue: _discordRestHttpVersion,
-    );
-
-    final shardVersion = env.get<int>(
-      AppEnv.discordWssVersion,
-      defaultValue: _discordWssVersion,
-    );
-
-    final wsEncodingStrategy = env.get(
-      AppEnv.discordWssEncoding,
-      defaultValue: _wssEncoder,
-    );
-
-    final http = ResilientHttpClient(
-      HttpClient(
-        config: HttpClientConfigImpl(
-          uri: Uri.parse('https://discord.com/api/v$httpVersion'),
-          headers: {
-            Header.userAgent('Mineral'),
-            Header.contentType('application/json'),
-          },
-        ),
-      ),
-    );
-
-    final shardConfig = ShardingConfig(
-      token: token,
-      intent: intent,
-      version: shardVersion,
-      encoding: wsEncodingStrategy.strategy(logger: wssLogger),
-    );
-
-    final eventListener = EventListener();
-    final providerManager = ProviderManager(logger: logger);
-    final globalStateManager = GlobalStateManager();
-    final interactiveComponent = InteractiveComponentManager(
-      logger: labelled('components'),
-    );
-    final wssOrchestrator = WebsocketOrchestrator(
-      shardConfig,
-      logger: wssLogger,
-      httpClient: http,
-    );
-
-    final runtimeState = RuntimeState();
-
-    final dataLayer = composeDataLayer(
-      marshallerLogger: marshallerLogger,
-      dataStoreLogger: dataStoreLogger,
-      httpLogger: httpLogger,
-      cache: _cache,
-      httpClient: http,
-      wss: wssOrchestrator,
-      runtimeState: runtimeState,
-    );
-    final marshaller = dataLayer.marshaller;
-    final dataStore = dataLayer.dataStore;
-    final entityContext = dataLayer.entityContext;
-    final commandManager = CommandInteractionManager(
-      dataStore: dataStore,
-      marshaller: marshaller,
-      ctx: entityContext,
-    );
-
-    // PacketListener is constructed here — after all its dependencies are
-    // available but before Kernel, because Kernel takes PacketListener as a
-    // required argument. The only field that cannot be passed here is `kernel`
-    // itself (genuine cycle), which is wired via the setter below.
-    final packetListener = PacketListener(
-      marshaller: marshaller,
-      dataStore: dataStore,
-      interactiveComponent: interactiveComponent,
-      commandManager: commandManager,
-      entityContext: entityContext,
-      runtimeState: runtimeState,
-      cacheConfig: _cacheConfig,
-    );
-
-    final kernel = Kernel(
-      logger: logger,
-      httpClient: http,
-      packetListener: packetListener,
-      providerManager: providerManager,
-      eventListener: eventListener,
-      globalState: globalStateManager,
-      interactiveComponent: interactiveComponent,
-      wss: wssOrchestrator,
-      runtimeState: runtimeState,
-    );
-
-    // Close the cycle: the orchestrator was built before the kernel, so its
-    // fatal-disconnect hook is wired here once the kernel exists.
-    wssOrchestrator.onFatalDisconnect = kernel.dispose;
-
-    final appState = AppState(
-      logger: logger,
-      httpClient: http,
+    final composition = composeApp(
+      env: env,
+      logger: _logger,
       cache: _cache,
       cacheConfig: _cacheConfig,
-      marshaller: marshaller,
-      dataStore: dataStore,
-      wss: wssOrchestrator,
-      packetListener: packetListener,
-      eventListener: eventListener,
-      providerManager: providerManager,
-      globalState: globalStateManager,
-      interactiveComponent: interactiveComponent,
-      commandManager: commandManager,
-      kernel: kernel,
+      token: _token,
+      intent: _intent,
+      discordRestHttpVersion: _discordRestHttpVersion,
+      discordWssVersion: _discordWssVersion,
+      wssEncoder: _wssEncoder,
     );
+    final appState = composition.appState;
 
     // Mirror AppState into the IoC for end-user DX. The core itself never
     // reads from these bindings; they exist so user handlers/commands/
     // providers can keep using `container.resolve<T>()`.
     ioc
+      ..bind<LoggerContract>(() => appState.logger)
       ..bind<HttpClientContract>(() => appState.httpClient)
       ..bind<Kernel>(() => appState.kernel)
       ..bind<MarshallerContract>(() => appState.marshaller)
@@ -237,7 +307,7 @@ final class ClientBuilder {
       )
       ..bindLazy<Bot>(
         () =>
-            runtimeState.bot ??
+            appState.kernel.runtimeState.bot ??
             (throw StateError(
               'Bot is not yet available — wait for the gateway READY event before resolving Bot from the container.',
             )),
@@ -252,13 +322,6 @@ final class ClientBuilder {
       ..require<InteractiveComponentManagerContract>()
       ..validateBindings();
 
-    // Wire the one field that could not be passed at construction time (cycle).
-    packetListener
-      ..kernel = appState.kernel
-      ..init();
-
-    eventListener.kernel = appState.kernel;
-
     final client = Client(
       appState.kernel,
       rest: appState.dataStore,
@@ -267,7 +330,7 @@ final class ClientBuilder {
     );
 
     for (final provider in _providers) {
-      providerManager.register(provider(client));
+      appState.providerManager.register(provider(client));
     }
 
     return client;

--- a/packages/core/lib/src/domains/commands/command_builder.dart
+++ b/packages/core/lib/src/domains/commands/command_builder.dart
@@ -1,1 +1,31 @@
-abstract interface class CommandBuilder {}
+import 'package:mineral/src/api/common/commands/builder/command_declaration_builder.dart';
+import 'package:mineral/src/api/common/commands/command_context_type.dart';
+import 'package:mineral/src/domains/commands/command_registration.dart';
+
+/// The shared shape every command builder must expose so
+/// [CommandInteractionManagerContract.addCommand] and command registration
+/// can operate on any implementer without an exhaustive type switch.
+///
+/// Implement this interface — and nothing else — to add a new command
+/// builder type; no other part of the framework needs to learn about it.
+abstract interface class CommandBuilder {
+  /// The command's name, or `null` until it has been set.
+  String? get name;
+
+  /// Whether the command is registered globally or scoped to a single guild.
+  CommandContextType get context;
+
+  /// The Discord API payload for this command.
+  Map<String, dynamic> toJson();
+
+  /// The handler registrations (root command and/or dotted sub-command
+  /// paths) this builder produces.
+  List<CommandRegistration> reduceHandlers();
+
+  /// The declarative option tree backing this command, used to discover
+  /// autocomplete handlers.
+  ///
+  /// `null` for builders with no option tree to walk (user and message
+  /// commands).
+  CommandDeclarationBuilder? get declaration;
+}

--- a/packages/core/lib/src/domains/commands/command_interaction_manager.dart
+++ b/packages/core/lib/src/domains/commands/command_interaction_manager.dart
@@ -2,10 +2,6 @@ import 'dart:async';
 
 import 'package:mineral/contracts.dart';
 import 'package:mineral/src/api/common/bot/bot.dart';
-import 'package:mineral/src/api/common/commands/builder/command_declaration_builder.dart';
-import 'package:mineral/src/api/common/commands/builder/command_definition_builder.dart';
-import 'package:mineral/src/api/common/commands/builder/message_command_builder.dart';
-import 'package:mineral/src/api/common/commands/builder/user_command_builder.dart';
 import 'package:mineral/src/api/common/commands/command_context_type.dart';
 import 'package:mineral/src/api/common/commands/command_option.dart';
 import 'package:mineral/src/api/common/snowflake.dart';
@@ -84,50 +80,13 @@ final class CommandInteractionManager
       throw InvalidCommandException('Command $command already exists');
     }
 
-    final name = switch (command) {
-      final CommandDeclarationBuilder command => command.name,
-      final CommandDefinitionBuilder definition => definition.command.name,
-      final UserCommandBuilder b => b.name,
-      final MessageCommandBuilder b => b.name,
-      final _ => throw InvalidCommandException('Unknown command type'),
-    };
+    final name = command.name;
 
     if (name == null) {
       throw MissingPropertyException('Command name is required');
     }
 
-    final handlers = switch (command) {
-      final CommandDeclarationBuilder command => command.reduceHandlers(
-        command.name!,
-      ),
-      final CommandDefinitionBuilder definition =>
-        definition.command.reduceHandlers(definition.command.name!),
-      final UserCommandBuilder b => [
-        if (b.handle != null)
-          CommandRegistration(
-            name: b.name!,
-            handler: b.handle!,
-            declaredOptions: const [],
-          )
-        else
-          throw InvalidCommandException(
-            'User command "${b.name}" has no handler',
-          ),
-      ],
-      final MessageCommandBuilder b => [
-        if (b.handle != null)
-          CommandRegistration(
-            name: b.name!,
-            handler: b.handle!,
-            declaredOptions: const [],
-          )
-        else
-          throw InvalidCommandException(
-            'Message command "${b.name}" has no handler',
-          ),
-      ],
-      final _ => throw InvalidCommandException('Unknown command type'),
-    };
+    final handlers = command.reduceHandlers();
 
     commands.add(command);
     commandsHandler.addAll(handlers);
@@ -138,11 +97,7 @@ final class CommandInteractionManager
 
   /// Walks the command's option tree and registers any [AutocompleteHandler]s.
   void _registerAutocompleteHandlers(String rootName, CommandBuilder command) {
-    final declaration = switch (command) {
-      final CommandDeclarationBuilder b => b,
-      final CommandDefinitionBuilder d => d.command,
-      _ => null,
-    };
+    final declaration = command.declaration;
 
     if (declaration == null) {
       return;
@@ -343,7 +298,8 @@ final class CommandInteractionManager
     Response response, {
     required String scope,
   }) {
-    final detail = _extractValidationDetail(response.body) ?? response.bodyString;
+    final detail =
+        _extractValidationDetail(response.body) ?? response.bodyString;
 
     return InvalidCommandException(
       'Command registration failed for $scope '
@@ -385,29 +341,10 @@ final class CommandInteractionManager
   }
 
   List<CommandBuilder> _getContext(CommandContextType contextType) {
-    return commands.where((command) {
-      final context = switch (command) {
-        final CommandDeclarationBuilder command => command.context,
-        final CommandDefinitionBuilder definition => definition.command.context,
-        final UserCommandBuilder b => b.context,
-        final MessageCommandBuilder b => b.context,
-        final _ => throw InvalidCommandException('Unknown command type'),
-      };
-
-      return context == contextType;
-    }).toList();
+    return commands.where((command) => command.context == contextType).toList();
   }
 
   List<Map<String, dynamic>> _serializeCommand(List<CommandBuilder> commands) {
-    return commands.map((command) {
-      return switch (command) {
-        final CommandDeclarationBuilder command => command.toJson(),
-        final CommandDefinitionBuilder definition =>
-          definition.command.toJson(),
-        final UserCommandBuilder b => b.toJson(),
-        final MessageCommandBuilder b => b.toJson(),
-        final _ => throw InvalidCommandException('Unknown command type'),
-      };
-    }).toList();
+    return commands.map((command) => command.toJson()).toList();
   }
 }

--- a/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart
+++ b/packages/core/lib/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart
@@ -3,6 +3,7 @@ import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
 import 'package:mineral/events.dart';
 import 'package:mineral/src/domains/common/entity_context.dart';
+import 'package:mineral/src/domains/components/buttons/button_context_base.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listenable_packet.dart';
 import 'package:mineral/src/infrastructure/internals/packets/packet_type.dart';
 import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
@@ -64,19 +65,8 @@ final class ButtonInteractionCreatePacket implements ListenablePacket {
     Map<String, dynamic> payload,
     DispatchEvent dispatch,
   ) async {
-    final metadata = payload['message']['interaction_metadata'];
-    final targetButton = findButtonByCustomId(
-      payload,
-      (payload['data'] as Map<String, dynamic>)['custom_id'] as String,
-    );
-    final type = ButtonType.values.firstWhereOrNull(
-      (e) => e.value == targetButton?['type'],
-    );
-
+    final type = _resolveButtonType(payload);
     if (type == null) {
-      _logger.warn(
-        'Button type ${(metadata as Map<String, dynamic>)['type']} not found',
-      );
       return;
     }
 
@@ -96,32 +86,19 @@ final class ButtonInteractionCreatePacket implements ListenablePacket {
       ),
     );
 
-    dispatch<GuildButtonClickArgs>(
+    await _dispatchButtonClick(
+      ctx: ctx,
       event: Event.guildButtonClick,
-      payload: (ctx: ctx),
-      constraint: (String? customId) => customId == ctx.customId,
+      dispatch: dispatch,
     );
-
-    await _interactiveComponentManager.dispatch(ctx.customId, [ctx]);
   }
 
   Future<void> _handlePrivateButton(
     Map<String, dynamic> payload,
     DispatchEvent dispatch,
   ) async {
-    final metadata = payload['message']['interaction_metadata'];
-    final targetButton = findButtonByCustomId(
-      payload,
-      (payload['data'] as Map<String, dynamic>)['custom_id'] as String,
-    );
-    final type = ButtonType.values.firstWhereOrNull(
-      (e) => e.value == targetButton?['custom_id'],
-    );
-
+    final type = _resolveButtonType(payload);
     if (type == null) {
-      _logger.warn(
-        'Button type ${(metadata as Map<String, dynamic>)['type']} not found',
-      );
       return;
     }
 
@@ -134,8 +111,7 @@ final class ButtonInteractionCreatePacket implements ListenablePacket {
       customId:
           (payload['data'] as Map<String, dynamic>)['custom_id'] as String,
       authorId: Snowflake.parse(
-        ((payload['member'] as Map<String, dynamic>)['user']
-            as Map<String, dynamic>)['id'],
+        (payload['user'] as Map<String, dynamic>)['id'],
       ),
       channelId: Snowflake.parse(payload['channel_id']),
       messageId: Snowflake.parse(
@@ -143,11 +119,50 @@ final class ButtonInteractionCreatePacket implements ListenablePacket {
       ),
     );
 
-    dispatch<PrivateButtonClickArgs>(
+    await _dispatchButtonClick(
+      ctx: ctx,
       event: Event.privateButtonClick,
+      dispatch: dispatch,
+    );
+  }
+
+  /// Resolves the [ButtonType] of the button that was clicked, or logs a
+  /// warning and returns null if it cannot be found. Shared by the guild and
+  /// private paths so the lookup can only drift in one place.
+  ButtonType? _resolveButtonType(Map<String, dynamic> payload) {
+    final metadata = payload['message']['interaction_metadata'];
+    final targetButton = findButtonByCustomId(
+      payload,
+      (payload['data'] as Map<String, dynamic>)['custom_id'] as String,
+    );
+    final type = ButtonType.values.firstWhereOrNull(
+      (e) => e.value == targetButton?['type'],
+    );
+
+    if (type == null) {
+      _logger.warn(
+        'Button type ${(metadata as Map<String, dynamic>)['type']} not found',
+      );
+    }
+    return type;
+  }
+
+  /// Dispatches the click [event] and notifies any registered
+  /// [InteractiveButton] for [ctx]. Shared by the guild and private paths so
+  /// a fix to one can no longer land without the other — this is exactly how
+  /// the private path shipped without the component-manager dispatch call.
+  Future<void> _dispatchButtonClick<TCtx extends ButtonContextBase>({
+    required TCtx ctx,
+    required Event event,
+    required DispatchEvent dispatch,
+  }) async {
+    dispatch<({TCtx ctx})>(
+      event: event,
       payload: (ctx: ctx),
       constraint: (String? customId) => customId == ctx.customId,
     );
+
+    await _interactiveComponentManager.dispatch(ctx.customId, [ctx]);
   }
 
   Map<String, dynamic>? findButtonByCustomId(

--- a/packages/core/test/commands/command_autocomplete_handler_test.dart
+++ b/packages/core/test/commands/command_autocomplete_handler_test.dart
@@ -205,6 +205,78 @@ void main() {
         expect(result.choices[0].name, 'Alpha');
         expect(result.choices[1].name, 'Beta');
       });
+
+      test(
+        'registers autocomplete handler for a CommandDefinitionBuilder '
+        '(forwards through .declaration to its inner command, #478)',
+        () async {
+          String? capturedValue;
+
+          final definition = CommandDefinitionBuilder();
+          definition.command
+            ..setName('lookup')
+            ..setDescription('Look something up')
+            ..addOption(
+              Option.string(
+                name: 'query',
+                description: 'The search query',
+                autocomplete: true,
+                onAutocomplete: (ctx) {
+                  capturedValue = ctx.value;
+                  return [Choice('Result', 'result')];
+                },
+              ),
+            )
+            ..setHandle((ctx, opts) {});
+
+          manager.addCommand(definition);
+
+          await manager.handleAutocomplete({
+            'id': '888888888888888888',
+            'token': 'test-token',
+            'data': {
+              'name': 'lookup',
+              'options': [
+                {'name': 'query', 'type': 3, 'value': 'hello', 'focused': true},
+              ],
+            },
+          });
+
+          expect(capturedValue, 'hello');
+          expect(fakePart.autocompleteResults, hasLength(1));
+        },
+      );
+
+      test('does not register autocomplete handlers for a UserCommandBuilder '
+          '(declaration is null, #478)', () async {
+        final command = UserCommandBuilder()
+          ..setName('Get user info')
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        await manager.handleAutocomplete({
+          'id': '999999999999999999',
+          'token': 'tok',
+          'data': {
+            'name': 'Get user info',
+            'options': [
+              {'name': 'q', 'type': 3, 'value': 'x', 'focused': true},
+            ],
+          },
+        });
+
+        expect(fakePart.autocompleteResults, isEmpty);
+        expect(
+          logger.warnings,
+          contains(
+            contains(
+              'No autocomplete handler for command "Get user info" '
+              'option "q"',
+            ),
+          ),
+        );
+      });
     });
 
     // ── Context correctness ─────────────────────────────────────────────────

--- a/packages/core/test/commands/command_declaration_builder_test.dart
+++ b/packages/core/test/commands/command_declaration_builder_test.dart
@@ -301,7 +301,7 @@ void main() {
           ..setDescription('Pong!')
           ..setHandle(handler);
 
-        final registrations = builder.reduceHandlers('ping');
+        final registrations = builder.reduceHandlers();
 
         expect(registrations, hasLength(1));
         expect(registrations.first.name, 'ping');
@@ -331,7 +331,7 @@ void main() {
               ..setHandle(kickHandler);
           });
 
-        final registrations = builder.reduceHandlers('mod');
+        final registrations = builder.reduceHandlers();
 
         expect(registrations, hasLength(2));
         expect(registrations[0].name, 'mod.ban');
@@ -358,7 +358,7 @@ void main() {
               });
           });
 
-        final registrations = builder.reduceHandlers('admin');
+        final registrations = builder.reduceHandlers();
 
         expect(registrations, hasLength(1));
         expect(registrations.first.name, 'admin.user.ban');
@@ -375,7 +375,7 @@ void main() {
           ..addOption(Option.string(name: 'reason', description: 'Reason'))
           ..setHandle((ctx, options) {});
 
-        final registrations = builder.reduceHandlers('ban');
+        final registrations = builder.reduceHandlers();
 
         expect(registrations.first.declaredOptions, hasLength(2));
         expect(registrations.first.declaredOptions[0].name, 'target');
@@ -394,10 +394,7 @@ void main() {
               ..setDescription('Ban');
           });
 
-        expect(
-          () => builder.reduceHandlers('mod'),
-          throwsA(isA<MissingMethodException>()),
-        );
+        expect(builder.reduceHandlers, throwsA(isA<MissingMethodException>()));
       });
     });
   });

--- a/packages/core/test/commands/command_interaction_manager_test.dart
+++ b/packages/core/test/commands/command_interaction_manager_test.dart
@@ -180,11 +180,9 @@ void main() {
           'registerGlobal throws on $status instead of completing silently',
           () async {
             final bucket = _RecordingRequestBucket()
-              ..failWith = FakeResponse<dynamic>(
-                status,
-                {'message': 'boom'},
-                bodyString: '{"message":"boom"}',
-              );
+              ..failWith = FakeResponse<dynamic>(status, {
+                'message': 'boom',
+              }, bodyString: '{"message":"boom"}');
             final dataStore = _RoutingDataStore(bucket);
             final marshaller = FakeMarshaller(dataStore: dataStore);
             final manager = _buildManager(
@@ -205,37 +203,32 @@ void main() {
           },
         );
 
-        test(
-          'registerServer throws on $status and names the guild instead of '
-          'completing silently',
-          () async {
-            final bucket = _RecordingRequestBucket()
-              ..failWith = FakeResponse<dynamic>(
-                status,
-                {'message': 'boom'},
-                bodyString: '{"message":"boom"}',
-              );
-            final dataStore = _RoutingDataStore(bucket);
-            final marshaller = FakeMarshaller(dataStore: dataStore);
-            final manager = _buildManager(
-              dataStore: dataStore,
-              marshaller: marshaller,
-            );
+        test('registerServer throws on $status and names the guild instead of '
+            'completing silently', () async {
+          final bucket = _RecordingRequestBucket()
+            ..failWith = FakeResponse<dynamic>(status, {
+              'message': 'boom',
+            }, bodyString: '{"message":"boom"}');
+          final dataStore = _RoutingDataStore(bucket);
+          final marshaller = FakeMarshaller(dataStore: dataStore);
+          final manager = _buildManager(
+            dataStore: dataStore,
+            marshaller: marshaller,
+          );
 
-            await expectLater(
-              () => manager.registerServer(bot, guild),
-              throwsA(
-                isA<InvalidCommandException>()
-                    .having((e) => e.message, 'message', contains('$status'))
-                    .having(
-                      (e) => e.message,
-                      'message',
-                      contains(guild.id.value),
-                    ),
-              ),
-            );
-          },
-        );
+          await expectLater(
+            () => manager.registerServer(bot, guild),
+            throwsA(
+              isA<InvalidCommandException>()
+                  .having((e) => e.message, 'message', contains('$status'))
+                  .having(
+                    (e) => e.message,
+                    'message',
+                    contains(guild.id.value),
+                  ),
+            ),
+          );
+        });
       }
     });
 
@@ -306,30 +299,26 @@ void main() {
     });
 
     group('end-to-end through the real RequestBucket', () {
-      test(
-        'registerGlobal throws on a 403 (missing applications.commands '
-        'scope)',
-        () async {
-          final http = FakeHttpClient([
-            FakeResponse<dynamic>(
-              403,
-              {'message': 'Missing Access', 'code': 50001},
-              bodyString: '{"message":"Missing Access","code":50001}',
-            ),
-          ]);
-          final dataStore = FakeDataStore(http);
-          final marshaller = FakeMarshaller(dataStore: dataStore);
-          final manager = _buildManager(
-            dataStore: dataStore,
-            marshaller: marshaller,
-          );
+      test('registerGlobal throws on a 403 (missing applications.commands '
+          'scope)', () async {
+        final http = FakeHttpClient([
+          FakeResponse<dynamic>(403, {
+            'message': 'Missing Access',
+            'code': 50001,
+          }, bodyString: '{"message":"Missing Access","code":50001}'),
+        ]);
+        final dataStore = FakeDataStore(http);
+        final marshaller = FakeMarshaller(dataStore: dataStore);
+        final manager = _buildManager(
+          dataStore: dataStore,
+          marshaller: marshaller,
+        );
 
-          await expectLater(
-            () => manager.registerGlobal(bot),
-            throwsA(isA<InvalidCommandException>()),
-          );
-        },
-      );
+        await expectLater(
+          () => manager.registerGlobal(bot),
+          throwsA(isA<InvalidCommandException>()),
+        );
+      });
 
       test('registerServer throws on a 500 and names the guild', () async {
         final http = FakeHttpClient([
@@ -366,6 +355,211 @@ void main() {
         );
 
         await manager.registerGlobal(bot);
+      });
+    });
+  });
+
+  // ── #478: CommandBuilder interface unification ───────────────────────────
+  //
+  // command_interaction_manager.dart used to re-derive name/context/toJson/
+  // handlers by exhaustive type-switching on CommandBuilder. Those switches
+  // are gone; these tests exercise every implementer (CommandDeclarationBuilder,
+  // CommandDefinitionBuilder, UserCommandBuilder, MessageCommandBuilder)
+  // through the manager to prove the polymorphic dispatch is equivalent —
+  // previously only CommandDeclarationBuilder ever reached addCommand/
+  // registerGlobal/registerServer in this suite.
+  group('CommandBuilder interface unification (#478)', () {
+    late Bot bot;
+    late Guild guild;
+
+    setUp(() {
+      bot = _buildBot();
+      guild = buildMinimalGuild('222222222222222222', fakeEntityContext());
+    });
+
+    CommandInteractionManager buildManager() {
+      final dataStore = _RoutingDataStore(_RecordingRequestBucket());
+      final marshaller = FakeMarshaller(dataStore: dataStore);
+      return _buildManager(dataStore: dataStore, marshaller: marshaller);
+    }
+
+    group('addCommand derives name and handlers for every builder type', () {
+      test('CommandDeclarationBuilder', () {
+        final manager = buildManager();
+        final command = CommandDeclarationBuilder()
+          ..setName('ping')
+          ..setDescription('Pong!')
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        expect(manager.commands, contains(command));
+        expect(manager.commandsHandler.map((r) => r.name), contains('ping'));
+      });
+
+      test('CommandDefinitionBuilder forwards to its inner command', () {
+        final manager = buildManager();
+        final definition = CommandDefinitionBuilder();
+        definition.command
+          ..setName('defined')
+          ..setDescription('A definition-driven command')
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(definition);
+
+        expect(manager.commands, contains(definition));
+        expect(manager.commandsHandler.map((r) => r.name), contains('defined'));
+      });
+
+      test('UserCommandBuilder', () {
+        final manager = buildManager();
+        final command = UserCommandBuilder()
+          ..setName('Get user info')
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        expect(manager.commands, contains(command));
+        expect(
+          manager.commandsHandler.map((r) => r.name),
+          contains('Get user info'),
+        );
+      });
+
+      test('MessageCommandBuilder', () {
+        final manager = buildManager();
+        final command = MessageCommandBuilder()
+          ..setName('Report message')
+          ..setHandle((ctx, opts) {});
+
+        manager.addCommand(command);
+
+        expect(manager.commands, contains(command));
+        expect(
+          manager.commandsHandler.map((r) => r.name),
+          contains('Report message'),
+        );
+      });
+
+      test(
+        'UserCommandBuilder without a handler throws InvalidCommandException',
+        () {
+          final manager = buildManager();
+          final command = UserCommandBuilder()..setName('No handler');
+
+          expect(
+            () => manager.addCommand(command),
+            throwsA(isA<InvalidCommandException>()),
+          );
+        },
+      );
+    });
+
+    group('registerGlobal/registerServer filter by context and serialize every '
+        'builder type', () {
+      test('registerGlobal sends only global-context commands, correctly '
+          'serialized per type', () async {
+        final bucket = _RecordingRequestBucket();
+        final dataStore = _RoutingDataStore(bucket);
+        final marshaller = FakeMarshaller(dataStore: dataStore);
+        final manager = _buildManager(
+          dataStore: dataStore,
+          marshaller: marshaller,
+        );
+
+        final globalDeclaration = CommandDeclarationBuilder()
+          ..setName('global-chat')
+          ..setDescription('desc')
+          ..setContext(CommandContextType.global)
+          ..setHandle((ctx, opts) {});
+        final guildDeclaration = CommandDeclarationBuilder()
+          ..setName('guild-chat')
+          ..setDescription('desc')
+          ..setHandle((ctx, opts) {});
+        final globalUser = UserCommandBuilder()
+          ..setName('Global User')
+          ..setContext(CommandContextType.global)
+          ..setHandle((ctx, opts) {});
+        final guildMessage = MessageCommandBuilder()
+          ..setName('Guild Message')
+          ..setHandle((ctx, opts) {});
+        final globalDefinition = CommandDefinitionBuilder();
+        globalDefinition.command
+          ..setName('global-defined')
+          ..setDescription('desc')
+          ..setContext(CommandContextType.global)
+          ..setHandle((ctx, opts) {});
+
+        for (final command in [
+          globalDeclaration,
+          guildDeclaration,
+          globalUser,
+          guildMessage,
+          globalDefinition,
+        ]) {
+          manager.addCommand(command);
+        }
+
+        await manager.registerGlobal(bot);
+
+        final payload = bucket.lastRequest!.body as List<dynamic>;
+        final names = payload
+            .map((e) => (e as Map<String, dynamic>)['name'])
+            .toSet();
+
+        expect(names, equals({'global-chat', 'Global User', 'global-defined'}));
+      });
+
+      test('registerServer sends only guild-context commands, correctly '
+          'serialized per type', () async {
+        final bucket = _RecordingRequestBucket();
+        final dataStore = _RoutingDataStore(bucket);
+        final marshaller = FakeMarshaller(dataStore: dataStore);
+        final manager = _buildManager(
+          dataStore: dataStore,
+          marshaller: marshaller,
+        );
+
+        final globalDeclaration = CommandDeclarationBuilder()
+          ..setName('global-chat')
+          ..setDescription('desc')
+          ..setContext(CommandContextType.global)
+          ..setHandle((ctx, opts) {});
+        final guildDeclaration = CommandDeclarationBuilder()
+          ..setName('guild-chat')
+          ..setDescription('desc')
+          ..setHandle((ctx, opts) {});
+        final globalUser = UserCommandBuilder()
+          ..setName('Global User')
+          ..setContext(CommandContextType.global)
+          ..setHandle((ctx, opts) {});
+        final guildMessage = MessageCommandBuilder()
+          ..setName('Guild Message')
+          ..setHandle((ctx, opts) {});
+        final guildDefinition = CommandDefinitionBuilder();
+        guildDefinition.command
+          ..setName('guild-defined')
+          ..setDescription('desc')
+          ..setHandle((ctx, opts) {});
+
+        for (final command in [
+          globalDeclaration,
+          guildDeclaration,
+          globalUser,
+          guildMessage,
+          guildDefinition,
+        ]) {
+          manager.addCommand(command);
+        }
+
+        await manager.registerServer(bot, guild);
+
+        final payload = bucket.lastRequest!.body as List<dynamic>;
+        final names = payload
+            .map((e) => (e as Map<String, dynamic>)['name'])
+            .toSet();
+
+        expect(names, equals({'guild-chat', 'Guild Message', 'guild-defined'}));
       });
     });
   });

--- a/packages/core/test/commands/message_command_builder_test.dart
+++ b/packages/core/test/commands/message_command_builder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:mineral/api.dart';
 import 'package:test/test.dart';
 
@@ -48,6 +50,48 @@ void main() {
       final builder = MessageCommandBuilder()
         ..setContext(CommandContextType.global);
       expect(builder.context, equals(CommandContextType.global));
+    });
+
+    group('reduceHandlers', () {
+      test('returns a single registration for the command name', () {
+        FutureOr<void> handler(
+          MessageCommandContext ctx,
+          CommandOptions options,
+        ) {}
+        final builder = MessageCommandBuilder()
+          ..setName('Report message')
+          ..setHandle(handler);
+
+        final registrations = builder.reduceHandlers();
+
+        expect(registrations, hasLength(1));
+        expect(registrations.first.name, 'Report message');
+        expect(registrations.first.handler, handler);
+        expect(registrations.first.declaredOptions, isEmpty);
+      });
+
+      test('throws InvalidCommandException naming the command when no '
+          'handler is set', () {
+        final builder = MessageCommandBuilder()..setName('Report message');
+
+        expect(
+          builder.reduceHandlers,
+          throwsA(
+            isA<InvalidCommandException>().having(
+              (e) => e.message,
+              'message',
+              contains('Report message'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('declaration', () {
+      test('is null (message commands have no option tree)', () {
+        final builder = MessageCommandBuilder()..setName('Report message');
+        expect(builder.declaration, isNull);
+      });
     });
   });
 }

--- a/packages/core/test/commands/user_command_builder_test.dart
+++ b/packages/core/test/commands/user_command_builder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:mineral/api.dart';
 import 'package:test/test.dart';
 
@@ -48,6 +50,48 @@ void main() {
       final builder = UserCommandBuilder()
         ..setContext(CommandContextType.global);
       expect(builder.context, equals(CommandContextType.global));
+    });
+
+    group('reduceHandlers', () {
+      test('returns a single registration for the command name', () {
+        FutureOr<void> handler(
+          UserCommandContext ctx,
+          CommandOptions options,
+        ) {}
+        final builder = UserCommandBuilder()
+          ..setName('Get user info')
+          ..setHandle(handler);
+
+        final registrations = builder.reduceHandlers();
+
+        expect(registrations, hasLength(1));
+        expect(registrations.first.name, 'Get user info');
+        expect(registrations.first.handler, handler);
+        expect(registrations.first.declaredOptions, isEmpty);
+      });
+
+      test('throws InvalidCommandException naming the command when no '
+          'handler is set', () {
+        final builder = UserCommandBuilder()..setName('Get user info');
+
+        expect(
+          builder.reduceHandlers,
+          throwsA(
+            isA<InvalidCommandException>().having(
+              (e) => e.message,
+              'message',
+              contains('Get user info'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('declaration', () {
+      test('is null (user commands have no option tree)', () {
+        final builder = UserCommandBuilder()..setName('Get user info');
+        expect(builder.declaration, isNull);
+      });
     });
   });
 }

--- a/packages/core/test/packets/button_interaction_create_packet_test.dart
+++ b/packages/core/test/packets/button_interaction_create_packet_test.dart
@@ -1,5 +1,9 @@
+import 'package:mineral/api.dart';
 import 'package:mineral/contracts.dart';
+import 'package:mineral/events.dart';
+import 'package:mineral/src/domains/services/wss/constants/op_code.dart';
 import 'package:mineral/src/infrastructure/internals/packets/listeners/interactions/button_interaction_create_packet.dart';
+import 'package:mineral/src/infrastructure/internals/wss/shard_message.dart';
 import 'package:mineral/src/testing/fake_logger.dart';
 import 'package:test/test.dart';
 
@@ -23,6 +27,80 @@ final class _NoopInteractiveComponent
   T get<T extends InteractiveComponent>(String customId) =>
       throw UnimplementedError();
 }
+
+/// Records every [dispatch] call so tests can assert an
+/// [InteractiveButton] would actually have fired.
+final class _RecordingInteractiveComponent
+    implements InteractiveComponentManagerContract {
+  final List<({String customId, List params})> calls = [];
+
+  @override
+  void Function(
+    InteractiveComponent component,
+    Object error,
+    StackTrace stackTrace,
+  )?
+  onComponentError;
+
+  @override
+  void register(InteractiveComponent component) {}
+  @override
+  Future<void> dispatch(String customId, List params) async {
+    calls.add((customId: customId, params: params));
+  }
+
+  @override
+  T get<T extends InteractiveComponent>(String customId) =>
+      throw UnimplementedError();
+}
+
+/// A realistic DM MESSAGE_COMPONENT (button) interaction payload.
+///
+/// Verified against Discord's Interaction object docs
+/// (https://docs.discord.com/developers/interactions/receiving-and-responding):
+/// `member` is only present for guild interactions; DM interactions carry a
+/// top-level `user` object instead and omit `member`/`guild`/`guild_id`
+/// entirely. `channel_id` is present in both cases.
+Map<String, dynamic> _dmButtonPayload({String customId = 'confirm_button'}) {
+  return {
+    'id': '1100000000000000001',
+    'application_id': '1100000000000000002',
+    'type': InteractionType.messageComponent.value,
+    'data': {
+      'component_type': ComponentType.button.value,
+      'custom_id': customId,
+    },
+    'channel_id': '1100000000000000003',
+    'token': 'interaction-token',
+    'version': 1,
+    'user': {'id': '1100000000000000004', 'username': 'someuser'},
+    'message': {
+      'id': '1100000000000000005',
+      'channel_id': '1100000000000000003',
+      'interaction_metadata': {'id': '1100000000000000006', 'type': 2},
+      'components': [
+        {
+          'type': 1,
+          'components': [
+            {
+              'type': ComponentType.button.value,
+              'style': 1,
+              'custom_id': customId,
+              'label': 'Confirm',
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+ShardMessage<dynamic> _dmMsg(Map<String, dynamic> payload) => ShardMessage(
+  type: 'INTERACTION_CREATE',
+  opCode: OpCode.dispatch,
+  sequence: 1,
+  payload: payload,
+);
 
 void main() {
   group('ButtonInteractionCreatePacket.findButtonByCustomId', () {
@@ -126,5 +204,176 @@ void main() {
       expect(result, isNotNull);
       expect(result!['custom_id'], equals('row2_btn'));
     });
+  });
+
+  group('ButtonInteractionCreatePacket.listen - private (DM) button clicks', () {
+    late _RecordingInteractiveComponent componentManager;
+    late ButtonInteractionCreatePacket packet;
+
+    setUp(() {
+      componentManager = _RecordingInteractiveComponent();
+      packet = ButtonInteractionCreatePacket(
+        logger: FakeLogger(),
+        interactiveComponent: componentManager,
+        ctx: fakeEntityContext(),
+      );
+    });
+
+    // Regression test for defect 1: the enum lookup compared ButtonType
+    // against targetButton['custom_id'] (always a mismatch) instead of
+    // targetButton['type'], so the handler warned and returned before ever
+    // dispatching anything.
+    test(
+      'dispatches Event.privateButtonClick for a realistic DM button click',
+      () async {
+        Event? capturedEvent;
+        PrivateButtonContext? capturedCtx;
+
+        void dispatch<T extends Object>({
+          required Event event,
+          required T payload,
+          bool Function(String?)? constraint,
+        }) {
+          capturedEvent = event;
+          capturedCtx = (payload as PrivateButtonClickArgs).ctx;
+        }
+
+        await packet.listen(_dmMsg(_dmButtonPayload()), dispatch);
+
+        expect(
+          capturedEvent,
+          equals(Event.privateButtonClick),
+          reason:
+              'a DM button click with a realistic custom_id must dispatch '
+              'Event.privateButtonClick; the enum lookup must compare '
+              "against targetButton['type'], not targetButton['custom_id']",
+        );
+        expect(capturedCtx, isNotNull);
+        expect(capturedCtx!.customId, equals('confirm_button'));
+      },
+    );
+
+    // Regression test for defect 3: Discord omits `member` on DM
+    // interactions and sends `user` at the top level instead. The old code
+    // cast payload['member'], which is null in a DM and throws.
+    test(
+      'builds PrivateButtonContext.authorId from payload["user"], not '
+      'payload["member"]',
+      () async {
+        PrivateButtonContext? capturedCtx;
+
+        void dispatch<T extends Object>({
+          required Event event,
+          required T payload,
+          bool Function(String?)? constraint,
+        }) {
+          capturedCtx = (payload as PrivateButtonClickArgs).ctx;
+        }
+
+        await packet.listen(_dmMsg(_dmButtonPayload()), dispatch);
+
+        expect(capturedCtx, isNotNull);
+        expect(
+          capturedCtx!.authorId,
+          equals(Snowflake('1100000000000000004')),
+        );
+      },
+    );
+
+    // Regression test for defect 2: the private handler never called
+    // _interactiveComponentManager.dispatch, so a registered
+    // InteractiveButton would never fire for a DM button click.
+    test('dispatches the click to the interactive component manager', () async {
+      void dispatch<T extends Object>({
+        required Event event,
+        required T payload,
+        bool Function(String?)? constraint,
+      }) {}
+
+      await packet.listen(_dmMsg(_dmButtonPayload()), dispatch);
+
+      expect(componentManager.calls, hasLength(1));
+      expect(componentManager.calls.single.customId, equals('confirm_button'));
+      expect(componentManager.calls.single.params, hasLength(1));
+      expect(
+        componentManager.calls.single.params.single,
+        isA<PrivateButtonContext>(),
+      );
+    });
+  });
+
+  group('ButtonInteractionCreatePacket.listen - guild button clicks', () {
+    // The guild and private paths share _resolveButtonType and
+    // _dispatchButtonClick; this guards that the shared helpers still
+    // behave correctly for the guild path (TCtx = GuildButtonContext),
+    // since no other test exercises _handleServerButton via listen().
+    Map<String, dynamic> guildButtonPayload({String customId = 'confirm'}) {
+      return {
+        'id': '2100000000000000001',
+        'application_id': '2100000000000000002',
+        'type': InteractionType.messageComponent.value,
+        'data': {
+          'component_type': ComponentType.button.value,
+          'custom_id': customId,
+        },
+        'guild': {'id': '2100000000000000003'},
+        'token': 'interaction-token',
+        'version': 1,
+        'message': {
+          'id': '2100000000000000004',
+          'channel_id': '2100000000000000005',
+          'interaction_metadata': {'id': '2100000000000000006', 'type': 2},
+          'components': [
+            {
+              'type': 1,
+              'components': [
+                {
+                  'type': ComponentType.button.value,
+                  'style': 1,
+                  'custom_id': customId,
+                  'label': 'Confirm',
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+
+    test(
+      'dispatches Event.guildButtonClick and notifies the component manager',
+      () async {
+        final componentManager = _RecordingInteractiveComponent();
+        final packet = ButtonInteractionCreatePacket(
+          logger: FakeLogger(),
+          interactiveComponent: componentManager,
+          ctx: fakeEntityContext(),
+        );
+
+        Event? capturedEvent;
+        GuildButtonContext? capturedCtx;
+
+        void dispatch<T extends Object>({
+          required Event event,
+          required T payload,
+          bool Function(String?)? constraint,
+        }) {
+          capturedEvent = event;
+          capturedCtx = (payload as GuildButtonClickArgs).ctx;
+        }
+
+        await packet.listen(_dmMsg(guildButtonPayload()), dispatch);
+
+        expect(capturedEvent, equals(Event.guildButtonClick));
+        expect(capturedCtx, isNotNull);
+        expect(capturedCtx!.customId, equals('confirm'));
+        expect(componentManager.calls, hasLength(1));
+        expect(componentManager.calls.single.customId, equals('confirm'));
+        expect(
+          componentManager.calls.single.params.single,
+          isA<GuildButtonContext>(),
+        );
+      },
+    );
   });
 }

--- a/packages/core/test/unit/client_builder_test.dart
+++ b/packages/core/test/unit/client_builder_test.dart
@@ -1,0 +1,307 @@
+import 'dart:io';
+
+import 'package:mineral/api.dart';
+import 'package:mineral/container.dart';
+import 'package:mineral/contracts.dart';
+import 'package:mineral/services.dart';
+import 'package:mineral/src/domains/client/client_builder.dart';
+import 'package:mineral/src/domains/common/kernel.dart';
+import 'package:mineral/src/domains/services/packets/packet_dispatcher.dart';
+import 'package:test/test.dart';
+
+import '../helpers/fake_cache_provider.dart';
+import '../helpers/fake_logger.dart';
+
+// Regression coverage for the composition root (issue #479 / A26).
+//
+// `ClientBuilder.build()` used to be the only path through this wiring, and
+// it read the process-global `env` and wrote the process-global `ioc`
+// directly — there was no way to construct the graph in a test and inspect
+// it. `composeApp` (declared alongside `build()` in `client_builder.dart`)
+// is the extracted seam: it takes an `Env` as an explicit argument, builds
+// the exact same object graph, and returns it instead of mutating globals.
+//
+// The two things this file exists to catch are the two genuine construction
+// cycles `composeApp` closes by hand:
+//   1. `WebsocketOrchestrator.onFatalDisconnect` <-> `Kernel`
+//   2. `PacketListener.kernel` / `PacketListener.init()` <-> `Kernel`
+// If either regresses, the graph still *constructs* successfully — it just
+// silently never dispatches a gateway packet. "It returned an object" is
+// not a sufficient assertion for that failure mode, so every test below
+// checks the actual wiring, not just successful construction.
+
+/// A minimal `.env` fixture satisfying `AppEnv`'s schema (see
+/// `lib/src/infrastructure/internals/environment/app_env.dart`).
+const _validEnvContents =
+    'DART_ENV=development\n'
+    'TOKEN=unit-test-token\n'
+    'DISCORD_REST_API_VERSION=10\n'
+    'DISCORD_WS_VERSION=10\n'
+    'INTENT=53608447\n'
+    'LOG_LEVEL=INFO\n';
+
+/// Builds a fresh, fully-validated [Env] instance — never the process-global
+/// `env` singleton — from a temp `.env` file, and schedules the temp
+/// directory for deletion once the current test finishes.
+///
+/// This is exactly what the acceptance criteria for #479 ask for: composeApp
+/// must be callable from a test with an injected [Env], without touching
+/// process globals. If composeApp silently fell back to reading the
+/// process-global `env` instead of the instance passed to it, every test
+/// below would throw instead of passing, because the global `env` is never
+/// touched here.
+Env _isolatedEnv() {
+  final tempDir = Directory.systemTemp.createTempSync('client_builder_test');
+  addTearDown(() => tempDir.deleteSync(recursive: true));
+
+  File('${tempDir.path}/.env').writeAsStringSync(_validEnvContents);
+
+  final env = Env()
+    ..defineOf(AppEnv.new, root: tempDir, includeDartEnv: false);
+  return env;
+}
+
+/// Seeds the process-global `env` singleton the way a real bot's startup
+/// does, for the duration of [body], without touching the real process
+/// working directory or leaving files in the repo.
+///
+/// `ClientBuilder.build()` always validates against the global `env`
+/// (`_validateEnvironment()` calls `env.defineOf(AppEnv.new)` unconditionally,
+/// with no way to inject an override) — that coupling is exactly what
+/// `composeApp` exists to avoid, but `build()` itself, being the thin
+/// adapter, still has it. [IOOverrides.runZoned] lets `env_guard`'s
+/// file-based loader see a temp directory as `Directory.current` — confined
+/// to this zone — instead of either mutating the real CWD (process-global,
+/// unsafe with concurrent test isolates) or writing a `.env` file into the
+/// repo itself.
+Future<T> _withGlobalEnv<T>(Future<T> Function() body) {
+  final tempDir = Directory.systemTemp.createTempSync(
+    'client_builder_build_test',
+  );
+  addTearDown(() {
+    env.dispose();
+    tempDir.deleteSync(recursive: true);
+  });
+  File('${tempDir.path}/.env').writeAsStringSync(_validEnvContents);
+
+  return IOOverrides.runZoned(body, getCurrentDirectory: () => tempDir);
+}
+
+void main() {
+  group('composeApp', () {
+    test(
+      'closes the WebsocketOrchestrator <-> Kernel cycle '
+      '(onFatalDisconnect)',
+      () {
+        final composition = composeApp(env: _isolatedEnv());
+
+        expect(composition.wss.onFatalDisconnect, isNotNull);
+        // Instance-method tear-offs of the same receiver are `==`-equal in
+        // Dart; this fails if the hook were left unset (null) or wired to
+        // some other kernel's dispose.
+        expect(
+          composition.wss.onFatalDisconnect,
+          equals(composition.kernel.dispose),
+        );
+      },
+    );
+
+    test('closes the PacketListener <-> Kernel cycle and runs init()', () {
+      final composition = composeApp(env: _isolatedEnv());
+
+      expect(
+        identical(composition.packetListener.kernel, composition.kernel),
+        isTrue,
+        reason: "PacketListener.kernel must point at this graph's Kernel",
+      );
+
+      // `dispatcher` is a `late final` field only assigned inside
+      // PacketListener.init(). If init() were dropped (or called before
+      // `kernel` was wired, since init() reads `kernel.logger`/`kernel.wss`
+      // to subscribe every packet), accessing it throws instead of
+      // returning normally — that's the exact "constructs fine, never
+      // dispatches a packet" failure mode this card is about.
+      expect(() => composition.packetListener.dispatcher, returnsNormally);
+      expect(
+        composition.packetListener.dispatcher,
+        isA<PacketDispatcherContract>(),
+      );
+    });
+
+    test(
+      'wires the same instances everywhere — no dependency silently '
+      'swapped for the wrong module',
+      () {
+        final composition = composeApp(env: _isolatedEnv());
+
+        expect(composition.appState.kernel, same(composition.kernel));
+        expect(composition.appState.wss, same(composition.wss));
+        expect(composition.appState.dataStore, same(composition.dataStore));
+        expect(composition.appState.marshaller, same(composition.marshaller));
+        expect(
+          composition.appState.packetListener,
+          same(composition.packetListener),
+        );
+
+        expect(
+          composition.packetListener.marshaller,
+          same(composition.marshaller),
+        );
+        expect(
+          composition.packetListener.dataStore,
+          same(composition.dataStore),
+        );
+        expect(
+          composition.packetListener.commandManager,
+          same(composition.appState.commandManager),
+        );
+        expect(
+          composition.packetListener.cacheConfig,
+          same(composition.appState.cacheConfig),
+        );
+        expect(composition.kernel.wss, same(composition.wss));
+        expect(
+          composition.kernel.packetListener,
+          same(composition.packetListener),
+        );
+      },
+    );
+
+    test(
+      'an injected logger is used verbatim, including for labelled '
+      'subsystem loggers',
+      () {
+        final logger = FakeLogger();
+        final composition = composeApp(env: _isolatedEnv(), logger: logger);
+
+        expect(composition.appState.logger, same(logger));
+        expect(composition.kernel.logger, same(logger));
+      },
+    );
+
+    test('an injected cache flows into both the data layer and AppState', () {
+      final cache = FakeCacheProvider();
+      final composition = composeApp(env: _isolatedEnv(), cache: cache);
+
+      expect(composition.appState.cache, same(cache));
+      expect(composition.marshaller.cache, same(cache));
+    });
+
+    test('threads env-derived config into the constructed graph', () {
+      final composition = composeApp(env: _isolatedEnv());
+
+      expect(composition.wss.config.token, 'unit-test-token');
+      expect(composition.wss.config.intent, 53608447);
+    });
+
+    test(
+      'never reads or writes the global ioc container (pure composition)',
+      () {
+        final before = ioc.services.length;
+
+        composeApp(env: _isolatedEnv());
+
+        expect(ioc.services.length, before);
+      },
+    );
+
+    test('two calls produce two fully independent graphs', () {
+      final a = composeApp(env: _isolatedEnv());
+      final b = composeApp(env: _isolatedEnv());
+
+      expect(identical(a.kernel, b.kernel), isFalse);
+      expect(identical(a.packetListener, b.packetListener), isFalse);
+      expect(identical(a.wss, b.wss), isFalse);
+    });
+  });
+
+  group('ClientBuilder.build() — thin adapter over composeApp', () {
+    test('stays synchronous and returns a Client', () async {
+      await _withGlobalEnv(() async {
+        return runWithIoc(IocContainer(), () async {
+          final builder = ClientBuilder()..setLogger((_) => FakeLogger());
+
+          // `Client build()` — not `Future<Client> build()` — is a
+          // deliberate, recorded design decision (async setup belongs in
+          // Client.init()). This is enforced at compile time by the
+          // declared return type, and checked here at runtime too.
+          expect(builder.build, isA<Client Function()>());
+          expect(builder.build(), isA<Client>());
+        });
+      });
+    });
+
+    test('mirrors the composed graph into the IoC container', () async {
+      await _withGlobalEnv(() async {
+        return runWithIoc(IocContainer(), () async {
+          final logger = FakeLogger();
+          final client = (ClientBuilder()..setLogger((_) => logger)).build();
+
+          expect(ioc.resolve<LoggerContract>(), same(logger));
+          expect(ioc.resolve<Kernel>().logger, same(logger));
+          expect(ioc.resolve<DataStoreContract>(), same(client.rest));
+          expect(
+            () => ioc.resolve<MarshallerContract>(),
+            returnsNormally,
+          );
+          expect(
+            () => ioc.resolve<CommandInteractionManagerContract>(),
+            returnsNormally,
+          );
+          expect(
+            () => ioc.resolve<WebsocketOrchestratorContract>(),
+            returnsNormally,
+          );
+          expect(
+            () => ioc.resolve<InteractiveComponentManagerContract>(),
+            returnsNormally,
+          );
+          expect(() => ioc.resolve<HttpClientContract>(), returnsNormally);
+        });
+      });
+    });
+
+    test(
+      'still registers builder providers, handed the fully-constructed '
+      'client',
+      () async {
+        await _withGlobalEnv(() async {
+          return runWithIoc(IocContainer(), () async {
+            final calls = <String>[];
+            Client? receivedClient;
+
+            (ClientBuilder()
+                  ..setLogger((_) => FakeLogger())
+                  ..registerProvider((client) {
+                    receivedClient = client;
+                    return _RecordingProvider(() => calls.add('ready'));
+                  }))
+                .build();
+
+            expect(receivedClient, isA<Client>());
+
+            // ProviderManager.register() has no externally-observable
+            // effect until ready() runs — call it directly (no gateway
+            // connection needed) to prove the provider this test registered
+            // was actually handed to the manager, not just constructed and
+            // discarded.
+            await ioc.resolve<Kernel>().providerManager.ready();
+            expect(calls, ['ready']);
+          });
+        });
+      },
+    );
+  });
+}
+
+final class _RecordingProvider implements ProviderContract {
+  _RecordingProvider(this._onReady);
+
+  final void Function() _onReady;
+
+  @override
+  Future<void> ready() async => _onReady();
+
+  @override
+  Future<void> dispose() async {}
+}


### PR DESCRIPTION
Closes #478, #479, #487.

> These `Closes` will not fire on merge — GitHub only auto-closes on the default branch. The chantier → `main` PR needs the full list.

## Result

`dart analyze lib test` and `dart analyze example` clean. Full suite **1744 passing, 0 failing** — 1714 at the start of this batch, 1584 before the chantier.

## The one real bug

**#487 — button clicks in DMs dispatched nothing at all.** Not the component handler, not even the event. This was not in the audit report; it surfaced while fixing #469 and I confirmed it by reading both handlers side by side.

`_handlePrivateButton` matched `ButtonType` against the button's `custom_id` where `_handleServerButton` correctly uses its `type`. An arbitrary developer-chosen id never matches an enum value, so the lookup returned null and the method logged `Button type ... not found` and returned. Behind that early return sat two more defects — the component manager was never called, and the author was read from `payload['member']`, which Discord omits in a DM.

Fixed together deliberately: repairing only the lookup would have reached the `member` cast and turned a silent no-op into a null-cast crash. The DM payload shape was verified against Discord's interaction-object documentation, not assumed.

The two handlers were near-identical apart from the context they build — which is precisely how a fix lands on one path only. The dispatch pair (event + component manager) is now one shared helper, so the second defect cannot be reintroduced by forgetting a line.

**Audit miss worth recording:** the coherence pass compared sibling *files* — the 23 datastore parts, the serializers — but never sibling *functions inside one file*. That is where this lived.

## Breaking changes

Three more, all from #478, all in the CHANGELOG.

| Change | Risk |
|---|---|
| `CommandBuilder` now declares five members | Downstream implementers must supply them — that is the point of the card |
| `CommandDefinitionBuilder.context<T>()` → `configure<T>()` | Low: zero usages and zero tests anywhere in the repo |
| `CommandDeclarationBuilder.reduceHandlers(String)` → no-arg | Low: every call site passed the receiver's own `name` |

## Two places the issues were wrong, and were corrected rather than followed

**#478's proposed interface was incomplete.** The four members I listed cannot remove the fifth switch — autocomplete option-tree discovery — because the user and message builders have no option tree. A `declaration` member was added to actually satisfy the acceptance criterion instead of leaving a switch and calling it done.

**`sealed` is not merely a tradeoff, it does not compile.** I asked for the public-extension-point argument to be weighed. The stronger reason came back: `sealed` requires every subtype in one library, and the four implementers live in four files.

## Verification quality

Two things above the bar I set:

- **#479 used mutation testing.** Deleting the `onFatalDisconnect` line failed exactly one test; deleting `..init()` failed exactly the other, with `LateInitializationError` on the dispatcher — which is literally the "constructs fine, never dispatches a packet" failure mode the card exists to catch. Both mutations reverted and confirmed.
- **#478 added coverage before deleting branches.** Four of the five switch sites had no test of their branching at all; `addCommand` was never called from the manager's tests. A branch deleted without a test is not proven equivalent.

## One thing I fixed on top

`composeApp` and `AppComposition` leaked into the public API through `api.dart`'s wildcard export of `client_builder.dart`, and `AppComposition` exposes `Kernel` and the concrete `PacketListener` — internal types no barrel exports. A consumer could hold the record without being able to name its members. Hidden from the barrel; `ClientBuilder` remains the entry point. Same class of leak as #475, found by the agent and flagged rather than silently shipped.

## Follow-up worth a card

There are **two public classes named `CommandBuilder`** — the marker interface under `domains/commands/` and a concrete fluent builder under `api/common/commands/builder/`. Untouched here, correctly. Two homonymous public types in one framework is a trap for the reader.

## Still open in the chantier

#476, #477, #480 — plus #481 triage and #483. I have not dispatched these, deliberately; see the note in the chantier issue.
